### PR TITLE
[FEAT] Security 및 Jwt Configuration 정의 및 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,11 @@ dependencies {
     /* postgresql */
     implementation 'org.postgresql:postgresql'
     runtimeOnly 'org.postgresql:postgresql'
+
+    /* Jwt */
+    implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/goti/config/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/goti/config/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,37 @@
+package com.goti.config.jwt;
+
+import com.goti.constants.messages.ErrorCode;
+import com.goti.exception.CustomException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+	private final HandlerExceptionResolver resolver;
+
+	public JwtAccessDeniedHandler(
+		@Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver) {
+		this.resolver = resolver;
+	}
+
+	@Override
+	public void handle(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		AccessDeniedException accessDeniedException) {
+
+		Exception ex = (Exception)request.getAttribute("exception");
+		if (ex == null)
+			ex = new CustomException(ErrorCode.AUTH_PERMISSION_DENIED);
+
+		resolver.resolveException(request, response, null, ex);
+	}
+}
+

--- a/src/main/java/com/goti/config/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/goti/config/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,33 @@
+package com.goti.config.jwt;
+
+import com.goti.constants.messages.ErrorCode;
+
+import com.goti.exception.CustomException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+	private final HandlerExceptionResolver resolver;
+
+	public JwtAuthenticationEntryPoint(
+		@Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver) {
+		this.resolver = resolver;
+	}
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException authException) {
+		Exception ex = (Exception)request.getAttribute("exception");
+		if (ex == null)
+			ex = new CustomException(ErrorCode.AUTH_INVALID_ACCESS_PATH);
+		resolver.resolveException(request, response, null, ex);
+	}
+}

--- a/src/main/java/com/goti/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/goti/config/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,78 @@
+package com.goti.config.jwt;
+
+import com.goti.config.security.SecurityConfig;
+
+import com.goti.constants.messages.ErrorCode;
+
+import com.goti.exception.CustomException;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+	private final JwtTokenProvider jwtTokenProvider;
+
+	@Override
+	protected void doFilterInternal(
+		@NonNull HttpServletRequest request,
+		@NonNull HttpServletResponse response,
+		@NonNull FilterChain filterChain
+	) throws ServletException, IOException {
+
+		String requestURI = request.getRequestURI();
+
+		boolean isPublic = Arrays.stream(SecurityConfig.PERMIT_PUBLIC_PATH)
+			.anyMatch(pattern -> matches(pattern, requestURI));
+
+		if (isPublic) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		String token = jwtTokenProvider.resolve(request);
+
+		try {
+			if (token != null && !token.isEmpty()) {
+				jwtTokenProvider.validateToken(token);
+				Authentication authenticationToken = jwtTokenProvider.getAuthentication(token);
+				SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+			}
+		} catch (ExpiredJwtException e) {
+			reject(request, ErrorCode.AUTH_ACCESS_EXPIRED);
+		} catch (JwtException | IllegalArgumentException e) {
+			reject(request, ErrorCode.AUTH_INVALID);
+		}
+		filterChain.doFilter(request, response);
+	}
+
+	private boolean matches(String pattern, String path) {
+		AntPathMatcher pathMatcher = new AntPathMatcher();
+		return pathMatcher.match(pattern, path);
+	}
+
+	private void reject(HttpServletRequest request, ErrorCode error) {
+		CustomException exception = new CustomException(error);
+		request.setAttribute("exception", exception);
+		throw exception;
+	}
+}

