### PR TITLE
[BUG] OTel SDK 버전 충돌 수정 및 postgres healthcheck 환경변수 오류 수정

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,9 +1,17 @@
+// OpenTelemetry BOM을 Spring Boot보다 먼저 선언하여 SDK 버전 오버라이드
+// Spring Boot 3.5.x는 OTel SDK 1.49.0을 관리하지만, instrumentation 2.25.0은 SDK 1.59.0 필요
+dependencyManagement {
+    imports {
+        mavenBom 'io.opentelemetry:opentelemetry-bom:1.59.0'
+        mavenBom 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:2.25.0'
+    }
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     // OpenTelemetry (metrics + traces + logs 자동 설정)
-    implementation platform('io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:2.25.0')
     implementation 'io.opentelemetry.instrumentation:opentelemetry-spring-boot-starter'
 
     implementation(project(":common"))

--- a/docker/docker-compose.deploy.yml
+++ b/docker/docker-compose.deploy.yml
@@ -41,7 +41,7 @@ services:
       POSTGRES_USER: ${DATASOURCE_USERNAME}
       POSTGRES_PASSWORD: ${DATASOURCE_PASSWORD}
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U $${DATASOURCE_USERNAME}"]
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER}"]
       interval: 5s
       timeout: 3s
       retries: 5


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #50 
<br/>

## 🔎 개요
Spring Boot BOM의 OTel SDK 버전 다운그레이드로 인한 런타임 에러와 postgres healthcheck 환경변수 참조 오류를 수정

<br/>


## 📋 작업 내용
1. **api/build.gradle**: `dependencyManagement` 블록에 OTel BOM(1.59.0) + instrumentation BOM(2.25.0)을 Spring Boot BOM보다 먼저 선언하여 버전 오버라이드
2. **docker-compose.deploy.yml**: postgres healthcheck에서 `$${DATASOURCE_USERNAME}` → `$${POSTGRES_USER}`로 수정 (postgres 컨테이너 내부에는 `POSTGRES_USER`만 존재)


<br/>