### PR TITLE
[FEAT] RestClient Config 정의 및 공통통신모듈 생성

### DIFF
--- a/src/main/java/com/goti/config/api/RestClientConfig.java
+++ b/src/main/java/com/goti/config/api/RestClientConfig.java
@@ -1,0 +1,74 @@
+package com.goti.config.api;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+import com.goti.config.api.interceptor.ExternalLoggingInterceptor;
+
+import com.goti.config.api.interceptor.ExternalTraceInterceptor;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+import com.goti.config.properties.RestClientProperties;
+import com.goti.constants.messages.ErrorCode;
+import com.goti.exception.CustomException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class RestClientConfig {
+
+	private final RestClientProperties properties;
+	private final ExternalTraceInterceptor traceInterceptor;
+	private final ExternalLoggingInterceptor loggingInterceptor;
+
+	private static final String TRACE_HEADER = "X-Trace-Id";
+
+	@Bean
+	public RestClient restClient(RestClient.Builder builder) {
+		HttpClient httpClient = HttpClient.newBuilder()
+			.connectTimeout(Duration.ofSeconds(properties.connectTimeout()))
+			.build();
+
+		JdkClientHttpRequestFactory requestFactory = new JdkClientHttpRequestFactory(httpClient);
+		requestFactory.setReadTimeout(Duration.ofSeconds(properties.readTimeout()));
+
+		return builder
+			.requestFactory(requestFactory)
+			.requestInterceptor(traceInterceptor)
+			.requestInterceptor(loggingInterceptor)
+			.defaultStatusHandler(
+				HttpStatusCode::isError,
+				(request, response) -> handleError(request, response)
+			)
+			.build();
+	}
+
+	private void handleError(HttpRequest request, ClientHttpResponse response) throws IOException {
+		int status = response.getStatusCode().value();
+		String body = new String(response.getBody().readAllBytes(), StandardCharsets.UTF_8);
+		String traceId = request.getHeaders().getFirst(TRACE_HEADER);
+
+		log.error(
+			"[External API Error] traceId={}, method={}, uri={}, status={}, body={}",
+			traceId,
+			request.getMethod(),
+			request.getURI(),
+			status,
+			body
+		);
+
+		throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+	}
+}

--- a/src/main/java/com/goti/config/api/interceptor/ExternalLoggingInterceptor.java
+++ b/src/main/java/com/goti/config/api/interceptor/ExternalLoggingInterceptor.java
@@ -1,0 +1,25 @@
+package com.goti.config.api.interceptor;
+
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class ExternalLoggingInterceptor implements ClientHttpRequestInterceptor {
+
+	@Override
+	public ClientHttpResponse intercept(
+		HttpRequest request, byte[] body, ClientHttpRequestExecution execution
+	) throws IOException {
+
+		long start = System.nanoTime();
+		ClientHttpResponse response = execution.execute(request, body);
+		long tookMs = (System.nanoTime() - start) / 1_000_000;
+
+		return response;
+	}
+}

--- a/src/main/java/com/goti/config/api/interceptor/ExternalTraceInterceptor.java
+++ b/src/main/java/com/goti/config/api/interceptor/ExternalTraceInterceptor.java
@@ -1,0 +1,29 @@
+package com.goti.config.api.interceptor;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+public class ExternalTraceInterceptor implements ClientHttpRequestInterceptor {
+	private static final String TRACE_HEADER = "X-Trace-Id";
+
+	@Override
+	public ClientHttpResponse intercept(
+		HttpRequest request, byte[] body, ClientHttpRequestExecution execution
+	) throws IOException {
+
+		HttpHeaders headers = request.getHeaders();
+		if (!headers.containsKey(TRACE_HEADER)) {
+			headers.add(TRACE_HEADER, UUID.randomUUID().toString());
+		}
+
+		return execution.execute(request, body);
+	}
+}

--- a/src/main/java/com/goti/config/properties/RestClientProperties.java
+++ b/src/main/java/com/goti/config/properties/RestClientProperties.java
@@ -1,0 +1,10 @@
+package com.goti.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "external.api")
+public record RestClientProperties(
+	int connectTimeout,
+	int readTimeout
+) {
+}

