### PR TITLE
[FEAT] 소셜(Oauth) AccessToken 발급 API 요청 서비스 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,10 @@ dependencies {
     /* Test Module Lombok */
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
+
+    /* Redis */
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.32.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/goti/config/redis/RedisConfig.java
+++ b/src/main/java/com/goti/config/redis/RedisConfig.java
@@ -1,0 +1,57 @@
+package com.goti.config.redis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import lombok.RequiredArgsConstructor;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+
+	private final RedisProperties redisProperties;
+
+	@Bean
+	public RedissonClient localRedissonClient() {
+		var config = new Config();
+		var host = redisProperties.getCluster().getNodes().getFirst();
+		var uri = String.format("redis://%s", host);
+
+		config.useSingleServer().setAddress(uri);
+		return Redisson.create(config);
+	}
+
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory factory) {
+		RedisTemplate<String, Object> template = new RedisTemplate<>();
+		template.setConnectionFactory(factory);
+
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setHashKeySerializer(new StringRedisSerializer());
+
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new JavaTimeModule());
+		objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+		GenericJackson2JsonRedisSerializer serializer =
+			new GenericJackson2JsonRedisSerializer(objectMapper);
+
+		template.setValueSerializer(serializer);
+		template.setHashValueSerializer(serializer);
+
+		template.afterPropertiesSet();
+		return template;
+	}
+}

--- a/src/main/java/com/goti/constants/messages/ErrorCode.java
+++ b/src/main/java/com/goti/constants/messages/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
 	MISSING_PARAMETER(HttpStatus.BAD_REQUEST, "{0} 파라미터 필요"),
 	INVALID_FORMAT(HttpStatus.BAD_REQUEST, "{0} 형식 오류"),
 	INVALID_PROVIDER_TYPE(HttpStatus.BAD_REQUEST, "{0} 은(는) 지원하지 않는 소셜 서비스입니다."),
+	INVALID_STATE(HttpStatus.BAD_REQUEST, "유효하지 않은 state입니다."),
 
 	AUTH_INVALID_ACCESS_PATH(HttpStatus.UNAUTHORIZED, "올바르지 않은 접근 경로입니다."),
 	AUTH_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),

--- a/src/main/java/com/goti/constants/redis/RedisKey.java
+++ b/src/main/java/com/goti/constants/redis/RedisKey.java
@@ -1,0 +1,21 @@
+package com.goti.constants.redis;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.Duration;
+
+@Getter
+@RequiredArgsConstructor
+public enum RedisKey {
+	AUTH_CODE("auth:code:", Duration.ofMinutes(3)),
+	OAUTH_STATE("oauth:state:", Duration.ofMinutes(5));
+
+	private final String prefix;
+
+	private final Duration ttl;
+
+	public String getKey(Object val) {
+		return prefix + val;
+	}
+}

--- a/src/main/java/com/goti/infra/api/client/SocialClientProvider.java
+++ b/src/main/java/com/goti/infra/api/client/SocialClientProvider.java
@@ -1,0 +1,36 @@
+package com.goti.infra.api.client;
+
+import com.goti.constants.ProviderType;
+
+import com.goti.constants.messages.ErrorCode;
+import com.goti.exception.CustomException;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+public class SocialClientProvider {
+	private final Map<ProviderType, SocialApiClient> clients;
+
+	public SocialClientProvider(List<SocialApiClient> clientList) {
+		this.clients = clientList.stream()
+			.collect(Collectors.toUnmodifiableMap(
+				SocialApiClient::getProviderType,
+				Function.identity()
+			));
+	}
+
+	public SocialApiClient getClient(ProviderType providerType) {
+		return Optional.ofNullable(clients.get(providerType))
+			.orElseThrow(
+				() -> new CustomException(
+					ErrorCode.INVALID_PROVIDER_TYPE, providerType.name()
+				)
+			);
+	}
+}

