### PR TITLE
[FEAT] 야구 경기 도메인 엔티티 구현

### DIFF
--- a/core/src/main/java/com/goti/constants/GameResult.java
+++ b/core/src/main/java/com/goti/constants/GameResult.java
@@ -1,0 +1,9 @@
+package com.goti.constants;
+
+public enum GameResult {
+	PENDING,
+	HOME_WIN,
+	AWAY_WIN,
+	DRAW,
+	CANCELLED
+}

--- a/core/src/main/java/com/goti/constants/GameResult.java
+++ b/core/src/main/java/com/goti/constants/GameResult.java
@@ -1,9 +1,17 @@
 package com.goti.constants;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum GameResult {
-	PENDING,
-	HOME_WIN,
-	AWAY_WIN,
-	DRAW,
-	CANCELLED
+
+	PENDING("경기 미종료"),
+	HOME_WIN("홈팀 승리"),
+	AWAY_WIN("원정팀 승리"),
+	DRAW("무승부"),
+	CANCELLED("경기 취소");
+
+	private final String description;
 }

--- a/core/src/main/java/com/goti/constants/GameStatus.java
+++ b/core/src/main/java/com/goti/constants/GameStatus.java
@@ -1,11 +1,19 @@
 package com.goti.constants;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum GameStatus {
-	SCHEDULED,
-	IN_PROGRESS,
-	SUSPENDED,
-	RAIN_DELAY,
-	RAIN_CANCELLED,
-	CANCELLED,
-	FINISHED
+
+	SCHEDULED("경기 예정"),
+	IN_PROGRESS("경기 진행중"),
+	SUSPENDED("경기 중단"),
+	RAIN_DELAY("우천 중단"),
+	RAIN_CANCELLED("우천 취소"),
+	CANCELLED("경기 취소"),
+	FINISHED("경기 종료");
+
+	private final String description;
 }

--- a/core/src/main/java/com/goti/constants/GameStatus.java
+++ b/core/src/main/java/com/goti/constants/GameStatus.java
@@ -2,9 +2,10 @@ package com.goti.constants;
 
 public enum GameStatus {
 	SCHEDULED,
-	TICKET_OPEN,
-	SOLD_OUT,
 	IN_PROGRESS,
-	COMPLETED,
-	CANCELLED
+	SUSPENDED,
+	RAIN_DELAY,
+	RAIN_CANCELLED,
+	CANCELLED,
+	FINISHED
 }

--- a/core/src/main/java/com/goti/constants/GameStatus.java
+++ b/core/src/main/java/com/goti/constants/GameStatus.java
@@ -1,0 +1,10 @@
+package com.goti.constants;
+
+public enum GameStatus {
+	SCHEDULED,
+	TICKET_OPEN,
+	SOLD_OUT,
+	IN_PROGRESS,
+	COMPLETED,
+	CANCELLED
+}

--- a/core/src/main/java/com/goti/constants/LeagueType.java
+++ b/core/src/main/java/com/goti/constants/LeagueType.java
@@ -1,7 +1,15 @@
 package com.goti.constants;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum LeagueType {
-	PRE_SEASON,
-	REGULAR,
-	POSTSEASON
+
+	PRE_SEASON("프리시즌"),
+	REGULAR("정규리그"),
+	POSTSEASON("포스트시즌");
+
+	private final String description;
 }

--- a/core/src/main/java/com/goti/constants/LeagueType.java
+++ b/core/src/main/java/com/goti/constants/LeagueType.java
@@ -1,0 +1,7 @@
+package com.goti.constants;
+
+public enum LeagueType {
+	PRE_SEASON,
+	REGULAR,
+	POSTSEASON
+}

--- a/core/src/main/java/com/goti/constants/ReservationAvailableStatus.java
+++ b/core/src/main/java/com/goti/constants/ReservationAvailableStatus.java
@@ -1,8 +1,16 @@
 package com.goti.constants;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum ReservationAvailableStatus {
-	ON_SALE,
-	PENDING,
-	SOLD_OUT,
-	DISABLED
+
+	ON_SALE("판매중"),
+	PENDING("예매 예정"),
+	SOLD_OUT("매진"),
+	DISABLED("예매 불가");
+
+	private final String description;
 }

