### PR TITLE
[CHORE] Dockerfile 및 .dockerignore 추가 (#35)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Git
+.git
+.gitignore
+
+# Build output
+build/
+**/build/
+!gradle/wrapper/gradle-wrapper.jar
+
+# IDE
+.idea/
+.vscode/
+*.iml
+*.iws
+*.ipr
+out/
+
+# Docker
+docker/
+Dockerfile
+.dockerignore
+
+# CI/CD
+.github/
+
+# Env
+.env
+.env.*
+
+# Docs
+*.md
+LICENSE
+
+# OS
+.DS_Store
+Thumbs.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,62 @@
+# ===== Stage 1: Build =====
+FROM eclipse-temurin:21-jdk-alpine AS build
+
+WORKDIR /app
+
+# Gradle wrapper + 설정 파일 먼저 복사 (의존성 캐시 레이어)
+COPY gradlew settings.gradle build.gradle ./
+COPY gradle/ gradle/
+RUN chmod +x gradlew
+
+# 각 모듈의 build.gradle 복사 (의존성 해석용)
+COPY core/build.gradle core/build.gradle
+COPY common/build.gradle common/build.gradle
+COPY integration/build.gradle integration/build.gradle
+COPY user/build.gradle user/build.gradle
+COPY stadium/build.gradle stadium/build.gradle
+COPY ticketing/build.gradle ticketing/build.gradle
+COPY payment/build.gradle payment/build.gradle
+COPY resale/build.gradle resale/build.gradle
+COPY api/build.gradle api/build.gradle
+
+# 의존성 다운로드 (소스 변경 시 캐시 재사용)
+RUN --mount=type=cache,target=/root/.gradle \
+    ./gradlew dependencies --no-daemon || true
+
+# 전체 소스 복사
+COPY . .
+
+# bootJar 빌드
+RUN --mount=type=cache,target=/root/.gradle \
+    ./gradlew :api:bootJar --no-daemon -x test
+
+# ===== Stage 2: Extract (layertools) =====
+FROM eclipse-temurin:21-jdk-alpine AS extract
+
+WORKDIR /app
+
+COPY --from=build /app/api/build/libs/*.jar app.jar
+
+RUN java -Djarmode=layertools -jar app.jar extract
+
+# ===== Stage 3: Runtime =====
+FROM eclipse-temurin:21-jre-alpine
+
+RUN addgroup -S goti && adduser -S goti -G goti
+
+WORKDIR /app
+
+# 변경 빈도 낮은 순서대로 COPY (레이어 캐시 최적화)
+COPY --from=extract /app/dependencies/ ./
+COPY --from=extract /app/spring-boot-loader/ ./
+COPY --from=extract /app/snapshot-dependencies/ ./
+COPY --from=extract /app/application/ ./
+
+RUN chown -R goti:goti /app
+USER goti
+
+ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+UseG1GC"
+
+EXPOSE 8080
+
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS org.springframework.boot.loader.launch.JarLauncher"]


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #35

<br/>

## 🔎 개요
컨테이너화를 위한 Dockerfile, .dockerignore를 추가

<br/>


## 📋 작업 내용
- 3-stage Dockerfile 작성 (Build → Extract → Runtime)
  - eclipse-temurin:21 기반
  - Gradle 의존성 레이어 캐시 활용 (`--mount=type=cache`)
  - Spring Boot layertools로 JAR 레이어 분리
  - non-root 유저(goti) 실행
  - JVM 옵션: `-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+UseG1GC`
- .dockerignore 작성 (불필요한 파일 빌드 컨텍스트 제외)
<br/>