--- a/src/main/java/com/goti/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/goti/config/jwt/JwtTokenProvider.java
@@ -1,0 +1,86 @@
+package com.goti.config.jwt;
+
+import com.goti.config.properties.JwtProperties;
+
+import com.goti.constants.UserRole;
+
+import com.goti.security.ExtendedUserDetailsService;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import jakarta.servlet.http.HttpServletRequest;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+	private final JwtProperties jwtProperties;
+	private final ExtendedUserDetailsService userDetailsService;
+
+	private static final String TOKEN_PREFIX = "Bearer ";
+	private static final String ROLE_CLAIM_KEY = "role";
+	private static final String MOBILE_CLAIM_KEY = "mobile";
+	private static final String JWT_ID_KEY = "jti";
+
+	public String create(UUID id, String mobile, UserRole role) {
+		Date issuedAt = new Date();
+		Date expireAt = new Date(issuedAt.getTime() + jwtProperties.accessValidTime().toMillis());
+		String randomUUID = UUID.randomUUID().toString();
+		return Jwts.builder()
+			.subject(id.toString())
+			.claim(JWT_ID_KEY, randomUUID)
+			.claim(ROLE_CLAIM_KEY, role.name())
+			.claim(MOBILE_CLAIM_KEY, mobile)
+			.issuedAt(issuedAt)
+			.expiration(expireAt)
+			.signWith(jwtProperties.secretKey())
+			.compact();
+	}
+
+	public void validateToken(String token) throws JwtException {
+		Jws<Claims> claims = Jwts.parser()
+			.verifyWith(jwtProperties.secretKey())
+			.build().parseSignedClaims(token);
+		log.info("ExpiredAt :: {}", claims.getPayload().getExpiration());
+	}
+
+	public String resolve(HttpServletRequest request) {
+		String token = request.getHeader(HttpHeaders.AUTHORIZATION);
+		if (token != null && token.startsWith(TOKEN_PREFIX)) {
+			return token.substring(TOKEN_PREFIX.length());
+		}
+		return token;
+	}
+
+	public Authentication getAuthentication(String token) {
+		String userId = getClaims(token).getSubject();
+		UserDetails userDetails = userDetailsService.loadUserById(userId);
+		return UsernamePasswordAuthenticationToken.authenticated(
+			userDetails,
+			null,
+			userDetails.getAuthorities()
+		);
+	}
+
+	private Claims getClaims(String token) {
+		return Jwts.parser()
+			.verifyWith(jwtProperties.secretKey())
+			.build()
+			.parseSignedClaims(token)
+			.getPayload();
+	}
+}

--- a/src/main/java/com/goti/config/properties/JwtProperties.java
+++ b/src/main/java/com/goti/config/properties/JwtProperties.java
@@ -1,0 +1,21 @@
+package com.goti.config.properties;
+
+import io.jsonwebtoken.security.Keys;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import javax.crypto.SecretKey;
+
+import java.time.Duration;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+	String secret,
+	Duration accessValidTime,
+	Duration refreshValidTime
+) {
+
+	public SecretKey secretKey() {
+		return Keys.hmacShaKeyFor(secret.getBytes());
+	}
+}

--- a/src/main/java/com/goti/constants/UserRole.java
+++ b/src/main/java/com/goti/constants/UserRole.java
@@ -1,0 +1,11 @@
+package com.goti.constants;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum UserRole {
+	ADMIN("관리자"),
+	MEMBER("회원");
+
+	private final String description;
+}

