### PR TITLE
[FEAT] 소셜(Oauth) 3사 (Kakao, Naver, Google) 통신 모듈 생성

### DIFF
--- a/src/main/java/com/goti/config/properties/oauth/GoogleOauthProperties.java
+++ b/src/main/java/com/goti/config/properties/oauth/GoogleOauthProperties.java
@@ -1,0 +1,13 @@
+package com.goti.config.properties.oauth;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "oauth.google")
+public record GoogleOauthProperties(
+	String clientId,
+	String clientSecret,
+	String redirectUri,
+	String tokenUrl,
+	String userInfoUrl
+) {
+}

--- a/src/main/java/com/goti/config/properties/oauth/KakaoOauthProperties.java
+++ b/src/main/java/com/goti/config/properties/oauth/KakaoOauthProperties.java
@@ -1,0 +1,13 @@
+package com.goti.config.properties.oauth;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "oauth.kakao")
+public record KakaoOauthProperties(
+	String clientId,
+	String clientSecret,
+	String redirectUri,
+	String tokenUrl,
+	String userInfoUrl
+) {
+}

--- a/src/main/java/com/goti/config/properties/oauth/NaverOauthProperties.java
+++ b/src/main/java/com/goti/config/properties/oauth/NaverOauthProperties.java
@@ -1,0 +1,13 @@
+package com.goti.config.properties.oauth;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "oauth.naver")
+public record NaverOauthProperties(
+	String clientId,
+	String clientSecret,
+	String redirectUri,
+	String tokenUrl,
+	String userInfoUrl
+) {
+}

--- a/src/main/java/com/goti/constants/ProviderType.java
+++ b/src/main/java/com/goti/constants/ProviderType.java
@@ -1,0 +1,35 @@
+package com.goti.constants;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import com.goti.constants.messages.ErrorCode;
+import com.goti.exception.FieldValidationException;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProviderType {
+	NAVER("naver"),
+	KAKAO("kakao"),
+	GOOGLE("google")
+	;
+
+	private final String value;
+
+	@JsonCreator
+	public static ProviderType from(String value) {
+		return Arrays.stream(ProviderType.values())
+			.filter(type ->
+				type.name().equalsIgnoreCase(value) ||
+				type.value.equalsIgnoreCase(value)
+			)
+			.findFirst()
+			.orElseThrow(
+				() -> new FieldValidationException(ErrorCode.INVALID_PROVIDER_TYPE, value)
+			);
+	}
+}

--- a/src/main/java/com/goti/constants/messages/ErrorCode.java
+++ b/src/main/java/com/goti/constants/messages/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
 	TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "{0} 타입 오류"),
 	MISSING_PARAMETER(HttpStatus.BAD_REQUEST, "{0} 파라미터 필요"),
 	INVALID_FORMAT(HttpStatus.BAD_REQUEST, "{0} 형식 오류"),
+	INVALID_PROVIDER_TYPE(HttpStatus.BAD_REQUEST, "{0} 은(는) 지원하지 않는 소셜 서비스입니다."),
 
 	AUTH_INVALID_ACCESS_PATH(HttpStatus.UNAUTHORIZED, "올바르지 않은 접근 경로입니다."),
 	AUTH_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),

--- a/src/main/java/com/goti/infra/api/client/SocialApiClient.java
+++ b/src/main/java/com/goti/infra/api/client/SocialApiClient.java
@@ -1,0 +1,11 @@
+package com.goti.infra.api.client;
+
+import com.goti.constants.ProviderType;
+
+public interface SocialApiClient {
+	ProviderType getProviderType();
+
+	String getAccessToken(String code, String state);
+
+	String getProviderId(String accessToken);
+}

