### PR TITLE
[FEAT] 소셜 제공자 엔티티 도메인(SocialProviderEntity) 생성 및 도메인 테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,10 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'
+
+    /* Test Module Lombok */
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/goti/constants/OAuthProvider.java
+++ b/src/main/java/com/goti/constants/OAuthProvider.java
@@ -1,0 +1,12 @@
+package com.goti.constants;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum OAuthProvider {
+	GOOGLE("google"),
+	KAKAO("kakao"),
+	NAVER("naver");
+
+	private final String value;
+}

--- a/src/main/java/com/goti/domain/entity/user/MemberEntity.java
+++ b/src/main/java/com/goti/domain/entity/user/MemberEntity.java
@@ -21,43 +21,32 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PROTECTED)
 public class MemberEntity extends UserEntity {
 	private MemberEntity(
-		String email,
 		String mobile,
 		String name,
 		Gender gender,
 		LocalDate birthDate
 	) {
 		super(
-			email,
-			mobile,
-			name,
-			gender,
-			birthDate,
-			UserRole.MEMBER
+			mobile, name, gender, birthDate, UserRole.MEMBER
 		);
 	}
 
 	public static MemberEntity create(
-		final String email,
 		final String mobile,
 		final String name,
 		final Gender gender,
 		final LocalDate birthDate
 	) {
-		validate(email, mobile, name, gender, birthDate);
-		return new MemberEntity(email, mobile, name, gender, birthDate);
+		validate(mobile, name, gender, birthDate);
+		return new MemberEntity(mobile, name, gender, birthDate);
 	}
 
 	private static void validate(
-		String email,
 		String mobile,
 		String name,
 		Gender gender,
 		LocalDate birthDate
 	) {
-		Preconditions.domainValidate(
-			StringUtils.hasText(email), "회원 이메일은 비어 있을 수 없습니다."
-		);
 
 		Preconditions.domainValidate(
 			StringUtils.hasText(mobile), "회원 휴대전화 번호는 비어 있을 수 없습니다."

--- a/src/main/java/com/goti/domain/entity/user/SocialProviderEntity.java
+++ b/src/main/java/com/goti/domain/entity/user/SocialProviderEntity.java
@@ -1,0 +1,78 @@
+package com.goti.domain.entity.user;
+
+import com.goti.common.validation.Preconditions;
+import com.goti.constants.OAuthProvider;
+import com.goti.domain.base.ModificationTimestampEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import org.springframework.util.StringUtils;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Entity(name = "social_provider")
+@NoArgsConstructor(access = PROTECTED)
+public class SocialProviderEntity extends ModificationTimestampEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false)
+	private MemberEntity member;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private OAuthProvider provider;
+
+	@Column(nullable = false)
+	private String providerId;
+
+	@Column(nullable = false)
+	private String email;
+
+	private SocialProviderEntity(
+		MemberEntity member,
+		OAuthProvider provider,
+		String providerId,
+		String email
+	) {
+		this.member = member;
+		this.provider = provider;
+		this.providerId = providerId;
+		this.email = email;
+	}
+
+	public static SocialProviderEntity create(
+		final MemberEntity member,
+		final OAuthProvider provider,
+		final String providerId,
+		final String email
+	) {
+		validate(provider, providerId, email);
+		return new SocialProviderEntity(member, provider, providerId, email);
+	}
+
+	private static void validate(
+		OAuthProvider provider, String providerId, String email
+	) {
+		Preconditions.domainValidate(
+			provider != null,
+			"소셜 제공자(kakao, naver, google)는 비어 있을 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			StringUtils.hasText(providerId), "사용자 소셜 고유 ID 값은 비어있을 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			StringUtils.hasText(email), "이메일값은 비어있을 수 없습니다."
+		);
+	}
+}

--- a/src/main/java/com/goti/domain/entity/user/UserEntity.java
+++ b/src/main/java/com/goti/domain/entity/user/UserEntity.java
@@ -52,20 +52,20 @@ public class UserEntity extends ModificationTimestampEntity {
 
 	@Column(nullable = false)
 	@Enumerated(EnumType.STRING)
-	private UserRole userRole;
+	private UserRole role;
 
 	protected UserEntity(
 		String mobile,
 		String name,
 		Gender gender,
 		LocalDate birthDate,
-		UserRole userRole
+		UserRole role
 	) {
 		this.mobile = mobile;
 		this.name = name;
 		this.gender = gender;
 		this.birthDate = birthDate;
 		this.status = UserStatus.ACTIVATED;
-		this.userRole = userRole;
+		this.role = role;
 	}
 }

--- a/src/main/java/com/goti/domain/entity/user/UserEntity.java
+++ b/src/main/java/com/goti/domain/entity/user/UserEntity.java
@@ -33,9 +33,6 @@ import lombok.NoArgsConstructor;
 public class UserEntity extends ModificationTimestampEntity {
 
 	@Column(nullable = false)
-	private String email;
-
-	@Column(nullable = false)
 	private String mobile;
 
 	@Column(nullable = false)
@@ -58,14 +55,12 @@ public class UserEntity extends ModificationTimestampEntity {
 	private UserRole userRole;
 
 	protected UserEntity(
-		String email,
 		String mobile,
 		String name,
 		Gender gender,
 		LocalDate birthDate,
 		UserRole userRole
 	) {
-		this.email = email;
 		this.mobile = mobile;
 		this.name = name;
 		this.gender = gender;

--- a/src/test/java/com/goti/domain/entity/user/SocialProviderEntityTest.java
+++ b/src/test/java/com/goti/domain/entity/user/SocialProviderEntityTest.java
@@ -1,0 +1,79 @@
+package com.goti.domain.entity.user;
+
+import com.goti.constants.Gender;
+
+import com.goti.constants.OAuthProvider;
+
+import com.goti.exception.FieldValidationException;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+@ActiveProfiles("test")
+public class SocialProviderEntityTest {
+
+	OAuthProvider PROVIDER = OAuthProvider.KAKAO;
+	String PROVIDER_ID = "TestProviderID";
+	String EMAIL = "test@test.com";
+	MemberEntity member;
+
+	@BeforeEach
+	void setup() {
+		String mobile = "01012345678";
+		String name = "테스트회원";
+		member = MemberEntity.create(
+			mobile,
+			name,
+			Gender.MALE,
+			LocalDate.of(2000, 2,2)
+		);
+	}
+
+	@Test
+	void 소셜_제공자_생성_성공() {
+		SocialProviderEntity socialProvider = SocialProviderEntity.create(
+			member, PROVIDER, PROVIDER_ID, EMAIL
+		);
+		assertNotNull(socialProvider);
+		log.info("social email : {}", socialProvider.getEmail());
+		log.info("socialProvider's member name :: {}", socialProvider.getMember().getName());
+	}
+
+	@Test
+	void 소셜_제공자_생성_실패_provider_null() {
+		assertThatThrownBy(
+			() -> SocialProviderEntity.create(member, null, PROVIDER_ID, EMAIL)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("소셜 제공자(kakao, naver, google)는 비어 있을 수 없습니다.");
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	void 소셜_제공자_생성_실패_provider_id_null_또는_공백(String providerId) {
+		assertThatThrownBy(
+			() -> SocialProviderEntity.create(member, PROVIDER, providerId, EMAIL)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("사용자 소셜 고유 ID 값은 비어있을 수 없습니다.");
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	void 소셜_제공자_생성_실패_email_null_또는_공백(String email) {
+		assertThatThrownBy(
+			() -> SocialProviderEntity.create(member, PROVIDER, PROVIDER_ID, email)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("이메일값은 비어있을 수 없습니다.");
+	}
+
+}


### PR DESCRIPTION
<!-- 제목 예시: feat: 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#14 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
- SocialProviderEntity 정의 및 테스트(성공 및 실패)
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- SocialProviderEntity 엔티티 도메인 정의 (회원(MemberEntity) 엔티티 연관관계 정의)
- SocialProviderEntity 엔티티 생성 및 실패 테스트 코드 추가
- UserEntity Email 필드 제거
<br/>