--- a/core/src/main/java/com/goti/constants/ReservationAvailableStatus.java
+++ b/core/src/main/java/com/goti/constants/ReservationAvailableStatus.java
@@ -1,0 +1,8 @@
+package com.goti.constants;
+
+public enum ReservationAvailableStatus {
+	ON_SALE,
+	PENDING,
+	SOLD_OUT,
+	DISABLED
+}

--- a/core/src/main/java/com/goti/domain/entity/game/BaseballGameEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/game/BaseballGameEntity.java
@@ -1,0 +1,171 @@
+package com.goti.domain.entity.game;
+
+import com.goti.constants.GameStatus;
+import com.goti.constants.LeagueType;
+import com.goti.constants.ReservationAvailableStatus;
+import com.goti.domain.base.ModificationTimestampEntity;
+
+import com.goti.global.validation.Preconditions;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.UUID;
+
+import static lombok.AccessLevel.*;
+
+@Getter
+@Entity
+@Table(name = "baseball_games")
+@NoArgsConstructor(access = PROTECTED)
+public class BaseballGameEntity extends ModificationTimestampEntity {
+	@Column(nullable = false)
+	private UUID homeTeamId;
+
+	@Column(nullable = false)
+	private UUID awayTeamId;
+
+	@Column(nullable = false)
+	private UUID stadiumId;
+
+	@Column(nullable = false)
+	private LocalDate playDate;
+
+	@Column(nullable = false)
+	private LocalTime startAt;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private GameStatus gameStatus;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private LeagueType leagueType;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private ReservationAvailableStatus reservationAvailableStatus;
+
+	@Column(nullable = false)
+	private LocalDateTime reservationOpenedAt;
+
+	@Column(nullable = false)
+	private LocalDateTime reservationClosedAt;
+
+	private BaseballGameEntity(
+		UUID homeTeamId,
+		UUID awayTeamId,
+		UUID stadiumId,
+		LocalDate playDate,
+		LocalTime startAt,
+		GameStatus gameStatus,
+		LeagueType leagueType,
+		ReservationAvailableStatus reservationAvailableStatus,
+		LocalDateTime reservationOpenedAt,
+		LocalDateTime reservationClosedAt
+	) {
+		this.homeTeamId = homeTeamId;
+		this.awayTeamId = awayTeamId;
+		this.stadiumId = stadiumId;
+		this.playDate = playDate;
+		this.startAt = startAt;
+		this.gameStatus = gameStatus;
+		this.leagueType = leagueType;
+		this.reservationAvailableStatus = reservationAvailableStatus;
+		this.reservationOpenedAt = reservationOpenedAt;
+		this.reservationClosedAt = reservationClosedAt;
+	}
+
+	public static BaseballGameEntity create(
+		UUID homeTeamId,
+		UUID awayTeamId,
+		UUID stadiumId,
+		LocalDate playDate,
+		LocalTime startAt,
+		GameStatus gameStatus,
+		LeagueType leagueType,
+		ReservationAvailableStatus reservationAvailableStatus,
+		LocalDateTime reservationOpenedAt,
+		LocalDateTime reservationClosedAt
+	) {
+
+		validate(
+			homeTeamId, awayTeamId, stadiumId,
+			playDate, startAt,
+			reservationOpenedAt, reservationClosedAt
+		);
+
+		return new BaseballGameEntity(
+			homeTeamId,
+			awayTeamId,
+			stadiumId,
+			playDate,
+			startAt,
+			gameStatus == null ? GameStatus.SCHEDULED : gameStatus,
+			leagueType == null ? LeagueType.REGULAR : leagueType,
+			reservationAvailableStatus == null ? ReservationAvailableStatus.PENDING : reservationAvailableStatus,
+			reservationOpenedAt,
+			reservationClosedAt
+		);
+	}
+
+	private static void validate(
+		UUID homeTeamId,
+		UUID awayTeamId,
+		UUID stadiumId,
+		LocalDate playDate,
+		LocalTime startAt,
+		LocalDateTime reservationOpenedAt,
+		LocalDateTime reservationClosedAt
+	) {
+
+		Preconditions.domainValidate(
+			homeTeamId != null,
+			"홈팀 ID는 필수입니다."
+		)		;
+		Preconditions.domainValidate(
+			awayTeamId != null,
+			"원정팀 ID는 필수입니다."
+		);
+		Preconditions.domainValidate(
+			stadiumId != null,
+			"구장 ID는 필수입니다."
+		);
+
+		Preconditions.domainValidate(
+			!homeTeamId.equals(awayTeamId),
+			"홈팀과 원정팀은 같을 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			playDate != null,
+			"경기 날짜는 필수입니다."
+		);
+		Preconditions.domainValidate(
+			startAt != null,
+			"경기 시작 시간은 필수입니다."
+		);
+
+		Preconditions.domainValidate(
+			reservationOpenedAt != null,
+			"예매 오픈 일시는 필수입니다."
+		);
+		Preconditions.domainValidate(
+			reservationClosedAt != null,
+			"예매 종료 일시는 필수입니다."
+		);
+
+		Preconditions.domainValidate(
+			!reservationOpenedAt.isAfter(reservationClosedAt),
+			"예매 오픈 일시는 종료 일시보다 늦을 수 없습니다."
+		);
+	}
+}

