### PR TITLE
[REFACTOR] Jpa Entity 명 단수 통일 및 테이블명 복수 매핑

### DIFF
--- a/src/main/java/com/goti/domain/entity/baseball/BaseballTeamEntity.java
+++ b/src/main/java/com/goti/domain/entity/baseball/BaseballTeamEntity.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Table(
-	name = "baseball_team",
+	name = "baseball_teams",
 	uniqueConstraints = {
 		@UniqueConstraint(name = "uk_baseball_team_team_code", columnNames = {"team_code"})
 	})

--- a/src/main/java/com/goti/domain/entity/baseball/BaseballWinnerHistoryEntity.java
+++ b/src/main/java/com/goti/domain/entity/baseball/BaseballWinnerHistoryEntity.java
@@ -20,7 +20,7 @@ import static lombok.AccessLevel.*;
 @Getter
 @Entity
 @Table(
-	name = "baseball_winner_history",
+	name = "baseball_winner_histories",
 	uniqueConstraints = {
 		@UniqueConstraint(name = "uk_winner_history_team_year", columnNames = {"baseball_team_id", "winning_year"})
 	})

--- a/src/main/java/com/goti/domain/entity/stadium/StadiumEntity.java
+++ b/src/main/java/com/goti/domain/entity/stadium/StadiumEntity.java
@@ -4,6 +4,8 @@ import static lombok.AccessLevel.*;
 
 import java.math.BigDecimal;
 
+import jakarta.persistence.Table;
+
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 import org.springframework.util.StringUtils;
@@ -17,7 +19,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@Entity(name = "stadium")
+@Entity
+@Table(name = "stadiums")
 @NoArgsConstructor(access = PROTECTED)
 public class StadiumEntity extends ModificationTimestampEntity {
 	@Column(nullable = false)

--- a/src/main/java/com/goti/domain/entity/user/MemberEntity.java
+++ b/src/main/java/com/goti/domain/entity/user/MemberEntity.java
@@ -4,6 +4,8 @@ import static lombok.AccessLevel.*;
 
 import java.time.LocalDate;
 
+import jakarta.persistence.Table;
+
 import org.springframework.util.StringUtils;
 
 import com.goti.common.validation.Preconditions;
@@ -16,9 +18,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@Entity(name = "member")
-@DiscriminatorValue("MEMBER")
+@Entity
+@Table(name = "members")
 @NoArgsConstructor(access = PROTECTED)
+@DiscriminatorValue("MEMBER")
 public class MemberEntity extends UserEntity {
 	private MemberEntity(
 		String mobile,

--- a/src/main/java/com/goti/domain/entity/user/SocialProviderEntity.java
+++ b/src/main/java/com/goti/domain/entity/user/SocialProviderEntity.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,7 +20,8 @@ import org.springframework.util.StringUtils;
 import static lombok.AccessLevel.PROTECTED;
 
 @Getter
-@Entity(name = "social_provider")
+@Entity
+@Table(name = "social_providers")
 @NoArgsConstructor(access = PROTECTED)
 public class SocialProviderEntity extends ModificationTimestampEntity {
 

--- a/src/main/java/com/goti/domain/entity/user/UserEntity.java
+++ b/src/main/java/com/goti/domain/entity/user/UserEntity.java
@@ -22,12 +22,12 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Entity
 @Table(name = "users",
 	uniqueConstraints = {
 		@UniqueConstraint(name = "uk_users_mobile", columnNames = {"mobile"}),
 		@UniqueConstraint(name = "uk_users_email", columnNames = {"email"})
 	})
-@Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @NoArgsConstructor(access = PROTECTED)
 public class UserEntity extends ModificationTimestampEntity {


### PR DESCRIPTION
## #️⃣ 관련 이슈
#24 

<br/>

## 🔎 개요
Jpa 엔티티명 정의 옵션 일괄 정의

<br/>


## 📋 작업 내용
> @table(name= entity 복수명) 일괄 정의
> @entity name 옵션 일괄 제거

<br/>