--- a/src/main/java/com/goti/infra/api/client/google/GoogleApiClient.java
+++ b/src/main/java/com/goti/infra/api/client/google/GoogleApiClient.java
@@ -21,7 +21,7 @@ public class GoogleApiClient extends BaseRestClient implements SocialApiClient {
 
 	@Override
 	public ProviderType getProviderType() {
-		return null;
+		return ProviderType.GOOGLE;
 	}
 
 	// todo : accessToken API 구현 2026.02.23 오후 내로 완료 예정

--- a/src/main/java/com/goti/infra/api/client/google/GoogleApiClient.java
+++ b/src/main/java/com/goti/infra/api/client/google/GoogleApiClient.java
@@ -1,0 +1,38 @@
+package com.goti.infra.api.client.google;
+
+import com.goti.config.properties.oauth.GoogleOauthProperties;
+import com.goti.constants.ProviderType;
+import com.goti.infra.api.base.BaseRestClient;
+
+import com.goti.infra.api.client.SocialApiClient;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class GoogleApiClient extends BaseRestClient implements SocialApiClient {
+
+	private final GoogleOauthProperties properties;
+
+	public GoogleApiClient(RestClient restClient, GoogleOauthProperties properties) {
+		super(restClient.mutate());
+		this.properties = properties;
+	}
+
+	@Override
+	public ProviderType getProviderType() {
+		return null;
+	}
+
+	// todo : accessToken API 구현 2026.02.23 오후 내로 완료 예정
+	@Override
+	public String getAccessToken(String code, String state) {
+		return "";
+	}
+
+	// todo : getProviderId API 구현 2026.02.23 오후 내로 완료 예정
+	@Override
+	public String getProviderId(String accessToken) {
+		return "";
+	}
+}

--- a/src/main/java/com/goti/infra/api/client/kakao/KakaoApiClient.java
+++ b/src/main/java/com/goti/infra/api/client/kakao/KakaoApiClient.java
@@ -1,0 +1,38 @@
+package com.goti.infra.api.client.kakao;
+
+import com.goti.config.properties.oauth.KakaoOauthProperties;
+import com.goti.config.properties.oauth.NaverOauthProperties;
+import com.goti.constants.ProviderType;
+import com.goti.infra.api.base.BaseRestClient;
+import com.goti.infra.api.client.SocialApiClient;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class KakaoApiClient extends BaseRestClient implements SocialApiClient {
+
+	private final KakaoOauthProperties properties;
+
+	public KakaoApiClient(RestClient restClient, KakaoOauthProperties properties) {
+		super(restClient.mutate());
+		this.properties = properties;
+	}
+
+	@Override
+	public ProviderType getProviderType() {
+		return ProviderType.KAKAO;
+	}
+
+	// todo : accessToken API 구현 2026.02.23 오후 내로 완료 예정
+	@Override
+	public String getAccessToken(String code, String state) {
+		return "";
+	}
+
+	// todo : getProviderId API 구현 2026.02.23 오후 내로 완료 예정
+	@Override
+	public String getProviderId(String accessToken) {
+		return "";
+	}
+}

--- a/src/main/java/com/goti/infra/api/client/naver/NaverApiClient.java
+++ b/src/main/java/com/goti/infra/api/client/naver/NaverApiClient.java
@@ -1,0 +1,37 @@
+package com.goti.infra.api.client.naver;
+
+import com.goti.config.properties.oauth.NaverOauthProperties;
+import com.goti.constants.ProviderType;
+import com.goti.infra.api.base.BaseRestClient;
+import com.goti.infra.api.client.SocialApiClient;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class NaverApiClient extends BaseRestClient implements SocialApiClient {
+
+	private final NaverOauthProperties properties;
+
+	public NaverApiClient(RestClient restClient, NaverOauthProperties properties) {
+		super(restClient.mutate());
+		this.properties = properties;
+	}
+
+	@Override
+	public ProviderType getProviderType() {
+		return ProviderType.NAVER;
+	}
+
+	// todo : accessToken API 구현 2026.02.23 오후 내로 완료 예정
+	@Override
+	public String getAccessToken(String code, String state) {
+		return "";
+	}
+
+	// todo : getProviderId API 구현 2026.02.23 오후 내로 완료 예정
+	@Override
+	public String getProviderId(String accessToken) {
+		return "";
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,3 +38,23 @@ external:
   api:
     connect-timeout: 5
     read-timeout: 10
+
+oauth:
+  kakao:
+    client-id: ${KAKAO_CLIENT}
+    client-secret: ${KAKAO_SECRET}
+    redirect-uri: ${KAKAO_REDIRECT_URI}
+    token-url: ${KAKAO_TOKEN_URI:https://kauth.kakao.com/oauth/token}
+    user-info-url: ${KAKAO_USER_INFO_URL:https://kapi.kakao.com/v2/user/me}
+  naver:
+    client-id: ${NAVER_CLIENT}
+    client-secret: ${NAVER_SECRET}
+    redirect-uri: ${NAVER_REDIRECT_URI}
+    token-url: ${NAVER_TOKEN_URL:https://nid.naver.com/oauth2.0/token}
+    user-info-url: ${NAVER_USER_INFO_URL:https://openapi.naver.com/v1/nid/me}
+  google:
+    client-id: ${GOOGLE_CLIENT}
+    client-secret: ${GOOGLE_SECRET}
+    redirect-uri: ${GOOGLE_REDIRECT_URI}
+    token-url: ${GOOGLE_TOKEN_URL:https://oauth2.googleapis.com/token}
+    user-info-url: ${GOOGLE_USER_INFO_URL:https://www.googleapis.com/oauth2/v3/userinfo}


### PR DESCRIPTION
<!-- 제목 예시: feat: 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#27 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
- 각 소셜 서비스 통신 구현체 생성
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- SocialApiClient 외부 API 통신 공통 인터페이스 추가 및 정의
- 각 3사 소셜서비스 통신 구현체 추가 및 정의 (SocialApiClient implements)
- BaseRestClient 상속을 통한 RestClient 설정 공유
- 각 소셜 서비스 config 정의(application.yml) 및 properties 생성
- ErrorCode 추가 (지원하지 않는 소셜 서비스) 
<br/>