### PR TITLE
[FEAT] 야구 경기 생성 로직 구현

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -15,8 +15,6 @@ dependencies {
     // OpenTelemetry (metrics + traces + logs 자동 설정)
     implementation 'io.opentelemetry.instrumentation:opentelemetry-spring-boot-starter'
 
-    runtimeOnly 'org.postgresql:postgresql'
-
     implementation(project(":common"))
     implementation(project(":core"))
     implementation(project(":integration"))

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -10,9 +10,12 @@ dependencyManagement {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     // OpenTelemetry (metrics + traces + logs 자동 설정)
     implementation 'io.opentelemetry.instrumentation:opentelemetry-spring-boot-starter'
+
+    runtimeOnly 'org.postgresql:postgresql'
 
     implementation(project(":common"))
     implementation(project(":core"))

--- a/api/src/main/java/com/goti/GotiApplication.java
+++ b/api/src/main/java/com/goti/GotiApplication.java
@@ -3,9 +3,11 @@ package com.goti;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @ConfigurationPropertiesScan
 @SpringBootApplication
+@EnableJpaAuditing
 public class GotiApplication {
 
 	public static void main(String[] args) {

--- a/common/src/main/java/com/goti/constants/messages/ErrorCode.java
+++ b/common/src/main/java/com/goti/constants/messages/ErrorCode.java
@@ -25,6 +25,9 @@ public enum ErrorCode {
 	AUTH_INVALID(HttpStatus.UNAUTHORIZED, "올바르지 않은 인증 정보입니다."),
 	AUTH_ACCESS_EXPIRED(HttpStatus.UNAUTHORIZED, "엑세스 토큰이 만료되었습니다."),
 	AUTH_REGISTRATION_EXPIRED(HttpStatus.GONE, "회원가입 유효 시간이 만료되었습니다. 다시 소셜 로그인을 진행해주세요."),
+
+	GAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 동일한 경기 일정이 존재합니다."),
+
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생하였습니다. 잠시 후 다시 시도해주세요.")
 	;
 

--- a/core/src/main/java/com/goti/domain/entity/game/BaseballGameEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/game/BaseballGameEntity.java
@@ -1,6 +1,5 @@
 package com.goti.domain.entity.game;
 
-import com.goti.constants.GameStatus;
 import com.goti.constants.LeagueType;
 import com.goti.constants.ReservationAvailableStatus;
 import com.goti.domain.base.ModificationTimestampEntity;
@@ -63,7 +62,6 @@ public class BaseballGameEntity extends ModificationTimestampEntity {
 		LocalDate playDate,
 		LocalTime startAt,
 		LeagueType leagueType,
-		ReservationAvailableStatus reservationAvailableStatus,
 		LocalDateTime reservationOpenedAt,
 		LocalDateTime reservationClosedAt
 	) {
@@ -73,7 +71,7 @@ public class BaseballGameEntity extends ModificationTimestampEntity {
 		this.playDate = playDate;
 		this.startAt = startAt;
 		this.leagueType = leagueType;
-		this.reservationAvailableStatus = reservationAvailableStatus;
+		this.reservationAvailableStatus = ReservationAvailableStatus.PENDING;
 		this.reservationOpenedAt = reservationOpenedAt;
 		this.reservationClosedAt = reservationClosedAt;
 	}
@@ -84,9 +82,7 @@ public class BaseballGameEntity extends ModificationTimestampEntity {
 		UUID stadiumId,
 		LocalDate playDate,
 		LocalTime startAt,
-		GameStatus gameStatus,
 		LeagueType leagueType,
-		ReservationAvailableStatus reservationAvailableStatus,
 		LocalDateTime reservationOpenedAt,
 		LocalDateTime reservationClosedAt
 	) {
@@ -104,7 +100,6 @@ public class BaseballGameEntity extends ModificationTimestampEntity {
 			playDate,
 			startAt,
 			leagueType == null ? LeagueType.REGULAR : leagueType,
-			reservationAvailableStatus == null ? ReservationAvailableStatus.PENDING : reservationAvailableStatus,
 			reservationOpenedAt,
 			reservationClosedAt
 		);

--- a/core/src/main/java/com/goti/domain/entity/game/BaseballGameEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/game/BaseballGameEntity.java
@@ -61,7 +61,6 @@ public class BaseballGameEntity extends ModificationTimestampEntity {
 		UUID stadiumId,
 		LocalDate playDate,
 		LocalTime startAt,
-		LeagueType leagueType,
 		LocalDateTime reservationOpenedAt,
 		LocalDateTime reservationClosedAt
 	) {
@@ -70,7 +69,7 @@ public class BaseballGameEntity extends ModificationTimestampEntity {
 		this.stadiumId = stadiumId;
 		this.playDate = playDate;
 		this.startAt = startAt;
-		this.leagueType = leagueType;
+		this.leagueType = LeagueType.REGULAR;
 		this.reservationAvailableStatus = ReservationAvailableStatus.PENDING;
 		this.reservationOpenedAt = reservationOpenedAt;
 		this.reservationClosedAt = reservationClosedAt;
@@ -82,7 +81,6 @@ public class BaseballGameEntity extends ModificationTimestampEntity {
 		UUID stadiumId,
 		LocalDate playDate,
 		LocalTime startAt,
-		LeagueType leagueType,
 		LocalDateTime reservationOpenedAt,
 		LocalDateTime reservationClosedAt
 	) {
@@ -99,7 +97,6 @@ public class BaseballGameEntity extends ModificationTimestampEntity {
 			stadiumId,
 			playDate,
 			startAt,
-			leagueType == null ? LeagueType.REGULAR : leagueType,
 			reservationOpenedAt,
 			reservationClosedAt
 		);

--- a/core/src/main/java/com/goti/domain/entity/game/BaseballGameStatusEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/game/BaseballGameStatusEntity.java
@@ -56,31 +56,7 @@ public class BaseballGameStatusEntity extends ModificationTimestampEntity {
 		this.gameResult = gameResult;
 	}
 
-	public static BaseballGameStatusEntity create(
-		BaseballGameEntity baseballGameId,
-		GameStatus gameStatus,
-		Integer homeTeamScore,
-		Integer awayTeamScore,
-		GameResult gameResult
-	) {
-
-		validate(gameStatus);
-
-		return new BaseballGameStatusEntity(
-			baseballGameId,
-			gameStatus == null ? GameStatus.SCHEDULED : gameStatus,
-			0,
-			0,
-			gameResult == null ? GameResult.PENDING : gameResult
-		);
-	}
-
-	private static void validate(
-		GameStatus gameStatus
-	) {
-		Preconditions.domainValidate(
-			gameStatus != null,
-			"경기 상태는 필수입니다."
-		);
+	public static BaseballGameStatusEntity init(BaseballGameEntity game) {
+		return new BaseballGameStatusEntity(game, GameStatus.SCHEDULED, 0, 0, GameResult.PENDING);
 	}
 }

--- a/core/src/main/java/com/goti/domain/entity/game/BaseballGameStatusEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/game/BaseballGameStatusEntity.java
@@ -26,7 +26,7 @@ public class BaseballGameStatusEntity extends ModificationTimestampEntity {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "baseball_game_id", nullable = false)
-	private BaseballGameEntity baseballGameId;
+	private BaseballGameEntity baseballGame;
 
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
@@ -45,18 +45,18 @@ public class BaseballGameStatusEntity extends ModificationTimestampEntity {
 	private BaseballGameStatusEntity(
 		BaseballGameEntity baseballGameId,
 		GameStatus gameStatus,
-		Integer homeTeamScore,
-		Integer awayTeamScore,
 		GameResult gameResult
 	) {
-		this.baseballGameId = baseballGameId;
+		this.baseballGame = baseballGameId;
 		this.gameStatus = gameStatus;
-		this.homeTeamScore = homeTeamScore;
-		this.awayTeamScore = awayTeamScore;
+		this.homeTeamScore = 0;
+		this.awayTeamScore = 0;
 		this.gameResult = gameResult;
 	}
 
+	// TODO: 추후 점수 변경 시 메서드로 변경
+
 	public static BaseballGameStatusEntity init(BaseballGameEntity game) {
-		return new BaseballGameStatusEntity(game, GameStatus.SCHEDULED, 0, 0, GameResult.PENDING);
+		return new BaseballGameStatusEntity(game, GameStatus.SCHEDULED, GameResult.PENDING);
 	}
 }

--- a/core/src/test/java/game/BaseballGameEntityTest.java
+++ b/core/src/test/java/game/BaseballGameEntityTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
 
-import com.goti.constants.GameStatus;
 import com.goti.constants.LeagueType;
 import com.goti.constants.ReservationAvailableStatus;
 import com.goti.domain.entity.game.BaseballGameEntity;
@@ -51,9 +50,6 @@ public class BaseballGameEntityTest {
 			stadiumId,
 			playDate,
 			startAt,
-			GameStatus.SCHEDULED,
-			LeagueType.REGULAR,
-			ReservationAvailableStatus.ON_SALE,
 			reservationOpenedAt,
 			reservationClosedAt
 		);
@@ -65,23 +61,20 @@ public class BaseballGameEntityTest {
 		assertThat(game.getPlayDate()).isEqualTo(playDate);
 		assertThat(game.getStartAt()).isEqualTo(startAt);
 		assertThat(game.getLeagueType()).isEqualTo(LeagueType.REGULAR);
-		assertThat(game.getReservationAvailableStatus()).isEqualTo(ReservationAvailableStatus.ON_SALE);
+		assertThat(game.getReservationAvailableStatus()).isEqualTo(ReservationAvailableStatus.PENDING);
 
 		log.info("game playDate: {}", game.getPlayDate());
 		log.info("reservation status: {}", game.getReservationAvailableStatus());
 	}
 
 	@Test
-	void 경기_생성_성공_리그타입_예매상태_기본값_적용() {
+	void 경기_생성_성공_리그타입_기본값_적용() {
 		BaseballGameEntity game = BaseballGameEntity.create(
 			homeTeamId,
 			awayTeamId,
 			stadiumId,
 			playDate,
 			startAt,
-			GameStatus.SCHEDULED,
-			null,
-			null,
 			reservationOpenedAt,
 			reservationClosedAt
 		);
@@ -99,9 +92,6 @@ public class BaseballGameEntityTest {
 				stadiumId,
 				playDate,
 				startAt,
-				GameStatus.SCHEDULED,
-				LeagueType.REGULAR,
-				ReservationAvailableStatus.ON_SALE,
 				reservationOpenedAt,
 				reservationClosedAt
 			)
@@ -118,9 +108,6 @@ public class BaseballGameEntityTest {
 				stadiumId,
 				playDate,
 				startAt,
-				GameStatus.SCHEDULED,
-				LeagueType.REGULAR,
-				ReservationAvailableStatus.ON_SALE,
 				reservationOpenedAt,
 				reservationClosedAt
 			)
@@ -137,9 +124,6 @@ public class BaseballGameEntityTest {
 				null,
 				playDate,
 				startAt,
-				GameStatus.SCHEDULED,
-				LeagueType.REGULAR,
-				ReservationAvailableStatus.ON_SALE,
 				reservationOpenedAt,
 				reservationClosedAt
 			)
@@ -156,9 +140,6 @@ public class BaseballGameEntityTest {
 				stadiumId,
 				playDate,
 				startAt,
-				GameStatus.SCHEDULED,
-				LeagueType.REGULAR,
-				ReservationAvailableStatus.ON_SALE,
 				reservationOpenedAt,
 				reservationClosedAt
 			)
@@ -175,9 +156,6 @@ public class BaseballGameEntityTest {
 				stadiumId,
 				null,
 				startAt,
-				GameStatus.SCHEDULED,
-				LeagueType.REGULAR,
-				ReservationAvailableStatus.ON_SALE,
 				reservationOpenedAt,
 				reservationClosedAt
 			)
@@ -194,9 +172,6 @@ public class BaseballGameEntityTest {
 				stadiumId,
 				playDate,
 				null,
-				GameStatus.SCHEDULED,
-				LeagueType.REGULAR,
-				ReservationAvailableStatus.ON_SALE,
 				reservationOpenedAt,
 				reservationClosedAt
 			)
@@ -213,9 +188,6 @@ public class BaseballGameEntityTest {
 				stadiumId,
 				playDate,
 				startAt,
-				GameStatus.SCHEDULED,
-				LeagueType.REGULAR,
-				ReservationAvailableStatus.ON_SALE,
 				null,
 				reservationClosedAt
 			)
@@ -232,9 +204,6 @@ public class BaseballGameEntityTest {
 				stadiumId,
 				playDate,
 				startAt,
-				GameStatus.SCHEDULED,
-				LeagueType.REGULAR,
-				ReservationAvailableStatus.ON_SALE,
 				reservationOpenedAt,
 				null
 			)
@@ -254,9 +223,6 @@ public class BaseballGameEntityTest {
 				stadiumId,
 				playDate,
 				startAt,
-				GameStatus.SCHEDULED,
-				LeagueType.REGULAR,
-				ReservationAvailableStatus.ON_SALE,
 				invalidOpen,
 				invalidClose
 			)

--- a/core/src/test/java/game/BaseballGameStatusEntityTest.java
+++ b/core/src/test/java/game/BaseballGameStatusEntityTest.java
@@ -14,11 +14,8 @@ import org.springframework.test.context.ActiveProfiles;
 
 import com.goti.constants.GameResult;
 import com.goti.constants.GameStatus;
-import com.goti.constants.LeagueType;
-import com.goti.constants.ReservationAvailableStatus;
 import com.goti.domain.entity.game.BaseballGameEntity;
 import com.goti.domain.entity.game.BaseballGameStatusEntity;
-import com.goti.exception.FieldValidationException;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -36,27 +33,18 @@ public class BaseballGameStatusEntityTest {
 			UUID.randomUUID(),
 			LocalDate.of(2026, 4, 1),
 			LocalTime.of(18, 30),
-			GameStatus.SCHEDULED,
-			LeagueType.REGULAR,
-			ReservationAvailableStatus.PENDING,
 			LocalDateTime.of(2026, 3, 25, 14, 0),
 			LocalDateTime.of(2026, 4, 1, 17, 0)
 		);
 	}
 
 	@Test
-	void 경기상태_생성_성공() {
-		BaseballGameStatusEntity gameStatus = BaseballGameStatusEntity.create(
-			baseballGame,
-			GameStatus.IN_PROGRESS,
-			3,
-			1,
-			GameResult.PENDING
-		);
+	void 경기상태_init_성공() {
+		BaseballGameStatusEntity gameStatus = BaseballGameStatusEntity.init(baseballGame);
 
 		assertNotNull(gameStatus);
-		assertThat(gameStatus.getBaseballGameId()).isEqualTo(baseballGame);
-		assertThat(gameStatus.getGameStatus()).isEqualTo(GameStatus.IN_PROGRESS);
+		assertThat(gameStatus.getBaseballGame()).isEqualTo(baseballGame);
+		assertThat(gameStatus.getGameStatus()).isEqualTo(GameStatus.SCHEDULED);
 		assertThat(gameStatus.getHomeTeamScore()).isEqualTo(0);
 		assertThat(gameStatus.getAwayTeamScore()).isEqualTo(0);
 		assertThat(gameStatus.getGameResult()).isEqualTo(GameResult.PENDING);
@@ -66,29 +54,12 @@ public class BaseballGameStatusEntityTest {
 	}
 
 	@Test
-	void 경기상태_생성_성공_결과_기본값_적용() {
-		BaseballGameStatusEntity gameStatus = BaseballGameStatusEntity.create(
-			baseballGame,
-			GameStatus.SCHEDULED,
-			0,
-			0,
-			null
-		);
+	void 경기상태_init_기본값_적용() {
+		BaseballGameStatusEntity gameStatus = BaseballGameStatusEntity.init(baseballGame);
 
+		assertThat(gameStatus.getGameStatus()).isEqualTo(GameStatus.SCHEDULED);
 		assertThat(gameStatus.getGameResult()).isEqualTo(GameResult.PENDING);
-	}
-
-	@Test
-	void 경기상태_생성_실패_경기상태_null() {
-		assertThatThrownBy(
-			() -> BaseballGameStatusEntity.create(
-				baseballGame,
-				null,
-				0,
-				0,
-				GameResult.PENDING
-			)
-		).isInstanceOf(FieldValidationException.class)
-			.hasMessageContaining("경기 상태는 필수입니다.");
+		assertThat(gameStatus.getHomeTeamScore()).isEqualTo(0);
+		assertThat(gameStatus.getAwayTeamScore()).isEqualTo(0);
 	}
 }

--- a/ticketing/build.gradle
+++ b/ticketing/build.gradle
@@ -3,6 +3,8 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
 

--- a/ticketing/src/main/java/com/goti/game/controller/BaseballGameController.java
+++ b/ticketing/src/main/java/com/goti/game/controller/BaseballGameController.java
@@ -15,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.goti.global.api.ApiSuccessResponse.*;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/games/baseball")
@@ -26,6 +28,6 @@ public class BaseballGameController {
 		@Valid @RequestBody CreateGameRequest request
 	) {
 		GameResponse response = baseballGameApplicationService.create(request.toCommand());
-		return ApiSuccessResponse.wrap(response);
+		return wrap(response);
 	}
 }

--- a/ticketing/src/main/java/com/goti/game/controller/BaseballGameController.java
+++ b/ticketing/src/main/java/com/goti/game/controller/BaseballGameController.java
@@ -1,0 +1,31 @@
+package com.goti.game.controller;
+
+import com.goti.game.dto.request.CreateGameRequest;
+import com.goti.game.dto.response.GameResponse;
+import com.goti.game.service.BaseballGameApplicationService;
+import com.goti.global.api.ApiSuccessResponse;
+
+import jakarta.validation.Valid;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/games/baseball")
+public class BaseballGameController {
+	private final BaseballGameApplicationService baseballGameApplicationService;
+
+	@PostMapping
+	public ResponseEntity<ApiSuccessResponse<GameResponse>> create(
+		@Valid @RequestBody CreateGameRequest request
+	) {
+		GameResponse response = baseballGameApplicationService.create(request.toCommand());
+		return ApiSuccessResponse.wrap(response);
+	}
+}

--- a/ticketing/src/main/java/com/goti/game/dto/request/CreateGameRequest.java
+++ b/ticketing/src/main/java/com/goti/game/dto/request/CreateGameRequest.java
@@ -1,0 +1,58 @@
+package com.goti.game.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.goti.constants.GameStatus;
+import com.goti.constants.LeagueType;
+import com.goti.constants.ReservationAvailableStatus;
+import com.goti.game.service.command.CreateGameCommand;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.UUID;
+
+public record CreateGameRequest(
+	@NotNull(message = "홈팀 ID는 필수입니다.")
+	UUID homeTeamId,
+
+	@NotNull(message = "원정팀 ID는 필수입니다.")
+	UUID awayTeamId,
+
+	@NotNull(message = "구장 ID는 필수입니다.")
+	UUID stadiumId,
+
+	@NotNull(message = "경기 날짜는 필수입니다.")
+	@JsonFormat(pattern = "yyyy-MM-dd")
+	LocalDate playDate,
+
+	@NotNull(message = "경기 시작 시간은 필수입니다.")
+	@JsonFormat(pattern = "HH:mm:ss")
+	LocalTime startAt,
+
+	@NotNull(message = "리그 종류는 필수입니다.")
+	LeagueType leagueType,
+
+	@NotNull(message = "예매 오픈 일시는 필수입니다.")
+	@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+	LocalDateTime reservationOpenedAt,
+
+	@NotNull(message = "예매 종료 일시는 필수입니다.")
+	@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+	LocalDateTime reservationClosedAt
+
+) {
+	public CreateGameCommand toCommand() {
+		return new CreateGameCommand(
+			homeTeamId,
+			awayTeamId,
+			stadiumId,
+			playDate,
+			startAt,
+			leagueType,
+			reservationOpenedAt,
+			reservationClosedAt
+		);
+	}
+}

--- a/ticketing/src/main/java/com/goti/game/dto/request/CreateGameRequest.java
+++ b/ticketing/src/main/java/com/goti/game/dto/request/CreateGameRequest.java
@@ -1,17 +1,15 @@
 package com.goti.game.dto.request;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.goti.constants.GameStatus;
-import com.goti.constants.LeagueType;
-import com.goti.constants.ReservationAvailableStatus;
-import com.goti.game.service.command.CreateGameCommand;
-
-import jakarta.validation.constraints.NotNull;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.goti.constants.LeagueType;
+import com.goti.game.service.command.CreateGameCommand;
+
+import jakarta.validation.constraints.NotNull;
 
 public record CreateGameRequest(
 	@NotNull(message = "홈팀 ID는 필수입니다.")

--- a/ticketing/src/main/java/com/goti/game/dto/response/GameResponse.java
+++ b/ticketing/src/main/java/com/goti/game/dto/response/GameResponse.java
@@ -1,0 +1,38 @@
+package com.goti.game.dto.response;
+
+import com.goti.constants.LeagueType;
+import com.goti.constants.ReservationAvailableStatus;
+import com.goti.domain.entity.game.BaseballGameEntity;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.UUID;
+
+public record GameResponse(
+	UUID gameId,
+	UUID homeTeamId,
+	UUID awayTeamId,
+	UUID stadiumId,
+	LocalDate playDate,
+	LocalTime startAt,
+	LeagueType leagueType,
+	ReservationAvailableStatus reservationAvailableStatus,
+	LocalDateTime reservationOpenedAt,
+	LocalDateTime reservationClosedAt
+) {
+	public static GameResponse from(BaseballGameEntity game) {
+		return new GameResponse(
+			game.getId(),
+			game.getHomeTeamId(),
+			game.getAwayTeamId(),
+			game.getStadiumId(),
+			game.getPlayDate(),
+			game.getStartAt(),
+			game.getLeagueType(),
+			game.getReservationAvailableStatus(),
+			game.getReservationOpenedAt(),
+			game.getReservationClosedAt()
+		);
+	}
+}

--- a/ticketing/src/main/java/com/goti/game/repository/BaseballGameRepository.java
+++ b/ticketing/src/main/java/com/goti/game/repository/BaseballGameRepository.java
@@ -1,0 +1,20 @@
+package com.goti.game.repository;
+
+import com.goti.domain.entity.game.BaseballGameEntity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.UUID;
+
+@Repository
+public interface BaseballGameRepository extends JpaRepository<BaseballGameEntity, UUID> {
+	boolean existsByHomeTeamIdAndAwayTeamIdAndPlayDateAndStartAt(
+		UUID homeTeamId,
+		UUID awayTeamId,
+		LocalDate playDate,
+		LocalTime startAt
+	);
+}

--- a/ticketing/src/main/java/com/goti/game/repository/BaseballGameStatusRepository.java
+++ b/ticketing/src/main/java/com/goti/game/repository/BaseballGameStatusRepository.java
@@ -1,0 +1,12 @@
+package com.goti.game.repository;
+
+import com.goti.domain.entity.game.BaseballGameStatusEntity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface BaseballGameStatusRepository extends JpaRepository<BaseballGameStatusEntity, UUID> {
+}

--- a/ticketing/src/main/java/com/goti/game/service/BaseballGameApplicationService.java
+++ b/ticketing/src/main/java/com/goti/game/service/BaseballGameApplicationService.java
@@ -39,7 +39,6 @@ public class BaseballGameApplicationService {
 			cmd.stadiumId(),
 			cmd.playDate(),
 			cmd.startAt(),
-			cmd.leagueType(),
 			cmd.reservationOpenedAt(),
 			cmd.reservationClosedAt()
 		);

--- a/ticketing/src/main/java/com/goti/game/service/BaseballGameApplicationService.java
+++ b/ticketing/src/main/java/com/goti/game/service/BaseballGameApplicationService.java
@@ -1,0 +1,53 @@
+package com.goti.game.service;
+
+import com.goti.constants.messages.ErrorCode;
+import com.goti.domain.entity.game.BaseballGameEntity;
+import com.goti.domain.entity.game.BaseballGameStatusEntity;
+import com.goti.game.dto.response.GameResponse;
+import com.goti.game.repository.BaseballGameRepository;
+import com.goti.game.repository.BaseballGameStatusRepository;
+
+import com.goti.game.service.command.CreateGameCommand;
+
+import com.goti.global.validation.Preconditions;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BaseballGameApplicationService {
+	private final BaseballGameRepository baseballGameRepository;
+	private final BaseballGameStatusRepository baseballGameStatusRepository;
+
+	@Transactional
+	public GameResponse create(CreateGameCommand cmd) {
+		boolean exists = baseballGameRepository.existsByHomeTeamIdAndAwayTeamIdAndPlayDateAndStartAt(
+			cmd.homeTeamId(),
+			cmd.awayTeamId(),
+			cmd.playDate(),
+			cmd.startAt()
+		);
+
+		Preconditions.validate(!exists, ErrorCode.GAME_ALREADY_EXISTS);
+
+		BaseballGameEntity game = BaseballGameEntity.create(
+			cmd.homeTeamId(),
+			cmd.awayTeamId(),
+			cmd.stadiumId(),
+			cmd.playDate(),
+			cmd.startAt(),
+			cmd.leagueType(),
+			cmd.reservationOpenedAt(),
+			cmd.reservationClosedAt()
+		);
+		BaseballGameEntity savedGame = baseballGameRepository.save(game);
+
+		BaseballGameStatusEntity gameStatusEntity = BaseballGameStatusEntity.init(savedGame);
+		baseballGameStatusRepository.save(gameStatusEntity);
+
+		return GameResponse.from(savedGame);
+	}
+}

--- a/ticketing/src/main/java/com/goti/game/service/command/CreateGameCommand.java
+++ b/ticketing/src/main/java/com/goti/game/service/command/CreateGameCommand.java
@@ -1,0 +1,21 @@
+package com.goti.game.service.command;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.UUID;
+
+import com.goti.constants.GameStatus;
+import com.goti.constants.LeagueType;
+import com.goti.constants.ReservationAvailableStatus;
+
+public record CreateGameCommand(
+	UUID homeTeamId,
+	UUID awayTeamId,
+	UUID stadiumId,
+	LocalDate playDate,
+	LocalTime startAt,
+	LeagueType leagueType,
+	LocalDateTime reservationOpenedAt,
+	LocalDateTime reservationClosedAt
+) {}

--- a/ticketing/src/test/java/com/goti/game/controller/BaseballGameControllerTest.java
+++ b/ticketing/src/test/java/com/goti/game/controller/BaseballGameControllerTest.java
@@ -1,0 +1,124 @@
+package com.goti.game.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goti.constants.LeagueType;
+import com.goti.constants.ReservationAvailableStatus;
+import com.goti.exception.handler.SpringExceptionHandler;
+import com.goti.exception.handler.SystemExceptionHandler;
+import com.goti.game.dto.request.CreateGameRequest;
+import com.goti.game.dto.response.GameResponse;
+import com.goti.game.service.BaseballGameApplicationService;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.UUID;
+
+@ActiveProfiles("test")
+@WebMvcTest(BaseballGameController.class)
+@ContextConfiguration(classes = {
+	BaseballGameController.class,
+	SystemExceptionHandler.class,
+	SpringExceptionHandler.class
+})
+class BaseballGameControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockitoBean
+	private BaseballGameApplicationService baseballGameApplicationService;
+
+	@Test
+	@DisplayName("POST /api/v1/games/baseball - 경기 생성 성공")
+	@WithMockUser
+	void 경기_생성_API_성공() throws Exception {
+		UUID gameId = UUID.randomUUID();
+		UUID homeTeamId = UUID.randomUUID();
+		UUID awayTeamId = UUID.randomUUID();
+		UUID stadiumId = UUID.randomUUID();
+
+		CreateGameRequest request = new CreateGameRequest(
+			homeTeamId,
+			awayTeamId,
+			stadiumId,
+			LocalDate.of(2026, 4, 10),
+			LocalTime.of(18, 30),
+			LeagueType.REGULAR,
+			LocalDateTime.of(2026, 4, 1, 14, 0),
+			LocalDateTime.of(2026, 4, 10, 17, 0)
+		);
+
+		GameResponse response = new GameResponse(
+			gameId,
+			homeTeamId,
+			awayTeamId,
+			stadiumId,
+			request.playDate(),
+			request.startAt(),
+			LeagueType.REGULAR,
+			ReservationAvailableStatus.PENDING,
+			request.reservationOpenedAt(),
+			request.reservationClosedAt()
+		);
+		given(baseballGameApplicationService.create(any())).willReturn(response);
+
+		mockMvc.perform(
+				post("/api/v1/games/baseball")
+					.with(csrf())
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request))
+			)
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("ok"))
+			.andExpect(jsonPath("$.message").value("성공"))
+			.andExpect(jsonPath("$.data.gameId").value(gameId.toString()))
+			.andExpect(jsonPath("$.data.homeTeamId").value(homeTeamId.toString()));
+	}
+
+	@Test
+	@DisplayName("POST /api/v1/games/baseball - 필수값 누락 시 400 반환")
+	@WithMockUser
+	void 경기_생성_API_실패_필수값_누락() throws Exception {
+		String invalidBody = """
+			{
+			  "homeTeamId": "%s",
+			  "awayTeamId": "%s",
+			  "stadiumId": "%s",
+			  "playDate": "2026-04-10",
+			  "startAt": "18:30:00",
+			  "reservationOpenedAt": "2026-04-01 14:00:00",
+			  "reservationClosedAt": "2026-04-10 17:00:00"
+			}
+			""".formatted(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+
+		mockMvc.perform(
+				post("/api/v1/games/baseball")
+					.with(csrf())
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(invalidBody)
+			)
+			.andExpect(status().isBadRequest());
+	}
+}

--- a/ticketing/src/test/java/com/goti/game/service/BaseballGameApplicationServiceTest.java
+++ b/ticketing/src/test/java/com/goti/game/service/BaseballGameApplicationServiceTest.java
@@ -1,0 +1,109 @@
+package com.goti.game.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.*;
+
+import com.goti.constants.LeagueType;
+import com.goti.constants.messages.ErrorCode;
+import com.goti.domain.entity.game.BaseballGameEntity;
+import com.goti.domain.entity.game.BaseballGameStatusEntity;
+import com.goti.exception.CustomException;
+import com.goti.game.dto.response.GameResponse;
+import com.goti.game.repository.BaseballGameRepository;
+import com.goti.game.repository.BaseballGameStatusRepository;
+import com.goti.game.service.command.CreateGameCommand;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.UUID;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+class BaseballGameApplicationServiceTest {
+
+	@Mock
+	private BaseballGameRepository baseballGameRepository;
+
+	@Mock
+	private BaseballGameStatusRepository baseballGameStatusRepository;
+
+	@InjectMocks
+	private BaseballGameApplicationService baseballGameApplicationService;
+
+	private CreateGameCommand createGameCommand;
+
+	@BeforeEach
+	void setUp() {
+		createGameCommand = new CreateGameCommand(
+			UUID.randomUUID(),
+			UUID.randomUUID(),
+			UUID.randomUUID(),
+			LocalDate.of(2026, 4, 10),
+			LocalTime.of(18, 30),
+			LeagueType.REGULAR,
+			LocalDateTime.of(2026, 4, 1, 14, 0),
+			LocalDateTime.of(2026, 4, 10, 17, 0)
+		);
+	}
+
+	@Test
+	@DisplayName("method: create() - 경기 생성 성공")
+	void 경기_생성_성공() {
+		given(baseballGameRepository.existsByHomeTeamIdAndAwayTeamIdAndPlayDateAndStartAt(
+			any(UUID.class), any(UUID.class), any(LocalDate.class), any(LocalTime.class)
+		)).willReturn(false);
+
+		BaseballGameEntity savedGame = BaseballGameEntity.create(
+			createGameCommand.homeTeamId(),
+			createGameCommand.awayTeamId(),
+			createGameCommand.stadiumId(),
+			createGameCommand.playDate(),
+			createGameCommand.startAt(),
+			createGameCommand.reservationOpenedAt(),
+			createGameCommand.reservationClosedAt()
+		);
+		ReflectionTestUtils.setField(savedGame, "id", UUID.randomUUID());
+
+		given(baseballGameRepository.save(any(BaseballGameEntity.class))).willReturn(savedGame);
+		given(baseballGameStatusRepository.save(any(BaseballGameStatusEntity.class)))
+			.willAnswer(invocation -> invocation.getArgument(0));
+
+		GameResponse response = baseballGameApplicationService.create(createGameCommand);
+
+		assertThat(response).isNotNull();
+		assertThat(response.homeTeamId()).isEqualTo(createGameCommand.homeTeamId());
+		assertThat(response.awayTeamId()).isEqualTo(createGameCommand.awayTeamId());
+		assertThat(response.stadiumId()).isEqualTo(createGameCommand.stadiumId());
+
+		verify(baseballGameRepository, times(1)).save(any(BaseballGameEntity.class));
+		verify(baseballGameStatusRepository, times(1)).save(any(BaseballGameStatusEntity.class));
+	}
+
+	@Test
+	@DisplayName("method: create() - 동일 경기 일정 존재 시 생성 실패")
+	void 경기_생성_실패_중복_일정() {
+		given(baseballGameRepository.existsByHomeTeamIdAndAwayTeamIdAndPlayDateAndStartAt(
+			any(UUID.class), any(UUID.class), any(LocalDate.class), any(LocalTime.class)
+		)).willReturn(true);
+
+		assertThatThrownBy(() -> baseballGameApplicationService.create(createGameCommand))
+			.isInstanceOf(CustomException.class)
+			.hasMessageContaining(ErrorCode.GAME_ALREADY_EXISTS.getMessage());
+
+		verify(baseballGameRepository, never()).save(any(BaseballGameEntity.class));
+		verify(baseballGameStatusRepository, never()).save(any(BaseballGameStatusEntity.class));
+	}
+}


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#58 

<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
야구 경기 생성 로직 구현했습니다.

<br/>


## 📋 작업 내용
> 야구 경기 생성 요청/응답/커맨드 DTO 추가
> 야구 경기 저장 Repository 추가
> 야구 경기 상태 저장 Repository 추가
> 야구 경기 생성 Application Service 구현
> 야구 경기 생성 컨트롤러 추가

> 서비스/컨트롤러 테스트코드 추가


<br/>