--- a/src/main/java/com/goti/infra/api/client/google/GoogleApiClient.java
+++ b/src/main/java/com/goti/infra/api/client/google/GoogleApiClient.java
@@ -6,8 +6,16 @@ import com.goti.infra.api.base.BaseRestClient;
 
 import com.goti.infra.api.client.SocialApiClient;
 
+import com.goti.infra.api.dto.request.google.GoogleTokenRequest;
+
+import com.goti.infra.api.dto.response.common.SocialAccessTokenResponse;
+
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 @Component
 public class GoogleApiClient extends BaseRestClient implements SocialApiClient {
@@ -24,10 +32,24 @@ public class GoogleApiClient extends BaseRestClient implements SocialApiClient {
 		return ProviderType.GOOGLE;
 	}
 
-	// todo : accessToken API 구현 2026.02.23 오후 내로 완료 예정
 	@Override
 	public String getAccessToken(String code, String state) {
-		return "";
+		String originCode = URLDecoder.decode(code, StandardCharsets.UTF_8);
+		GoogleTokenRequest request = new GoogleTokenRequest(
+			properties.clientId(),
+			properties.clientSecret(),
+			properties.redirectUri(),
+			originCode
+		);
+
+		SocialAccessTokenResponse response = post(
+			properties.tokenUrl(),
+			request.toFormData(),
+			MediaType.APPLICATION_FORM_URLENCODED,
+			SocialAccessTokenResponse.class
+		);
+
+		return response.accessToken();
 	}
 
 	// todo : getProviderId API 구현 2026.02.23 오후 내로 완료 예정

--- a/src/main/java/com/goti/infra/api/client/kakao/KakaoApiClient.java
+++ b/src/main/java/com/goti/infra/api/client/kakao/KakaoApiClient.java
@@ -6,6 +6,11 @@ import com.goti.constants.ProviderType;
 import com.goti.infra.api.base.BaseRestClient;
 import com.goti.infra.api.client.SocialApiClient;
 
+import com.goti.infra.api.dto.request.kakao.KakaoTokenRequest;
+
+import com.goti.infra.api.dto.response.common.SocialAccessTokenResponse;
+
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
@@ -24,10 +29,22 @@ public class KakaoApiClient extends BaseRestClient implements SocialApiClient {
 		return ProviderType.KAKAO;
 	}
 
-	// todo : accessToken API 구현 2026.02.23 오후 내로 완료 예정
 	@Override
 	public String getAccessToken(String code, String state) {
-		return "";
+		KakaoTokenRequest request = new KakaoTokenRequest(
+			properties.clientId(),
+			properties.clientSecret(),
+			properties.redirectUri(),
+			code
+		);
+		SocialAccessTokenResponse response = post(
+			properties.tokenUrl(),
+			request.toFormData(),
+			MediaType.APPLICATION_FORM_URLENCODED,
+			SocialAccessTokenResponse.class
+		);
+
+		return response.accessToken();
 	}
 
 	// todo : getProviderId API 구현 2026.02.23 오후 내로 완료 예정

--- a/src/main/java/com/goti/infra/api/client/naver/NaverApiClient.java
+++ b/src/main/java/com/goti/infra/api/client/naver/NaverApiClient.java
@@ -5,6 +5,11 @@ import com.goti.constants.ProviderType;
 import com.goti.infra.api.base.BaseRestClient;
 import com.goti.infra.api.client.SocialApiClient;
 
+import com.goti.infra.api.dto.request.naver.NaverTokenRequest;
+
+import com.goti.infra.api.dto.response.common.SocialAccessTokenResponse;
+
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
@@ -23,10 +28,24 @@ public class NaverApiClient extends BaseRestClient implements SocialApiClient {
 		return ProviderType.NAVER;
 	}
 
-	// todo : accessToken API 구현 2026.02.23 오후 내로 완료 예정
 	@Override
 	public String getAccessToken(String code, String state) {
-		return "";
+		NaverTokenRequest request = new NaverTokenRequest(
+			properties.clientId(),
+			properties.clientSecret(),
+			properties.redirectUri(),
+			code,
+			state
+		);
+
+		SocialAccessTokenResponse response = post(
+			properties.tokenUrl(),
+			request.toFormData(),
+			MediaType.APPLICATION_FORM_URLENCODED,
+			SocialAccessTokenResponse.class
+		);
+
+		return response.accessToken();
 	}
 
 	// todo : getProviderId API 구현 2026.02.23 오후 내로 완료 예정

--- a/src/main/java/com/goti/infra/api/dto/request/google/GoogleTokenRequest.java
+++ b/src/main/java/com/goti/infra/api/dto/request/google/GoogleTokenRequest.java
@@ -1,0 +1,27 @@
+package com.goti.infra.api.dto.request.google;
+
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+public record GoogleTokenRequest(
+	String clientId,
+	String clientSecret,
+	String redirectUri,
+	String code
+) {
+	private static final String GRANT_TYPE = "authorization_code";
+
+	public MultiValueMap<String, String> toFormData() {
+		MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+		formData.add("grant_type", GRANT_TYPE);
+		formData.add("client_id", clientId);
+
+		if (clientSecret != null && !clientSecret.isBlank()) {
+			formData.add("client_secret", clientSecret);
+		}
+		formData.add("redirect_uri", redirectUri);
+		formData.add("code", code);
+
+		return formData;
+	}
+}

--- a/src/main/java/com/goti/infra/api/dto/request/kakao/KakaoTokenRequest.java
+++ b/src/main/java/com/goti/infra/api/dto/request/kakao/KakaoTokenRequest.java
@@ -1,0 +1,28 @@
+package com.goti.infra.api.dto.request.kakao;
+
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+public record KakaoTokenRequest(
+	String clientId,
+	String clientSecret,
+	String redirectUri,
+	String code
+) {
+	private static final String GRANT_TYPE = "authorization_code";
+
+	public MultiValueMap<String, String> toFormData() {
+		MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+		formData.add("grant_type", GRANT_TYPE);
+		formData.add("client_id", clientId);
+
+		if (clientSecret != null && !clientSecret.isBlank()) {
+			formData.add("client_secret", clientSecret);
+		}
+
+		formData.add("redirect_uri", redirectUri);
+		formData.add("code", code);
+
+		return formData;
+	}
+}

--- a/src/main/java/com/goti/infra/api/dto/request/naver/NaverTokenRequest.java
+++ b/src/main/java/com/goti/infra/api/dto/request/naver/NaverTokenRequest.java
@@ -1,0 +1,30 @@
+package com.goti.infra.api.dto.request.naver;
+
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+public record NaverTokenRequest(
+	String clientId,
+	String clientSecret,
+	String redirectUri,
+	String code,
+	String state
+) {
+	private static final String GRANT_TYPE = "authorization_code";
+
+	public MultiValueMap<String, String> toFormData() {
+		MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+
+		formData.add("grant_type", GRANT_TYPE);
+		formData.add("client_id", clientId);
+		if (clientSecret != null && !clientSecret.isBlank()) {
+			formData.add("client_secret", clientSecret);
+		}
+		formData.add("redirect_uri", redirectUri);
+		formData.add("code", code);
+		formData.add("state", state);
+
+		return formData;
+	}
+}
+

--- a/src/main/java/com/goti/infra/api/dto/response/common/SocialAccessTokenResponse.java
+++ b/src/main/java/com/goti/infra/api/dto/response/common/SocialAccessTokenResponse.java
@@ -1,0 +1,9 @@
+package com.goti.infra.api.dto.response.common;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record SocialAccessTokenResponse(
+	@JsonProperty("access_token")
+	String accessToken
+) {
+}

--- a/src/main/java/com/goti/infra/api/dto/response/common/SocialStateResponse.java
+++ b/src/main/java/com/goti/infra/api/dto/response/common/SocialStateResponse.java
@@ -1,0 +1,10 @@
+package com.goti.infra.api.dto.response.common;
+
+public record SocialStateResponse(
+	String state
+) {
+	public static SocialStateResponse of(String state) {
+		return new SocialStateResponse(state);
+	}
+}
+

--- a/src/main/java/com/goti/infra/cache/RedisCache.java
+++ b/src/main/java/com/goti/infra/cache/RedisCache.java
@@ -1,0 +1,43 @@
+package com.goti.infra.cache;
+
+import com.goti.constants.redis.RedisKey;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class RedisCache {
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	public <T> void set(String key, T value) {
+		redisTemplate.opsForValue().set(key, value);
+	}
+
+	public <T> void set(String key, T value, Duration ttl) {
+		redisTemplate.opsForValue().set(key, value, ttl.toMillis(), TimeUnit.MILLISECONDS);
+	}
+
+	public <T> void set(RedisKey redisKey, Object keyParam, T value) {
+		set(redisKey.getKey(keyParam), value, redisKey.getTtl());
+	}
+
+	public <T> T get(String key, Class<T> clazz) {
+		Object value = redisTemplate.opsForValue().get(key);
+		return value != null ? clazz.cast(value) : null;
+	}
+
+	public boolean consume(String key) {
+		Boolean deleted = redisTemplate.delete(key);
+		return Boolean.TRUE.equals(deleted);
+	}
+
+	public boolean hasKey(String key) {
+		return redisTemplate.hasKey(key);
+	}
+}

--- a/src/main/java/com/goti/service/auth/application/AuthApplicationService.java
+++ b/src/main/java/com/goti/service/auth/application/AuthApplicationService.java
@@ -1,0 +1,69 @@
+package com.goti.service.auth.application;
+
+import com.goti.constants.ProviderType;
+import com.goti.constants.messages.ErrorCode;
+import com.goti.constants.redis.RedisKey;
+import com.goti.exception.CustomException;
+import com.goti.infra.api.client.SocialApiClient;
+import com.goti.infra.api.client.SocialClientProvider;
+
+import com.goti.infra.api.dto.response.common.SocialStateResponse;
+import com.goti.infra.cache.RedisCache;
+
+import lombok.RequiredArgsConstructor;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthApplicationService {
+	private final SocialClientProvider socialClientProvider;
+	private final RedisCache redisCache;
+
+	static final String KEY_SEPARATOR = ":";
+
+	public void login(ProviderType provider, String code, String state) {
+		validateState(provider, state);
+		String accessToken = getAccessToken(provider, code, state);
+		log.info("accessToken :: {}", accessToken);
+	}
+
+
+	public SocialStateResponse issueState(ProviderType provider) {
+		if (provider == ProviderType.KAKAO) {
+			throw new CustomException(ErrorCode.BAD_REQUEST);
+		}
+		String state = UUID.randomUUID().toString();
+		String keyParam = provider + KEY_SEPARATOR + state;
+
+		redisCache.set(RedisKey.OAUTH_STATE, keyParam, true);
+
+		return SocialStateResponse.of(state);
+	}
+
+	private void validateState(ProviderType provider, String state) {
+		if (provider == ProviderType.KAKAO) return;
+
+		if (state == null || state.isBlank()) {
+			throw new CustomException(ErrorCode.MISSING_PARAMETER, "state");
+		}
+		String keyParam = provider + KEY_SEPARATOR + state;
+		String stateKey = RedisKey.OAUTH_STATE.getKey(keyParam);
+		if (!redisCache.consume(stateKey)) {
+			throw new CustomException(ErrorCode.INVALID_STATE);
+		}
+	}
+
+	private String getAccessToken(ProviderType provider, String code, String state) {
+		SocialApiClient apiClient = socialClientProvider.getClient(provider);
+		return apiClient.getAccessToken(code, state);
+	}
+
+	// todo: proverId 발급 로직 구현 예정
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,13 @@ spring:
           format_sql: true
           show_sql: true
           dialect: org.hibernate.dialect.PostgreSQLDialect
+  data:
+    redis:
+      ssl:
+        enabled: true
+      cluster:
+        nodes: ${REDIS_HOST}
+        max-redirects: 3
   config:
     import:
       - optional:file:.env[.properties]

--- a/src/test/java/com/goti/service/auth/application/AuthApplicationServiceTest.java
+++ b/src/test/java/com/goti/service/auth/application/AuthApplicationServiceTest.java
@@ -1,0 +1,85 @@
+package com.goti.service.auth.application;
+
+import com.goti.constants.ProviderType;
+
+import com.goti.constants.messages.ErrorCode;
+import com.goti.constants.redis.RedisKey;
+import com.goti.exception.CustomException;
+
+import com.goti.infra.api.dto.response.common.SocialStateResponse;
+
+import com.goti.infra.cache.RedisCache;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Slf4j
+@ActiveProfiles("test")
+@SpringBootTest
+public class AuthApplicationServiceTest {
+
+	@Autowired
+	AuthApplicationService authApplicationService;
+
+	@Autowired
+	RedisCache redisCache;
+
+	static final String KEY_SEPARATOR = ":";
+
+	@Test
+	@DisplayName("method : issueState()")
+	void state_생성_성공() {
+		ProviderType provider = ProviderType.NAVER;
+		SocialStateResponse response = authApplicationService.issueState(provider);
+		assertNotNull(response);
+		String state = response.state();
+		log.info("state :: {}", response.state());
+		String keyParam = provider + KEY_SEPARATOR + state;
+		boolean isExists = redisCache.get(RedisKey.OAUTH_STATE.getKey(keyParam), Boolean.class);
+		assertTrue(isExists);
+		log.info("isExists :: {}", isExists);
+	}
+
+	@Test
+	@DisplayName("method : issueState()")
+	void state_생성_실패_kakao() {
+		ProviderType provider = ProviderType.KAKAO;
+		assertThatThrownBy(
+			() -> authApplicationService.issueState(provider)
+		).isInstanceOf(CustomException.class)
+			.hasMessageContaining(ErrorCode.BAD_REQUEST.getMessage());
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	@DisplayName("method : login() (google, naver)")
+	void 엑세스토큰_생성_실패_state_필수_소셜로그_state_null_또는_공백(String code) {
+		ProviderType provider = ProviderType.NAVER; // (or GOOGLE)
+		assertThatThrownBy(
+			() -> authApplicationService.login(provider, code, null)
+		).isInstanceOf(CustomException.class)
+			.hasMessageContaining(ErrorCode.MISSING_PARAMETER.format("state"));
+	}
+
+	@Test
+	@DisplayName("method : login() (google, naver)")
+	void 엑세스토큰_생성_실패_state_필수_소셜로그_redis_state_미존재() {
+		ProviderType provider = ProviderType.NAVER; // (or GOOGLE)
+		String code = "testCode";
+		String state = "NOT_EXISTS_STATE";
+		assertThatThrownBy(
+			() -> authApplicationService.login(provider, code, state)
+		).isInstanceOf(CustomException.class)
+			.hasMessageContaining(ErrorCode.INVALID_STATE.getMessage());
+	}
+}


### PR DESCRIPTION
<!-- 제목 예시: feat: 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#29 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
- AuthApplicationService 추가 (accessToken 요청 api 로직 구현, State 발급 로직 구현)
- Redis 의존성 추가 및 정의
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- AuthApplicationService 추가
    - accessToken 발급 외부 소셜 api 요청 및 accessToken 발급 로직 구현 (테스트 코드 제한으로, 실제 테스트 완료)
    - State 생성 서비스 생성 로직 구현 및 테스트(성공 및 실패케이스) 추가
- Redis application.yml 정의 및 RedisConfig 정의
- RedisCache(RedisCache Provider 제공) 및 RedisKey(redis Key 모음 Enum 정의 파일)정의
- accessToken 요청 시 외부 api 응답 dto 추가
- state responseDto 추가
<br/>