--- a/src/main/java/com/goti/infra/api/base/BaseRestClient.java
+++ b/src/main/java/com/goti/infra/api/base/BaseRestClient.java
@@ -1,0 +1,109 @@
+package com.goti.infra.api.base;
+
+import org.springframework.http.MediaType;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriBuilder;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.Map;
+
+public abstract class BaseRestClient {
+	protected final RestClient restClient;
+
+	protected BaseRestClient(RestClient.Builder builder) {
+		this.restClient = builder
+			.defaultHeaders(headers -> {
+				headers.setContentType(MediaType.APPLICATION_JSON);
+				headers.setAccept(java.util.List.of(MediaType.APPLICATION_JSON));
+			})
+			.build();
+	}
+
+	private UriBuilder getActualUriBuilder(String uri, UriBuilder defaultBuilder) {
+		return uri.startsWith("http")
+			? UriComponentsBuilder.fromUriString(uri)
+			: defaultBuilder.path(uri);
+	}
+
+	private MultiValueMap<String, String> toParams(Map<String, ?> queryParams) {
+		MultiValueMap<String, String> multiValueMap = new LinkedMultiValueMap<>();
+		if (queryParams != null) {
+			queryParams.forEach((k, v) -> {
+				if (v != null) multiValueMap.add(k, String.valueOf(v));
+			});
+		}
+		return multiValueMap;
+	}
+
+	protected <T> T get(
+		String uri,
+		Map<String, String> headers,
+		Map<String, ?> queryParams,
+		Class<T> responseType
+	) {
+		return restClient.get()
+			.uri(uriBuilder -> {
+				UriBuilder builder = getActualUriBuilder(uri, uriBuilder);
+				if (queryParams != null) {
+					builder.queryParams(toParams(queryParams));
+				}
+				return builder.build();
+			})
+			.headers(header -> {
+				if (headers != null) headers.forEach(header::add);
+			})
+			.retrieve()
+			.body(responseType);
+	}
+
+	protected <T> T post(
+		String uri,
+		Object body,
+		MediaType contentType,
+		Class<T> responseType
+	) {
+		return restClient.post()
+			.uri(uriBuilder -> getActualUriBuilder(uri, uriBuilder).build())
+			.headers(header -> {
+				if (contentType != null)
+					header.setContentType(contentType);
+			})
+			.body(
+				body instanceof Map ? toParams((Map<String, ?>) body) : body
+			)
+			.retrieve()
+			.body(responseType);
+	}
+
+	protected <T> T post(String uri, Object body, Class<T> responseType) {
+		return post(uri, body, null, responseType);
+	}
+
+	protected <T> T put(String uri, Object body, Class<T> responseType) {
+		return restClient.put().uri(
+			uriBuilder -> getActualUriBuilder(uri, uriBuilder).build()
+			)
+			.body(body)
+			.retrieve()
+			.body(responseType);
+	}
+
+	protected <T> T delete(
+		String uri,
+		Map<String, ?> queryParams,
+		Class<T> responseType
+	) {
+		return restClient.delete()
+			.uri(uriBuilder -> {
+				UriBuilder builder = getActualUriBuilder(uri, uriBuilder);
+				if (queryParams != null) {
+					builder.queryParams(toParams(queryParams));
+				}
+				return builder.build();
+			})
+			.retrieve()
+			.body(responseType);
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,3 +33,8 @@ jwt:
   secret: ${JWT_SECRET_KEY}
   access-valid-time: ${JWT_ACCESS_TIME}
   refresh-valid-time: ${JWT_REFRESH_TIME}
+
+external:
+  api:
+    connect-timeout: 5
+    read-timeout: 10

--- a/src/test/java/com/goti/infra/api/base/BaseRestClientTest.java
+++ b/src/test/java/com/goti/infra/api/base/BaseRestClientTest.java
@@ -1,0 +1,107 @@
+package com.goti.infra.api.base;
+
+import com.goti.config.api.RestClientConfig;
+
+import com.goti.config.api.interceptor.ExternalLoggingInterceptor;
+
+import com.goti.config.api.interceptor.ExternalTraceInterceptor;
+
+import com.goti.constants.messages.ErrorCode;
+import com.goti.exception.CustomException;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Import({
+	RestClientConfig.class,
+	ExternalLoggingInterceptor.class,
+	ExternalTraceInterceptor.class
+})
+@Slf4j
+@ActiveProfiles("test")
+@SpringBootTest
+public class BaseRestClientTest {
+
+	@Autowired
+	RestClient restClient;
+
+	static final String BASE_URL = "https://jsonplaceholder.typicode.com";
+
+	TestApiClient testApiClient;
+
+	@BeforeEach
+	void setUp() {
+		testApiClient = new TestApiClient(restClient);
+	}
+
+	static class TestApiClient extends BaseRestClient {
+		public TestApiClient(RestClient restClient) {
+			super(restClient.mutate());
+		}
+
+		@Override
+		protected <T> T get(
+			String path,
+			Map<String, String> headers,
+			Map<String, ?> queryParams,
+			Class<T> responseType
+		) {
+			return super.get(path, headers, queryParams, responseType);
+		}
+	}
+
+	@Test
+	void restClient_get_요청_성공_테스트() {
+		Map<String, String> query = Map.of("postId", "2");
+		String result = testApiClient.get(
+			BASE_URL + "/comments",
+			null,
+			query,
+			String.class
+		);
+		assertNotNull(result);
+		log.info("Test Result :: {}", result);
+	}
+
+	@Test
+	void restClient_get_요청_실패_테스트() {
+
+		CustomException exception = assertThrows(CustomException.class, () -> {
+			testApiClient.get(
+				BASE_URL + "/posts/99999999",
+				null,
+				null,
+				String.class
+			);
+		});
+		assertThat(exception.error()).isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR);
+	}
+
+	@Test
+	void restClient_post_요청_성공_테스트() {
+		Map<String, Object> body = Map.of(
+			"title", "foo",
+			"body", "bar",
+			"userId", 1
+		);
+		String result = testApiClient.post(
+			BASE_URL + "/posts",
+			body,
+			String.class
+		);
+		assertNotNull(result);
+		log.info("result :: {}", result);
+	}
+}


### PR DESCRIPTION
<!-- 제목 예시: feat: 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#20 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
- RestClient Config 정의
- RestClient 공통통신 모듈 정의 (Get, Post, Put, Delete Custom)
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- RestClient configuration 정의 및 Trace, Logging Interceptor 정의
- RestClient 공통 통신 모듈 정의 (BaseRestClient) (추후 추상화 모듈 상속받아 확장 예정)
- RestClient 공통 통신 모듈 테스트 코드 작성 (Get 성공,실패, Post 성공, BaseRestClientTest)
- RestApi client connection, read Timeout 정의 (application.yml) 및 properties 정의
<br/>