### PR TITLE
[FEAT] 소셜 로그인 사전 검증 서비스 및 API 구현

### DIFF
--- a/user/src/main/java/com/goti/config/jwt/JwtTokenProvider.java
+++ b/user/src/main/java/com/goti/config/jwt/JwtTokenProvider.java
@@ -43,6 +43,7 @@ public class JwtTokenProvider {
 	private static final String PROVIDER_TYPE_KEY = "provider_type";
 	private static final String PROVIDER_ID_KEY = "provider_id";
 	static final String REGISTRATION_SUBJECT = "registration";
+	static final String SOCIAL_VERIFY_SUBJECT = "social_verify";
 
 	public String create(UUID id, String mobile, UserRole role) {
 		Date issuedAt = new Date();
@@ -61,9 +62,25 @@ public class JwtTokenProvider {
 
 	// todo: Duration.ofMinutes(10) 하드코딩 기입 부분 -> user module application.yml 파일 읽지 못하는 부분 수정 예정
 	// todo: 추가로 create method 도 같은 error 날것으로 예상됨
+	public String createSocialVerifyToken(OAuthProvider provider, String providerId) {
+		Date issuedAt = new Date();
+		Date expireAt = new Date(issuedAt.getTime() + Duration.ofMinutes(3).toMillis());
+		String jwtId = getJwtId();
+		return Jwts.builder()
+			.subject(SOCIAL_VERIFY_SUBJECT)
+			.id(jwtId)
+			.claim(PROVIDER_TYPE_KEY, provider)
+			.claim(PROVIDER_ID_KEY, providerId)
+			.issuedAt(issuedAt)
+			.expiration(expireAt)
+			.signWith(jwtProperties.secretKey())
+			.compact();
+	}
+
+	// todo: 삭제 예정
 	public String createRegistrationToken(OAuthProvider provider, String providerId) {
 		Date issuedAt = new Date();
-		Date expireAt = new Date(issuedAt.getTime() + Duration.ofMinutes(10).toMillis());
+		Date expireAt = new Date(issuedAt.getTime() + Duration.ofMinutes(3).toMillis());
 		String jwtId = getJwtId();
 		return Jwts.builder()
 			.subject(REGISTRATION_SUBJECT)

--- a/user/src/main/java/com/goti/controller/AuthController.java
+++ b/user/src/main/java/com/goti/controller/AuthController.java
@@ -6,6 +6,7 @@ import com.goti.dto.request.SocialVerifyRequest;
 import com.goti.dto.response.LoginResponse;
 import com.goti.dto.response.SocialVerifyResponse;
 import com.goti.global.api.ApiSuccessResponse;
+import com.goti.infra.api.dto.response.common.SocialStateResponse;
 import com.goti.service.auth.application.AuthApplicationService;
 
 import com.goti.service.auth.application.SocialAuthService;
@@ -14,6 +15,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -29,6 +31,15 @@ public class AuthController {
 
 	private final AuthApplicationService authApplicationService;
 	private final SocialAuthService socialAuthService;
+
+	@GetMapping("/{provider}/state")
+	public ResponseEntity<ApiSuccessResponse<SocialStateResponse>> issueState(
+		@PathVariable OAuthProvider provider
+	) {
+		return wrap(
+			socialAuthService.issueState(provider)
+		);
+	}
 
 	@PostMapping("/{provider}/social/verify")
 	public ResponseEntity<ApiSuccessResponse<SocialVerifyResponse>> verify(

--- a/user/src/main/java/com/goti/controller/AuthController.java
+++ b/user/src/main/java/com/goti/controller/AuthController.java
@@ -2,9 +2,13 @@ package com.goti.controller;
 
 import com.goti.constants.OAuthProvider;
 import com.goti.dto.request.LoginRequest;
+import com.goti.dto.request.SocialVerifyRequest;
 import com.goti.dto.response.LoginResponse;
+import com.goti.dto.response.SocialVerifyResponse;
 import com.goti.global.api.ApiSuccessResponse;
 import com.goti.service.auth.application.AuthApplicationService;
+
+import com.goti.service.auth.application.SocialAuthService;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +28,17 @@ import static com.goti.global.api.ApiSuccessResponse.wrap;
 public class AuthController {
 
 	private final AuthApplicationService authApplicationService;
+	private final SocialAuthService socialAuthService;
+
+	@PostMapping("/{provider}/social/verify")
+	public ResponseEntity<ApiSuccessResponse<SocialVerifyResponse>> verify(
+		@PathVariable OAuthProvider provider,
+		@RequestBody @Valid SocialVerifyRequest request
+	) {
+		return wrap(
+			socialAuthService.verify(provider, request.authCode(), request.state())
+		);
+	}
 
 	@PostMapping("/{provider}/login")
 	public ResponseEntity<ApiSuccessResponse<LoginResponse>> login(

--- a/user/src/main/java/com/goti/dto/request/SocialVerifyRequest.java
+++ b/user/src/main/java/com/goti/dto/request/SocialVerifyRequest.java
@@ -1,0 +1,11 @@
+package com.goti.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record SocialVerifyRequest(
+	@NotBlank(message = "인증 코드는 필수 항목입니다.")
+	String authCode,
+
+	String state
+) {
+}

--- a/user/src/main/java/com/goti/dto/response/SocialVerifyResponse.java
+++ b/user/src/main/java/com/goti/dto/response/SocialVerifyResponse.java
@@ -1,0 +1,13 @@
+package com.goti.dto.response;
+
+public record SocialVerifyResponse(
+	boolean isRegistered,
+	String socialVerifyToken
+) {
+
+	public static SocialVerifyResponse of(boolean isRegistered, String token) {
+		return new SocialVerifyResponse(
+			isRegistered, token
+		);
+	}
+}

--- a/user/src/main/java/com/goti/service/auth/application/SocialAuthService.java
+++ b/user/src/main/java/com/goti/service/auth/application/SocialAuthService.java
@@ -7,6 +7,7 @@ import com.goti.dto.response.SocialVerifyResponse;
 import com.goti.exception.CustomException;
 import com.goti.infra.api.client.SocialApiClient;
 import com.goti.infra.api.client.SocialClientProvider;
+import com.goti.infra.api.dto.response.common.SocialStateResponse;
 import com.goti.infra.api.dto.response.common.SocialUserInfoResponse;
 import com.goti.infra.cache.RedisCache;
 import com.goti.infra.constants.redis.RedisKey;
@@ -15,8 +16,13 @@ import com.goti.service.domain.user.SocialProviderService;
 
 import lombok.RequiredArgsConstructor;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.stereotype.Service;
 
+import java.util.UUID;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SocialAuthService {
@@ -28,13 +34,24 @@ public class SocialAuthService {
 
 	private static final String KEY_SEPARATOR = ":";
 
+	public SocialStateResponse issueState(OAuthProvider provider) {
+		if (provider == OAuthProvider.KAKAO) {
+			throw new CustomException(ErrorCode.BAD_REQUEST);
+		}
+		String state = UUID.randomUUID().toString();
+		String keyParam = provider + KEY_SEPARATOR + state;
+
+		redisCache.set(RedisKey.OAUTH_STATE, keyParam, true);
+
+		return SocialStateResponse.of(state);
+	}
+
 	public SocialVerifyResponse verify(OAuthProvider provider, String authCode, String state) {
 		validateState(provider, state);
 		SocialApiClient apiClient = socialClientProvider.getClient(provider);
 		String socialAccessToken = apiClient.getAccessToken(authCode, state);
 		SocialUserInfoResponse socialUserInfo = apiClient.getSocialUserInfo(socialAccessToken);
 		String providerId = socialUserInfo.providerId();
-
 		boolean isRegistered = socialProviderService.findByProviderIdAndProvider(
 			providerId, provider
 		).isPresent();

--- a/user/src/main/java/com/goti/service/auth/application/SocialAuthService.java
+++ b/user/src/main/java/com/goti/service/auth/application/SocialAuthService.java
@@ -1,0 +1,60 @@
+package com.goti.service.auth.application;
+
+import com.goti.config.jwt.JwtTokenProvider;
+import com.goti.constants.OAuthProvider;
+import com.goti.constants.messages.ErrorCode;
+import com.goti.dto.response.SocialVerifyResponse;
+import com.goti.exception.CustomException;
+import com.goti.infra.api.client.SocialApiClient;
+import com.goti.infra.api.client.SocialClientProvider;
+import com.goti.infra.api.dto.response.common.SocialUserInfoResponse;
+import com.goti.infra.cache.RedisCache;
+import com.goti.infra.constants.redis.RedisKey;
+
+import com.goti.service.domain.user.SocialProviderService;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SocialAuthService {
+
+	private final SocialClientProvider socialClientProvider;
+	private final SocialProviderService socialProviderService;
+	private final JwtTokenProvider jwtTokenProvider;
+	private final RedisCache redisCache;
+
+	private static final String KEY_SEPARATOR = ":";
+
+	public SocialVerifyResponse verify(OAuthProvider provider, String authCode, String state) {
+		validateState(provider, state);
+		SocialApiClient apiClient = socialClientProvider.getClient(provider);
+		String socialAccessToken = apiClient.getAccessToken(authCode, state);
+		SocialUserInfoResponse socialUserInfo = apiClient.getSocialUserInfo(socialAccessToken);
+		String providerId = socialUserInfo.providerId();
+
+		boolean isRegistered = socialProviderService.findByProviderIdAndProvider(
+			providerId, provider
+		).isPresent();
+
+		String socialVerifyToken = jwtTokenProvider.createSocialVerifyToken(
+			provider, providerId
+		);
+		return SocialVerifyResponse.of(isRegistered, socialVerifyToken);
+	}
+
+	private void validateState(OAuthProvider provider, String state) {
+		if (provider == OAuthProvider.KAKAO) return;
+
+		if (state == null || state.isBlank()) {
+			throw new CustomException(ErrorCode.MISSING_PARAMETER, "state");
+		}
+		String keyParam = provider + KEY_SEPARATOR + state;
+		String stateKey = RedisKey.OAUTH_STATE.getKey(keyParam);
+		if (!redisCache.consume(stateKey)) {
+			throw new CustomException(ErrorCode.INVALID_STATE);
+		}
+	}
+}


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#71 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
- 소셜로그인 시도 전 검증 api 및 서비스 구현
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- 검증 api 및 서비스 구현 
  - 응답 구조
    - boolean isRegistered (providerId 에 해당하는 데이터 유무)
    - String socialVerifyToken  (jwt 방식으로 provider, providerId 를 payload 로 묶은)
- 기존 로그인 응답으로 주던 (LoginResponse) registrationToken 추후 삭제 예정
- registrationToken -> socialVerifyToken 변경 (기존 로그인 단계 -> 검증단계에서 응답)
- SocialAuthService 생성
- issueState 서비스 이관 (AuthApplicationService -> SocialAuthService)
- SocialVerifyRequest 및 Response 추가 (검증 api request, response)
<br/>