### PR TITLE
[FEAT] 회원가입 서비스 로직 구현

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }

--- a/common/src/main/java/com/goti/config/validator/MobileValidator.java
+++ b/common/src/main/java/com/goti/config/validator/MobileValidator.java
@@ -1,0 +1,27 @@
+package com.goti.config.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class MobileValidator implements ConstraintValidator<ValidMobile, String> {
+
+	final static int MOBILE_LENGTH = 11;
+	final static String MOBILE_PREFIX = "010";
+
+	@Override
+	public boolean isValid(String value, ConstraintValidatorContext context) {
+		if (value.length() != MOBILE_LENGTH || !value.startsWith(MOBILE_PREFIX)) {
+			return false;
+		}
+
+		String body = value.substring(3);
+
+		for (char c : body.toCharArray()) {
+			if (!Character.isDigit(c)) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+}

--- a/common/src/main/java/com/goti/config/validator/ValidMobile.java
+++ b/common/src/main/java/com/goti/config/validator/ValidMobile.java
@@ -1,0 +1,23 @@
+package com.goti.config.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = MobileValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidMobile {
+
+	String message() default "휴대전화 번호 형식이 올바르지 않습니다.";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+}

--- a/user/src/main/java/com/goti/config/jwt/JwtAuthenticationFilter.java
+++ b/user/src/main/java/com/goti/config/jwt/JwtAuthenticationFilter.java
@@ -58,10 +58,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 				SecurityContextHolder.getContext().setAuthentication(authenticationToken);
 			}
 		} catch (ExpiredJwtException e) {
-			String subject = e.getClaims().getSubject();
-			if (JwtTokenProvider.REGISTRATION_SUBJECT.equals(subject)) {
-				reject(request, ErrorCode.AUTH_REGISTRATION_EXPIRED);
-			}
 			reject(request, ErrorCode.AUTH_ACCESS_EXPIRED);
 		} catch (JwtException | IllegalArgumentException e) {
 			reject(request, ErrorCode.AUTH_INVALID);

--- a/user/src/main/java/com/goti/config/jwt/JwtTokenProvider.java
+++ b/user/src/main/java/com/goti/config/jwt/JwtTokenProvider.java
@@ -5,9 +5,12 @@ import com.goti.config.properties.JwtProperties;
 import com.goti.constants.OAuthProvider;
 import com.goti.constants.UserRole;
 
+import com.goti.constants.messages.ErrorCode;
+import com.goti.exception.CustomException;
 import com.goti.security.ExtendedUserDetailsService;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
@@ -78,6 +81,24 @@ public class JwtTokenProvider {
 			.verifyWith(jwtProperties.secretKey())
 			.build().parseSignedClaims(token);
 		log.info("ExpiredAt :: {}", claims.getPayload().getExpiration());
+	}
+
+	public Claims getRegistrationClaims(String token) {
+		try {
+			Claims claims = Jwts.parser()
+				.verifyWith(jwtProperties.secretKey())
+				.build()
+				.parseSignedClaims(token)
+				.getPayload();
+			if (!REGISTRATION_SUBJECT.equals(claims.getSubject())) {
+				throw new CustomException(ErrorCode.AUTH_INVALID);
+			}
+			return claims;
+		} catch (ExpiredJwtException e) {
+			throw new CustomException(ErrorCode.AUTH_REGISTRATION_EXPIRED);
+		} catch (JwtException | IllegalArgumentException e) {
+			throw new CustomException(ErrorCode.AUTH_INVALID);
+		}
 	}
 
 	public String resolve(HttpServletRequest request) {

--- a/user/src/main/java/com/goti/dto/request/SignupRequest.java
+++ b/user/src/main/java/com/goti/dto/request/SignupRequest.java
@@ -1,5 +1,6 @@
 package com.goti.dto.request;
 
+import com.goti.config.validator.ValidMobile;
 import com.goti.constants.Gender;
 
 import jakarta.validation.constraints.NotBlank;
@@ -12,6 +13,7 @@ public record SignupRequest(
 	@NotBlank(message = "이름은 필수 항목입니다.")
 	String name,
 
+	@ValidMobile
 	@NotBlank(message = "휴대전화번호는 필수 항목입니다.")
 	String mobile,
 

--- a/user/src/main/java/com/goti/dto/request/SignupRequest.java
+++ b/user/src/main/java/com/goti/dto/request/SignupRequest.java
@@ -1,0 +1,28 @@
+package com.goti.dto.request;
+
+import com.goti.constants.Gender;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+import java.time.LocalDate;
+
+public record SignupRequest(
+	@NotBlank(message = "이름은 필수 항목입니다.")
+	String name,
+
+	@NotBlank(message = "휴대전화번호는 필수 항목입니다.")
+	String mobile,
+
+	@NotNull(message = "성별은 필수 항목입니다.")
+	Gender gender,
+
+	@NotBlank(message = "생년월일은 필수 항목입니다.")
+	@Pattern(
+		regexp = "^\\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$",
+		message = "생년월일 형식이 올바르지 않습니다. (yyyy-MM-dd)"
+	)
+	LocalDate birthDate
+) {
+}

--- a/user/src/main/java/com/goti/dto/request/SignupRequest.java
+++ b/user/src/main/java/com/goti/dto/request/SignupRequest.java
@@ -20,7 +20,7 @@ public record SignupRequest(
 	@NotNull(message = "성별은 필수 항목입니다.")
 	Gender gender,
 
-	@NotBlank(message = "생년월일은 필수 항목입니다.")
+	@NotNull(message = "생년월일은 필수 항목입니다.")
 	@Pattern(
 		regexp = "^\\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$",
 		message = "생년월일 형식이 올바르지 않습니다. (yyyy-MM-dd)"

--- a/user/src/main/java/com/goti/repository/MemberRepository.java
+++ b/user/src/main/java/com/goti/repository/MemberRepository.java
@@ -5,9 +5,12 @@ import com.goti.domain.entity.user.MemberEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface MemberRepository extends JpaRepository<MemberEntity, UUID> {
+
+	Optional<MemberEntity> findByMobile(String mobile);
 
 }

--- a/user/src/main/java/com/goti/repository/SocialProviderRepository.java
+++ b/user/src/main/java/com/goti/repository/SocialProviderRepository.java
@@ -19,8 +19,9 @@ public interface SocialProviderRepository extends JpaRepository<SocialProviderEn
 		 "JOIN FETCH s.member " +
 					"WHERE s.providerId = :providerId " +
 		 				"AND s.provider = :provider")
-	Optional<SocialProviderEntity> findByProviderIdAndProviderWithUser(
+	Optional<SocialProviderEntity> findByProviderIdAndProvider(
 		@Param("providerId") String providerId,
 		@Param("provider") OAuthProvider provider
 	);
+
 }

--- a/user/src/main/java/com/goti/service/auth/application/SignupService.java
+++ b/user/src/main/java/com/goti/service/auth/application/SignupService.java
@@ -1,0 +1,74 @@
+package com.goti.service.auth.application;
+
+import com.goti.config.jwt.JwtTokenProvider;
+import com.goti.constants.Gender;
+import com.goti.constants.OAuthProvider;
+import com.goti.constants.UserRole;
+import com.goti.domain.entity.user.MemberEntity;
+import com.goti.domain.entity.user.SocialProviderEntity;
+import com.goti.dto.request.LoginRequest;
+import com.goti.dto.response.LoginResponse;
+import com.goti.repository.MemberRepository;
+
+import com.goti.service.domain.user.MemberService;
+
+import com.goti.service.domain.user.SocialProviderService;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class SignupService {
+
+	private final MemberRepository memberRepository;
+	private final JwtTokenProvider jwtTokenProvider;
+	private final MemberService memberService;
+	private final SocialProviderService socialProviderService;
+
+	static final String PROVIDER_ID_KEY = "provider_id";
+	static final String REGISTRATION_SUBJECT = "registration";
+
+	public LoginResponse signup(
+		String registrationToken,
+		String email,
+		String name,
+		String mobile,
+		Gender gender,
+		LocalDate birthDate
+	) {
+		Claims claims = jwtTokenProvider.getRegistrationClaims(registrationToken);
+		String providerId = claims.get(PROVIDER_ID_KEY, String.class);
+		OAuthProvider provider = OAuthProvider.valueOf(claims.get(REGISTRATION_SUBJECT, String.class));
+
+		MemberEntity member = memberRepository.findByMobile(mobile).orElseGet(
+			() -> createMember(name, mobile, gender, birthDate)
+		);
+
+		socialProviderService.findByProviderIdAndProvider(providerId, provider)
+			.orElseGet(
+				() -> createSocialProvider(member, provider, providerId, email)
+			);
+
+		String accessToken = jwtTokenProvider.create(
+			member.getId(), member.getMobile(), member.getRole()
+		);
+		return LoginResponse.authenticated(accessToken);
+	}
+
+	private MemberEntity createMember(String name, String mobile, Gender gender, LocalDate birthDate) {
+		return memberService.save(name, mobile, gender, birthDate);
+	}
+
+	private SocialProviderEntity createSocialProvider(
+		MemberEntity member, OAuthProvider provider, String providerId, String email
+	) {
+		return socialProviderService.save(member, provider, providerId, email);
+	}
+
+
+}

--- a/user/src/main/java/com/goti/service/domain/user/MemberService.java
+++ b/user/src/main/java/com/goti/service/domain/user/MemberService.java
@@ -1,0 +1,11 @@
+package com.goti.service.domain.user;
+
+import com.goti.constants.Gender;
+import com.goti.domain.entity.user.MemberEntity;
+
+import java.time.LocalDate;
+
+public interface MemberService {
+
+	MemberEntity save(String name, String mobile, Gender gender, LocalDate birthDate);
+}

--- a/user/src/main/java/com/goti/service/domain/user/MemberServiceImpl.java
+++ b/user/src/main/java/com/goti/service/domain/user/MemberServiceImpl.java
@@ -1,0 +1,28 @@
+package com.goti.service.domain.user;
+
+import com.goti.constants.Gender;
+import com.goti.domain.entity.user.MemberEntity;
+import com.goti.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService {
+
+	private final MemberRepository memberRepository;
+
+	@Transactional
+	public MemberEntity save(String name, String mobile, Gender gender, LocalDate birthDate) {
+		MemberEntity member = MemberEntity.create(
+			mobile, name, gender, birthDate
+		);
+		memberRepository.save(member);
+		return member;
+	}
+}

--- a/user/src/main/java/com/goti/service/domain/user/SocialProviderService.java
+++ b/user/src/main/java/com/goti/service/domain/user/SocialProviderService.java
@@ -2,10 +2,17 @@ package com.goti.service.domain.user;
 
 import com.goti.constants.OAuthProvider;
 import com.goti.domain.entity.user.MemberEntity;
+import com.goti.domain.entity.user.SocialProviderEntity;
 
 import java.util.Optional;
 
 public interface SocialProviderService {
 
+	SocialProviderEntity save(
+		MemberEntity member, OAuthProvider provider, String providerId, String email
+	);
+
 	Optional<MemberEntity> findMemberBySocialInfo(String providerId, OAuthProvider provider);
+
+	Optional<SocialProviderEntity> findByProviderIdAndProvider(String providerId, OAuthProvider provider);
 }

--- a/user/src/main/java/com/goti/service/domain/user/SocialProviderServiceImpl.java
+++ b/user/src/main/java/com/goti/service/domain/user/SocialProviderServiceImpl.java
@@ -9,6 +9,7 @@ import com.goti.repository.SocialProviderRepository;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -19,9 +20,27 @@ public class SocialProviderServiceImpl implements SocialProviderService {
 	private final SocialProviderRepository socialProviderRepository;
 
 	@Override
+	@Transactional
+	public SocialProviderEntity save(
+		MemberEntity member, OAuthProvider provider, String providerId, String email
+	) {
+		SocialProviderEntity socialProvider = SocialProviderEntity.create(
+			member, provider, providerId, email
+		);
+		socialProviderRepository.save(socialProvider);
+		return socialProvider;
+	}
+
+	@Override
 	public Optional<MemberEntity> findMemberBySocialInfo(String providerId, OAuthProvider provider) {
-		return socialProviderRepository.findByProviderIdAndProviderWithUser(
+		return findByProviderIdAndProvider(providerId, provider)
+			.map(SocialProviderEntity::getMember);
+	}
+
+	@Override
+	public Optional<SocialProviderEntity> findByProviderIdAndProvider(String providerId, OAuthProvider provider) {
+		return socialProviderRepository.findByProviderIdAndProvider(
 			providerId, provider
-		).map(SocialProviderEntity::getMember);
+		);
 	}
 }


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#62 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
회원가입 서비스 로직 (SignupService) 추가
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- 회원가입 시 요청된 정보를 토대로 회원 객체 유무 체크
  -  미 존재 시 -> 회원 객체 생성
- 만들어진 혹은 기존에 있던 회원 객체를 토대로 socialProvider (소셜 인증 정보) 저장 (kakao, naver, google 에 한하여 각 1개)

<br/>