--- a/src/main/java/com/goti/constants/messages/ErrorCode.java
+++ b/src/main/java/com/goti/constants/messages/ErrorCode.java
@@ -18,6 +18,11 @@ public enum ErrorCode {
 	MISSING_PARAMETER(HttpStatus.BAD_REQUEST, "{0} 파라미터 필요"),
 	INVALID_FORMAT(HttpStatus.BAD_REQUEST, "{0} 형식 오류"),
 
+	AUTH_INVALID_ACCESS_PATH(HttpStatus.UNAUTHORIZED, "올바르지 않은 접근 경로입니다."),
+	AUTH_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+	AUTH_INVALID(HttpStatus.UNAUTHORIZED, "올바르지 않은 인증 정보입니다."),
+	AUTH_ACCESS_EXPIRED(HttpStatus.UNAUTHORIZED, "엑세스 토큰이 만료되었습니다."),
+
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생하였습니다. 잠시 후 다시 시도해주세요.")
 	;
 

--- a/src/main/java/com/goti/domain/entity/user/UserEntity.java
+++ b/src/main/java/com/goti/domain/entity/user/UserEntity.java
@@ -1,0 +1,28 @@
+package com.goti.domain.entity.user;
+
+import com.goti.constants.UserRole;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+import static lombok.AccessLevel.*;
+
+@Getter
+@Entity(name = "user")
+@Inheritance(strategy = InheritanceType.JOINED)
+@NoArgsConstructor(access = PROTECTED)
+public class UserEntity {
+
+	@Id
+	private UUID id;
+
+	private String mobile;
+
+	private UserRole role;
+}

--- a/src/main/java/com/goti/security/ExtendedUserDetails.java
+++ b/src/main/java/com/goti/security/ExtendedUserDetails.java
@@ -1,0 +1,24 @@
+package com.goti.security;
+
+import com.goti.constants.UserRole;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.UUID;
+
+@Getter
+@EqualsAndHashCode(callSuper = true)
+public class ExtendedUserDetails extends User {
+	private final UUID id;
+
+	public ExtendedUserDetails(UUID id, String mobile, UserRole role) {
+		super(mobile, "", AuthorityUtils.createAuthorityList("ROLE_" + role.name()));
+		this.id = id;
+	}
+
+}
+

--- a/src/main/java/com/goti/security/ExtendedUserDetailsService.java
+++ b/src/main/java/com/goti/security/ExtendedUserDetailsService.java
@@ -1,0 +1,10 @@
+package com.goti.security;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+public interface ExtendedUserDetailsService extends UserDetailsService {
+
+	UserDetails loadUserById(String userId) throws UsernameNotFoundException;
+}

--- a/src/main/java/com/goti/security/ExtendedUserDetailsServiceImpl.java
+++ b/src/main/java/com/goti/security/ExtendedUserDetailsServiceImpl.java
@@ -1,0 +1,47 @@
+package com.goti.security;
+
+import com.goti.domain.entity.user.UserEntity;
+
+import com.goti.service.domain.user.UserService;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.context.annotation.Primary;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@Primary
+@RequiredArgsConstructor
+public class ExtendedUserDetailsServiceImpl implements ExtendedUserDetailsService {
+
+	private final UserService userService;
+
+	@Override
+	public UserDetails loadUserByUsername(String mobile) throws UsernameNotFoundException {
+		return userService.findUserByMobile(mobile).map(this::convert).orElseThrow(
+			() -> new UsernameNotFoundException(mobile + " 번호로 등록된 사용자 정보를 찾을 수 없습니다.")
+		);
+	}
+
+	@Override
+	public UserDetails loadUserById(String userId) throws UsernameNotFoundException {
+		Optional<UserEntity> user = userService.findUserById(UUID.fromString(userId));
+		return user.map(this::convert).orElseThrow(
+			() -> new UsernameNotFoundException("사용자 정보를 찾을 수 없습니다.")
+		);
+	}
+
+	private UserDetails convert(UserEntity user) {
+		return new ExtendedUserDetails(
+			user.getId(),
+			user.getMobile(),
+			user.getRole()
+		);
+	}
+}
+

--- a/src/main/java/com/goti/service/domain/user/UserService.java
+++ b/src/main/java/com/goti/service/domain/user/UserService.java
@@ -1,0 +1,13 @@
+package com.goti.service.domain.user;
+
+import com.goti.domain.entity.user.UserEntity;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserService {
+
+	Optional<UserEntity> findUserById(UUID userId);
+
+	Optional<UserEntity> findUserByMobile(String mobile);
+}

--- a/src/main/java/com/goti/service/domain/user/UserServiceImpl.java
+++ b/src/main/java/com/goti/service/domain/user/UserServiceImpl.java
@@ -1,0 +1,25 @@
+package com.goti.service.domain.user;
+
+import com.goti.domain.entity.user.UserEntity;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+	@Override
+	public Optional<UserEntity> findUserById(UUID userId) {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<UserEntity> findUserByMobile(String mobile) {
+		return Optional.empty();
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,8 +25,11 @@ spring:
           format_sql: true
           show_sql: true
           dialect: org.hibernate.dialect.PostgreSQLDialect
-
   config:
     import:
       - optional:file:.env[.properties]
 
+jwt:
+  secret: ${JWT_SECRET_KEY}
+  access-valid-time: ${JWT_ACCESS_TIME}
+  refresh-valid-time: ${JWT_REFRESH_TIME}


### PR DESCRIPTION
<!-- 제목 예시: feat: 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#1 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
- UserService 및 User Entity(domain) 임의 생성
- Security 및 jwt config 정의
- Extended User Detail 커스텀 정의(Security UserDetails, User)
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- Security 유저 객체 상속 커스텀 정의
- Security UserDetailsService  커스텀 구현체 생성
- ExtendedUserDetails 구현을 위한 임의 UserEntity 및 UserService 정의
- Security Custom filter configuration 추가
- JwtFilter 추가 및 JwtProvider (accessor) 추가 (security config filter 우선순위 정의)
- Jwt 기반 인증 및 인가 ErrorHandling 추가 
- ErrorCode 인증 및 인가에 대한 에러메세지 추가
<br/>