### PR TITLE
[BUG] 로컬 환경 OpenTelemetry ConnectException 수정 (#57)

### DIFF
--- a/api/src/main/resources/application-prod.yml
+++ b/api/src/main/resources/application-prod.yml
@@ -20,3 +20,11 @@ management:
   tracing:
     sampling:
       probability: 0.1
+
+otel:
+  exporter:
+    otlp:
+      enabled: true
+      endpoint: http://otel-collector.monitoring:4318
+  sdk:
+    disabled: false

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -53,6 +53,13 @@ management:
     sampling:
       probability: 1.0  # dev 전수 — EKS에서는 SPRING_PROFILES_ACTIVE=prod → 0.1
 
+otel:
+  exporter:
+    otlp:
+      enabled: false
+  sdk:
+    disabled: true
+
 logging:
   pattern:
     level: "%5p [${spring.application.name:},%X{trace_id:-},%X{span_id:-}]"


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #57

<br/>

## 🔎 개요
로컬 개발 환경에서 OTel Collector 미실행 시 `ConnectException: Failed to connect to localhost:4318` 발생하는 문제 수정

<br/>


## 📋 작업 내용
- `application.yml`: OTel SDK 기본 비활성화 (`otel.sdk.disabled: true`)
- `application-prod.yml`: EKS 환경에서 OTel exporter 활성화 + Collector endpoint 설정

### 변경 파일
- `api/src/main/resources/application.yml`
- `api/src/main/resources/application-prod.yml`

<br/>