--- a/core/src/main/java/com/goti/domain/entity/game/BaseballGameEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/game/BaseballGameEntity.java
@@ -44,10 +44,6 @@ public class BaseballGameEntity extends ModificationTimestampEntity {
 
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
-	private GameStatus gameStatus;
-
-	@Enumerated(EnumType.STRING)
-	@Column(nullable = false)
 	private LeagueType leagueType;
 
 	@Enumerated(EnumType.STRING)
@@ -66,7 +62,6 @@ public class BaseballGameEntity extends ModificationTimestampEntity {
 		UUID stadiumId,
 		LocalDate playDate,
 		LocalTime startAt,
-		GameStatus gameStatus,
 		LeagueType leagueType,
 		ReservationAvailableStatus reservationAvailableStatus,
 		LocalDateTime reservationOpenedAt,
@@ -77,7 +72,6 @@ public class BaseballGameEntity extends ModificationTimestampEntity {
 		this.stadiumId = stadiumId;
 		this.playDate = playDate;
 		this.startAt = startAt;
-		this.gameStatus = gameStatus;
 		this.leagueType = leagueType;
 		this.reservationAvailableStatus = reservationAvailableStatus;
 		this.reservationOpenedAt = reservationOpenedAt;
@@ -109,7 +103,6 @@ public class BaseballGameEntity extends ModificationTimestampEntity {
 			stadiumId,
 			playDate,
 			startAt,
-			gameStatus == null ? GameStatus.SCHEDULED : gameStatus,
 			leagueType == null ? LeagueType.REGULAR : leagueType,
 			reservationAvailableStatus == null ? ReservationAvailableStatus.PENDING : reservationAvailableStatus,
 			reservationOpenedAt,

--- a/core/src/main/java/com/goti/domain/entity/game/BaseballGameStatusEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/game/BaseballGameStatusEntity.java
@@ -1,22 +1,22 @@
 package com.goti.domain.entity.game;
 
+import static lombok.AccessLevel.*;
+
 import com.goti.constants.GameResult;
 import com.goti.constants.GameStatus;
 import com.goti.domain.base.ModificationTimestampEntity;
-
 import com.goti.global.validation.Preconditions;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.UUID;
-
-import static lombok.AccessLevel.*;
 
 @Getter
 @Entity
@@ -24,25 +24,26 @@ import static lombok.AccessLevel.*;
 @NoArgsConstructor(access = PROTECTED)
 public class BaseballGameStatusEntity extends ModificationTimestampEntity {
 
-	@Column(name = "baseball_games_id", nullable = false)
-	private UUID baseballGameId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "baseball_game_id", nullable = false)
+	private BaseballGameEntity baseballGameId;
 
 	@Enumerated(EnumType.STRING)
-	@Column(name = "game_status", nullable = false, length = 50)
+	@Column(nullable = false)
 	private GameStatus gameStatus;
 
-	@Column(name = "home_team_score", nullable = false)
+	@Column(nullable = false)
 	private Integer homeTeamScore;
 
-	@Column(name = "away_team_score", nullable = false)
+	@Column(nullable = false)
 	private Integer awayTeamScore;
 
 	@Enumerated(EnumType.STRING)
-	@Column(name = "game_result", length = 50)
+	@Column(nullable = false)
 	private GameResult gameResult;
 
 	private BaseballGameStatusEntity(
-		UUID baseballGameId,
+		BaseballGameEntity baseballGameId,
 		GameStatus gameStatus,
 		Integer homeTeamScore,
 		Integer awayTeamScore,
@@ -56,7 +57,7 @@ public class BaseballGameStatusEntity extends ModificationTimestampEntity {
 	}
 
 	public static BaseballGameStatusEntity create(
-		UUID baseballGameId,
+		BaseballGameEntity baseballGameId,
 		GameStatus gameStatus,
 		Integer homeTeamScore,
 		Integer awayTeamScore,
@@ -64,7 +65,6 @@ public class BaseballGameStatusEntity extends ModificationTimestampEntity {
 	) {
 
 		validate(
-			baseballGameId,
 			gameStatus,
 			homeTeamScore,
 			awayTeamScore
@@ -80,16 +80,10 @@ public class BaseballGameStatusEntity extends ModificationTimestampEntity {
 	}
 
 	private static void validate(
-		UUID baseballGameId,
 		GameStatus gameStatus,
 		Integer homeTeamScore,
 		Integer awayTeamScore
 	) {
-
-		Preconditions.domainValidate(
-			baseballGameId != null,
-			"경기 ID는 필수입니다."
-		);
 		Preconditions.domainValidate(
 			gameStatus != null,
 			"경기 상태는 필수입니다."

--- a/core/src/main/java/com/goti/domain/entity/game/BaseballGameStatusEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/game/BaseballGameStatusEntity.java
@@ -75,7 +75,7 @@ public class BaseballGameStatusEntity extends ModificationTimestampEntity {
 			gameStatus == null ? GameStatus.SCHEDULED : gameStatus,
 			homeTeamScore == null ? 0 : homeTeamScore,
 			awayTeamScore == null ? 0 : awayTeamScore,
-			gameResult
+			gameResult == null ? GameResult.PENDING : gameResult
 		);
 	}
 

--- a/core/src/main/java/com/goti/domain/entity/game/BaseballGameStatusEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/game/BaseballGameStatusEntity.java
@@ -64,39 +64,23 @@ public class BaseballGameStatusEntity extends ModificationTimestampEntity {
 		GameResult gameResult
 	) {
 
-		validate(
-			gameStatus,
-			homeTeamScore,
-			awayTeamScore
-		);
+		validate(gameStatus);
 
 		return new BaseballGameStatusEntity(
 			baseballGameId,
 			gameStatus == null ? GameStatus.SCHEDULED : gameStatus,
-			homeTeamScore == null ? 0 : homeTeamScore,
-			awayTeamScore == null ? 0 : awayTeamScore,
+			0,
+			0,
 			gameResult == null ? GameResult.PENDING : gameResult
 		);
 	}
 
 	private static void validate(
-		GameStatus gameStatus,
-		Integer homeTeamScore,
-		Integer awayTeamScore
+		GameStatus gameStatus
 	) {
 		Preconditions.domainValidate(
 			gameStatus != null,
 			"경기 상태는 필수입니다."
-		);
-
-		Preconditions.domainValidate(
-			homeTeamScore != null && homeTeamScore >= 0,
-			"홈팀 점수는 0 이상이어야 합니다."
-		);
-
-		Preconditions.domainValidate(
-			awayTeamScore != null && awayTeamScore >= 0,
-			"원정팀 점수는 0 이상이어야 합니다."
 		);
 	}
 }

--- a/core/src/main/java/com/goti/domain/entity/game/BaseballGameStatusEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/game/BaseballGameStatusEntity.java
@@ -1,0 +1,108 @@
+package com.goti.domain.entity.game;
+
+import com.goti.constants.GameResult;
+import com.goti.constants.GameStatus;
+import com.goti.domain.base.ModificationTimestampEntity;
+
+import com.goti.global.validation.Preconditions;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+import static lombok.AccessLevel.*;
+
+@Getter
+@Entity
+@Table(name = "baseball_game_statuses")
+@NoArgsConstructor(access = PROTECTED)
+public class BaseballGameStatusEntity extends ModificationTimestampEntity {
+
+	@Column(name = "baseball_games_id", nullable = false)
+	private UUID baseballGameId;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "game_status", nullable = false, length = 50)
+	private GameStatus gameStatus;
+
+	@Column(name = "home_team_score", nullable = false)
+	private Integer homeTeamScore;
+
+	@Column(name = "away_team_score", nullable = false)
+	private Integer awayTeamScore;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "game_result", length = 50)
+	private GameResult gameResult;
+
+	private BaseballGameStatusEntity(
+		UUID baseballGameId,
+		GameStatus gameStatus,
+		Integer homeTeamScore,
+		Integer awayTeamScore,
+		GameResult gameResult
+	) {
+		this.baseballGameId = baseballGameId;
+		this.gameStatus = gameStatus;
+		this.homeTeamScore = homeTeamScore;
+		this.awayTeamScore = awayTeamScore;
+		this.gameResult = gameResult;
+	}
+
+	public static BaseballGameStatusEntity create(
+		UUID baseballGameId,
+		GameStatus gameStatus,
+		Integer homeTeamScore,
+		Integer awayTeamScore,
+		GameResult gameResult
+	) {
+
+		validate(
+			baseballGameId,
+			gameStatus,
+			homeTeamScore,
+			awayTeamScore
+		);
+
+		return new BaseballGameStatusEntity(
+			baseballGameId,
+			gameStatus == null ? GameStatus.SCHEDULED : gameStatus,
+			homeTeamScore == null ? 0 : homeTeamScore,
+			awayTeamScore == null ? 0 : awayTeamScore,
+			gameResult
+		);
+	}
+
+	private static void validate(
+		UUID baseballGameId,
+		GameStatus gameStatus,
+		Integer homeTeamScore,
+		Integer awayTeamScore
+	) {
+
+		Preconditions.domainValidate(
+			baseballGameId != null,
+			"경기 ID는 필수입니다."
+		);
+		Preconditions.domainValidate(
+			gameStatus != null,
+			"경기 상태는 필수입니다."
+		);
+
+		Preconditions.domainValidate(
+			homeTeamScore != null && homeTeamScore >= 0,
+			"홈팀 점수는 0 이상이어야 합니다."
+		);
+
+		Preconditions.domainValidate(
+			awayTeamScore != null && awayTeamScore >= 0,
+			"원정팀 점수는 0 이상이어야 합니다."
+		);
+	}
+}

--- a/core/src/main/java/com/goti/domain/entity/team/BaseballTeamEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/team/BaseballTeamEntity.java
@@ -1,4 +1,4 @@
-package com.goti.domain.entity.baseball;
+package com.goti.domain.entity.team;
 
 import static lombok.AccessLevel.*;
 

--- a/core/src/main/java/com/goti/domain/entity/team/BaseballWinnerHistoryEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/team/BaseballWinnerHistoryEntity.java
@@ -1,4 +1,4 @@
-package com.goti.domain.entity.baseball;
+package com.goti.domain.entity.team;
 
 import static lombok.AccessLevel.*;
 

--- a/core/src/test/java/game/BaseballGameEntityTest.java
+++ b/core/src/test/java/game/BaseballGameEntityTest.java
@@ -1,0 +1,266 @@
+package game;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.goti.constants.GameStatus;
+import com.goti.constants.LeagueType;
+import com.goti.constants.ReservationAvailableStatus;
+import com.goti.domain.entity.game.BaseballGameEntity;
+import com.goti.exception.FieldValidationException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@ActiveProfiles("test")
+public class BaseballGameEntityTest {
+
+	UUID homeTeamId;
+	UUID awayTeamId;
+	UUID stadiumId;
+	LocalDate playDate;
+	LocalTime startAt;
+	LocalDateTime reservationOpenedAt;
+	LocalDateTime reservationClosedAt;
+
+	@BeforeEach
+	void setup() {
+		homeTeamId = UUID.randomUUID();
+		awayTeamId = UUID.randomUUID();
+		stadiumId = UUID.randomUUID();
+		playDate = LocalDate.of(2026, 4, 1);
+		startAt = LocalTime.of(18, 30);
+		reservationOpenedAt = LocalDateTime.of(2026, 3, 25, 14, 0);
+		reservationClosedAt = LocalDateTime.of(2026, 4, 1, 17, 0);
+	}
+
+	@Test
+	void 경기_생성_성공() {
+		BaseballGameEntity game = BaseballGameEntity.create(
+			homeTeamId,
+			awayTeamId,
+			stadiumId,
+			playDate,
+			startAt,
+			GameStatus.SCHEDULED,
+			LeagueType.REGULAR,
+			ReservationAvailableStatus.ON_SALE,
+			reservationOpenedAt,
+			reservationClosedAt
+		);
+
+		assertNotNull(game);
+		assertThat(game.getHomeTeamId()).isEqualTo(homeTeamId);
+		assertThat(game.getAwayTeamId()).isEqualTo(awayTeamId);
+		assertThat(game.getStadiumId()).isEqualTo(stadiumId);
+		assertThat(game.getPlayDate()).isEqualTo(playDate);
+		assertThat(game.getStartAt()).isEqualTo(startAt);
+		assertThat(game.getLeagueType()).isEqualTo(LeagueType.REGULAR);
+		assertThat(game.getReservationAvailableStatus()).isEqualTo(ReservationAvailableStatus.ON_SALE);
+
+		log.info("game playDate: {}", game.getPlayDate());
+		log.info("reservation status: {}", game.getReservationAvailableStatus());
+	}
+
+	@Test
+	void 경기_생성_성공_리그타입_예매상태_기본값_적용() {
+		BaseballGameEntity game = BaseballGameEntity.create(
+			homeTeamId,
+			awayTeamId,
+			stadiumId,
+			playDate,
+			startAt,
+			GameStatus.SCHEDULED,
+			null,
+			null,
+			reservationOpenedAt,
+			reservationClosedAt
+		);
+
+		assertThat(game.getLeagueType()).isEqualTo(LeagueType.REGULAR);
+		assertThat(game.getReservationAvailableStatus()).isEqualTo(ReservationAvailableStatus.PENDING);
+	}
+
+	@Test
+	void 경기_생성_실패_홈팀_ID_null() {
+		assertThatThrownBy(
+			() -> BaseballGameEntity.create(
+				null,
+				awayTeamId,
+				stadiumId,
+				playDate,
+				startAt,
+				GameStatus.SCHEDULED,
+				LeagueType.REGULAR,
+				ReservationAvailableStatus.ON_SALE,
+				reservationOpenedAt,
+				reservationClosedAt
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("홈팀 ID는 필수입니다.");
+	}
+
+	@Test
+	void 경기_생성_실패_원정팀_ID_null() {
+		assertThatThrownBy(
+			() -> BaseballGameEntity.create(
+				homeTeamId,
+				null,
+				stadiumId,
+				playDate,
+				startAt,
+				GameStatus.SCHEDULED,
+				LeagueType.REGULAR,
+				ReservationAvailableStatus.ON_SALE,
+				reservationOpenedAt,
+				reservationClosedAt
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("원정팀 ID는 필수입니다.");
+	}
+
+	@Test
+	void 경기_생성_실패_구장_ID_null() {
+		assertThatThrownBy(
+			() -> BaseballGameEntity.create(
+				homeTeamId,
+				awayTeamId,
+				null,
+				playDate,
+				startAt,
+				GameStatus.SCHEDULED,
+				LeagueType.REGULAR,
+				ReservationAvailableStatus.ON_SALE,
+				reservationOpenedAt,
+				reservationClosedAt
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("구장 ID는 필수입니다.");
+	}
+
+	@Test
+	void 경기_생성_실패_홈팀_원정팀_동일() {
+		assertThatThrownBy(
+			() -> BaseballGameEntity.create(
+				homeTeamId,
+				homeTeamId,
+				stadiumId,
+				playDate,
+				startAt,
+				GameStatus.SCHEDULED,
+				LeagueType.REGULAR,
+				ReservationAvailableStatus.ON_SALE,
+				reservationOpenedAt,
+				reservationClosedAt
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("홈팀과 원정팀은 같을 수 없습니다.");
+	}
+
+	@Test
+	void 경기_생성_실패_경기날짜_null() {
+		assertThatThrownBy(
+			() -> BaseballGameEntity.create(
+				homeTeamId,
+				awayTeamId,
+				stadiumId,
+				null,
+				startAt,
+				GameStatus.SCHEDULED,
+				LeagueType.REGULAR,
+				ReservationAvailableStatus.ON_SALE,
+				reservationOpenedAt,
+				reservationClosedAt
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("경기 날짜는 필수입니다.");
+	}
+
+	@Test
+	void 경기_생성_실패_시작시간_null() {
+		assertThatThrownBy(
+			() -> BaseballGameEntity.create(
+				homeTeamId,
+				awayTeamId,
+				stadiumId,
+				playDate,
+				null,
+				GameStatus.SCHEDULED,
+				LeagueType.REGULAR,
+				ReservationAvailableStatus.ON_SALE,
+				reservationOpenedAt,
+				reservationClosedAt
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("경기 시작 시간은 필수입니다.");
+	}
+
+	@Test
+	void 경기_생성_실패_예매오픈일시_null() {
+		assertThatThrownBy(
+			() -> BaseballGameEntity.create(
+				homeTeamId,
+				awayTeamId,
+				stadiumId,
+				playDate,
+				startAt,
+				GameStatus.SCHEDULED,
+				LeagueType.REGULAR,
+				ReservationAvailableStatus.ON_SALE,
+				null,
+				reservationClosedAt
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("예매 오픈 일시는 필수입니다.");
+	}
+
+	@Test
+	void 경기_생성_실패_예매종료일시_null() {
+		assertThatThrownBy(
+			() -> BaseballGameEntity.create(
+				homeTeamId,
+				awayTeamId,
+				stadiumId,
+				playDate,
+				startAt,
+				GameStatus.SCHEDULED,
+				LeagueType.REGULAR,
+				ReservationAvailableStatus.ON_SALE,
+				reservationOpenedAt,
+				null
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("예매 종료 일시는 필수입니다.");
+	}
+
+	@Test
+	void 경기_생성_실패_예매오픈이_종료보다_늦음() {
+		LocalDateTime invalidOpen = LocalDateTime.of(2026, 4, 1, 18, 0);
+		LocalDateTime invalidClose = LocalDateTime.of(2026, 4, 1, 17, 0);
+
+		assertThatThrownBy(
+			() -> BaseballGameEntity.create(
+				homeTeamId,
+				awayTeamId,
+				stadiumId,
+				playDate,
+				startAt,
+				GameStatus.SCHEDULED,
+				LeagueType.REGULAR,
+				ReservationAvailableStatus.ON_SALE,
+				invalidOpen,
+				invalidClose
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("예매 오픈 일시는 종료 일시보다 늦을 수 없습니다.");
+	}
+}

--- a/core/src/test/java/game/BaseballGameStatusEntityTest.java
+++ b/core/src/test/java/game/BaseballGameStatusEntityTest.java
@@ -1,0 +1,94 @@
+package game;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.goti.constants.GameResult;
+import com.goti.constants.GameStatus;
+import com.goti.constants.LeagueType;
+import com.goti.constants.ReservationAvailableStatus;
+import com.goti.domain.entity.game.BaseballGameEntity;
+import com.goti.domain.entity.game.BaseballGameStatusEntity;
+import com.goti.exception.FieldValidationException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@ActiveProfiles("test")
+public class BaseballGameStatusEntityTest {
+
+	BaseballGameEntity baseballGame;
+
+	@BeforeEach
+	void setup() {
+		baseballGame = BaseballGameEntity.create(
+			UUID.randomUUID(),
+			UUID.randomUUID(),
+			UUID.randomUUID(),
+			LocalDate.of(2026, 4, 1),
+			LocalTime.of(18, 30),
+			GameStatus.SCHEDULED,
+			LeagueType.REGULAR,
+			ReservationAvailableStatus.PENDING,
+			LocalDateTime.of(2026, 3, 25, 14, 0),
+			LocalDateTime.of(2026, 4, 1, 17, 0)
+		);
+	}
+
+	@Test
+	void 경기상태_생성_성공() {
+		BaseballGameStatusEntity gameStatus = BaseballGameStatusEntity.create(
+			baseballGame,
+			GameStatus.IN_PROGRESS,
+			3,
+			1,
+			GameResult.PENDING
+		);
+
+		assertNotNull(gameStatus);
+		assertThat(gameStatus.getBaseballGameId()).isEqualTo(baseballGame);
+		assertThat(gameStatus.getGameStatus()).isEqualTo(GameStatus.IN_PROGRESS);
+		assertThat(gameStatus.getHomeTeamScore()).isEqualTo(0);
+		assertThat(gameStatus.getAwayTeamScore()).isEqualTo(0);
+		assertThat(gameStatus.getGameResult()).isEqualTo(GameResult.PENDING);
+
+		log.info("gameStatus : {}", gameStatus.getGameStatus());
+		log.info("score : {}:{}", gameStatus.getHomeTeamScore(), gameStatus.getAwayTeamScore());
+	}
+
+	@Test
+	void 경기상태_생성_성공_결과_기본값_적용() {
+		BaseballGameStatusEntity gameStatus = BaseballGameStatusEntity.create(
+			baseballGame,
+			GameStatus.SCHEDULED,
+			0,
+			0,
+			null
+		);
+
+		assertThat(gameStatus.getGameResult()).isEqualTo(GameResult.PENDING);
+	}
+
+	@Test
+	void 경기상태_생성_실패_경기상태_null() {
+		assertThatThrownBy(
+			() -> BaseballGameStatusEntity.create(
+				baseballGame,
+				null,
+				0,
+				0,
+				GameResult.PENDING
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("경기 상태는 필수입니다.");
+	}
+}


### PR DESCRIPTION
<!-- 제목 예시: feat: 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
#34 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
경기 및 경기 상태 도메인 엔티티 구현
<br/>


## 📋 작업 내용
> BaseballGame 엔티티 구현
> BaseballGameStatus 엔티티 구현
> 경기 상태 및 결과 Enum 정의.

>  테스트코드 작성


 > BaseballGames와 BaseballGameStatuses에 game_status 가 중복으로 있어서 BaseballGameStatuses의 game_status를 기준으로 작성했습니다.

<br/>