### PR TITLE
[FEAT] 경기 조회 로직 구현

### DIFF
--- a/common/src/main/java/com/goti/constants/messages/ErrorCode.java
+++ b/common/src/main/java/com/goti/constants/messages/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
 	AUTH_REGISTRATION_EXPIRED(HttpStatus.GONE, "회원가입 유효 시간이 만료되었습니다. 다시 소셜 로그인을 진행해주세요."),
 
 	GAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 동일한 경기 일정이 존재합니다."),
+	GAME_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 경기입니다."),
 
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생하였습니다. 잠시 후 다시 시도해주세요.")
 	;

--- a/ticketing/src/main/java/com/goti/game/controller/BaseballGameController.java
+++ b/ticketing/src/main/java/com/goti/game/controller/BaseballGameController.java
@@ -5,11 +5,15 @@ import com.goti.game.dto.response.GameResponse;
 import com.goti.game.service.BaseballGameApplicationService;
 import com.goti.global.api.ApiSuccessResponse;
 
+import com.goti.global.api.PageResponse;
+
 import jakarta.validation.Valid;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,5 +33,10 @@ public class BaseballGameController {
 	) {
 		GameResponse response = baseballGameApplicationService.create(request.toCommand());
 		return wrap(response);
+	}
+
+	@GetMapping
+	public ResponseEntity<ApiSuccessResponse<PageResponse<GameResponse>>> getGames(Pageable pageable) {
+		return page(baseballGameApplicationService.getGames(pageable));
 	}
 }

--- a/ticketing/src/main/java/com/goti/game/controller/BaseballGameController.java
+++ b/ticketing/src/main/java/com/goti/game/controller/BaseballGameController.java
@@ -14,10 +14,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
 
 import static com.goti.global.api.ApiSuccessResponse.*;
 
@@ -36,7 +39,16 @@ public class BaseballGameController {
 	}
 
 	@GetMapping
-	public ResponseEntity<ApiSuccessResponse<PageResponse<GameResponse>>> getGames(Pageable pageable) {
+	public ResponseEntity<ApiSuccessResponse<PageResponse<GameResponse>>> getGames(
+		Pageable pageable
+	) {
 		return page(baseballGameApplicationService.getGames(pageable));
+	}
+
+	@GetMapping("/{gameId}")
+	public ResponseEntity<ApiSuccessResponse<GameResponse>> getGame(
+		@PathVariable UUID gameId
+	) {
+		return wrap(baseballGameApplicationService.getGame(gameId));
 	}
 }

--- a/ticketing/src/main/java/com/goti/game/dto/response/GameResponse.java
+++ b/ticketing/src/main/java/com/goti/game/dto/response/GameResponse.java
@@ -1,8 +1,11 @@
 package com.goti.game.dto.response;
 
+import com.goti.constants.GameResult;
+import com.goti.constants.GameStatus;
 import com.goti.constants.LeagueType;
 import com.goti.constants.ReservationAvailableStatus;
 import com.goti.domain.entity.game.BaseballGameEntity;
+import com.goti.domain.entity.game.BaseballGameStatusEntity;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -19,7 +22,12 @@ public record GameResponse(
 	LeagueType leagueType,
 	ReservationAvailableStatus reservationAvailableStatus,
 	LocalDateTime reservationOpenedAt,
-	LocalDateTime reservationClosedAt
+	LocalDateTime reservationClosedAt,
+
+	GameStatus gameStatus,
+	Integer homeTeamScore,
+	Integer awayTeamScore,
+	GameResult gameResult
 ) {
 	public static GameResponse from(BaseballGameEntity game) {
 		return new GameResponse(
@@ -32,7 +40,33 @@ public record GameResponse(
 			game.getLeagueType(),
 			game.getReservationAvailableStatus(),
 			game.getReservationOpenedAt(),
-			game.getReservationClosedAt()
+			game.getReservationClosedAt(),
+			GameStatus.SCHEDULED,
+			0,
+			0,
+			GameResult.PENDING
+		);
+	}
+
+	public static GameResponse from(BaseballGameEntity game, BaseballGameStatusEntity status) {
+		if (status == null) {
+			return from(game);
+		}
+		return new GameResponse(
+			game.getId(),
+			game.getHomeTeamId(),
+			game.getAwayTeamId(),
+			game.getStadiumId(),
+			game.getPlayDate(),
+			game.getStartAt(),
+			game.getLeagueType(),
+			game.getReservationAvailableStatus(),
+			game.getReservationOpenedAt(),
+			game.getReservationClosedAt(),
+			status.getGameStatus(),
+			status.getHomeTeamScore(),
+			status.getAwayTeamScore(),
+			status.getGameResult()
 		);
 	}
 }

--- a/ticketing/src/main/java/com/goti/game/dto/response/GameResponse.java
+++ b/ticketing/src/main/java/com/goti/game/dto/response/GameResponse.java
@@ -23,35 +23,12 @@ public record GameResponse(
 	ReservationAvailableStatus reservationAvailableStatus,
 	LocalDateTime reservationOpenedAt,
 	LocalDateTime reservationClosedAt,
-
 	GameStatus gameStatus,
 	Integer homeTeamScore,
 	Integer awayTeamScore,
 	GameResult gameResult
 ) {
-	public static GameResponse from(BaseballGameEntity game) {
-		return new GameResponse(
-			game.getId(),
-			game.getHomeTeamId(),
-			game.getAwayTeamId(),
-			game.getStadiumId(),
-			game.getPlayDate(),
-			game.getStartAt(),
-			game.getLeagueType(),
-			game.getReservationAvailableStatus(),
-			game.getReservationOpenedAt(),
-			game.getReservationClosedAt(),
-			GameStatus.SCHEDULED,
-			0,
-			0,
-			GameResult.PENDING
-		);
-	}
-
 	public static GameResponse from(BaseballGameEntity game, BaseballGameStatusEntity status) {
-		if (status == null) {
-			return from(game);
-		}
 		return new GameResponse(
 			game.getId(),
 			game.getHomeTeamId(),

--- a/ticketing/src/main/java/com/goti/game/repository/BaseballGameStatusRepository.java
+++ b/ticketing/src/main/java/com/goti/game/repository/BaseballGameStatusRepository.java
@@ -6,7 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.UUID;
+import java.util.Optional;
 
 @Repository
 public interface BaseballGameStatusRepository extends JpaRepository<BaseballGameStatusEntity, UUID> {
+	Optional<BaseballGameStatusEntity> findByBaseballGame_Id(UUID gameId);
 }

--- a/ticketing/src/main/java/com/goti/game/service/BaseballGameApplicationService.java
+++ b/ticketing/src/main/java/com/goti/game/service/BaseballGameApplicationService.java
@@ -48,16 +48,18 @@ public class BaseballGameApplicationService {
 		);
 		BaseballGameEntity savedGame = baseballGameRepository.save(game);
 
-		BaseballGameStatusEntity gameStatusEntity = BaseballGameStatusEntity.init(savedGame);
-		baseballGameStatusRepository.save(gameStatusEntity);
+		BaseballGameStatusEntity gameStatus = BaseballGameStatusEntity.init(savedGame);
+		baseballGameStatusRepository.save(gameStatus);
 
-		return GameResponse.from(savedGame);
+		return GameResponse.from(savedGame, gameStatus);
 	}
 
 	@Transactional(readOnly = true)
 	public Page<GameResponse> getGames(Pageable pageable) {
 		return baseballGameRepository.findAll(pageable)
-			.map(GameResponse::from);
+			.map(game -> baseballGameStatusRepository.findByBaseballGame_Id(game.getId())
+				.map(status -> GameResponse.from(game, status))
+				.orElseGet(() -> GameResponse.from(game)));
 	}
 
 	@Transactional(readOnly = true)
@@ -65,6 +67,10 @@ public class BaseballGameApplicationService {
 		BaseballGameEntity game = baseballGameRepository.findById(gameId)
 			.orElseThrow(() -> new CustomException(ErrorCode.GAME_NOT_FOUND));
 
-		return GameResponse.from(game);
+		BaseballGameStatusEntity status = baseballGameStatusRepository
+			.findByBaseballGame_Id(gameId)
+			.orElseThrow(() -> new CustomException(ErrorCode.GAME_NOT_FOUND));
+
+		return GameResponse.from(game, status);
 	}
 }

--- a/ticketing/src/main/java/com/goti/game/service/BaseballGameApplicationService.java
+++ b/ticketing/src/main/java/com/goti/game/service/BaseballGameApplicationService.java
@@ -1,20 +1,20 @@
 package com.goti.game.service;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.goti.constants.messages.ErrorCode;
 import com.goti.domain.entity.game.BaseballGameEntity;
 import com.goti.domain.entity.game.BaseballGameStatusEntity;
 import com.goti.game.dto.response.GameResponse;
 import com.goti.game.repository.BaseballGameRepository;
 import com.goti.game.repository.BaseballGameStatusRepository;
-
 import com.goti.game.service.command.CreateGameCommand;
-
 import com.goti.global.validation.Preconditions;
 
 import lombok.RequiredArgsConstructor;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -48,5 +48,11 @@ public class BaseballGameApplicationService {
 		baseballGameStatusRepository.save(gameStatusEntity);
 
 		return GameResponse.from(savedGame);
+	}
+
+	@Transactional(readOnly = true)
+	public Page<GameResponse> getGames(Pageable pageable) {
+		return baseballGameRepository.findAll(pageable)
+			.map(GameResponse::from);
 	}
 }

--- a/ticketing/src/main/java/com/goti/game/service/BaseballGameApplicationService.java
+++ b/ticketing/src/main/java/com/goti/game/service/BaseballGameApplicationService.java
@@ -59,7 +59,7 @@ public class BaseballGameApplicationService {
 		return baseballGameRepository.findAll(pageable)
 			.map(game -> baseballGameStatusRepository.findByBaseballGame_Id(game.getId())
 				.map(status -> GameResponse.from(game, status))
-				.orElseGet(() -> GameResponse.from(game)));
+				.orElseThrow(() -> new CustomException(ErrorCode.GAME_NOT_FOUND)));
 	}
 
 	@Transactional(readOnly = true)

--- a/ticketing/src/main/java/com/goti/game/service/BaseballGameApplicationService.java
+++ b/ticketing/src/main/java/com/goti/game/service/BaseballGameApplicationService.java
@@ -1,5 +1,7 @@
 package com.goti.game.service;
 
+import com.goti.exception.CustomException;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -15,6 +17,8 @@ import com.goti.game.service.command.CreateGameCommand;
 import com.goti.global.validation.Preconditions;
 
 import lombok.RequiredArgsConstructor;
+
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -54,5 +58,13 @@ public class BaseballGameApplicationService {
 	public Page<GameResponse> getGames(Pageable pageable) {
 		return baseballGameRepository.findAll(pageable)
 			.map(GameResponse::from);
+	}
+
+	@Transactional(readOnly = true)
+	public GameResponse getGame(UUID gameId) {
+		BaseballGameEntity game = baseballGameRepository.findById(gameId)
+			.orElseThrow(() -> new CustomException(ErrorCode.GAME_NOT_FOUND));
+
+		return GameResponse.from(game);
 	}
 }

--- a/ticketing/src/test/java/com/goti/game/controller/BaseballGameControllerTest.java
+++ b/ticketing/src/test/java/com/goti/game/controller/BaseballGameControllerTest.java
@@ -9,6 +9,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goti.constants.GameResult;
+import com.goti.constants.GameStatus;
 import com.goti.constants.LeagueType;
 import com.goti.constants.ReservationAvailableStatus;
 import com.goti.constants.messages.ErrorCode;
@@ -86,7 +88,11 @@ class BaseballGameControllerTest {
 			LeagueType.REGULAR,
 			ReservationAvailableStatus.PENDING,
 			request.reservationOpenedAt(),
-			request.reservationClosedAt()
+			request.reservationClosedAt(),
+			GameStatus.SCHEDULED,
+			0,
+			0,
+			GameResult.PENDING
 		);
 		given(baseballGameApplicationService.create(any())).willReturn(response);
 
@@ -143,7 +149,11 @@ class BaseballGameControllerTest {
 			LeagueType.REGULAR,
 			ReservationAvailableStatus.PENDING,
 			LocalDateTime.of(2026, 4, 1, 14, 0),
-			LocalDateTime.of(2026, 4, 10, 17, 0)
+			LocalDateTime.of(2026, 4, 10, 17, 0),
+			GameStatus.SCHEDULED,
+			0,
+			0,
+			GameResult.PENDING
 		);
 		Page<GameResponse> page = new PageImpl<>(
 			java.util.List.of(response),
@@ -180,7 +190,11 @@ class BaseballGameControllerTest {
 			LeagueType.REGULAR,
 			ReservationAvailableStatus.PENDING,
 			LocalDateTime.of(2026, 4, 1, 14, 0),
-			LocalDateTime.of(2026, 4, 10, 17, 0)
+			LocalDateTime.of(2026, 4, 10, 17, 0),
+			GameStatus.SCHEDULED,
+			0,
+			0,
+			GameResult.PENDING
 		);
 		given(baseballGameApplicationService.getGame(gameId)).willReturn(response);
 

--- a/ticketing/src/test/java/com/goti/game/controller/BaseballGameControllerTest.java
+++ b/ticketing/src/test/java/com/goti/game/controller/BaseballGameControllerTest.java
@@ -2,6 +2,7 @@ package com.goti.game.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -10,6 +11,8 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.goti.constants.LeagueType;
 import com.goti.constants.ReservationAvailableStatus;
+import com.goti.constants.messages.ErrorCode;
+import com.goti.exception.CustomException;
 import com.goti.exception.handler.SpringExceptionHandler;
 import com.goti.exception.handler.SystemExceptionHandler;
 import com.goti.game.dto.request.CreateGameRequest;
@@ -21,6 +24,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -120,5 +126,82 @@ class BaseballGameControllerTest {
 					.content(invalidBody)
 			)
 			.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	@DisplayName("GET /api/v1/games/baseball - 경기 전체 조회 성공")
+	@WithMockUser
+	void 경기_전체조회_API_성공() throws Exception {
+		UUID gameId = UUID.randomUUID();
+		GameResponse response = new GameResponse(
+			gameId,
+			UUID.randomUUID(),
+			UUID.randomUUID(),
+			UUID.randomUUID(),
+			LocalDate.of(2026, 4, 10),
+			LocalTime.of(18, 30),
+			LeagueType.REGULAR,
+			ReservationAvailableStatus.PENDING,
+			LocalDateTime.of(2026, 4, 1, 14, 0),
+			LocalDateTime.of(2026, 4, 10, 17, 0)
+		);
+		Page<GameResponse> page = new PageImpl<>(
+			java.util.List.of(response),
+			PageRequest.of(0, 10),
+			1
+		);
+		given(baseballGameApplicationService.getGames(any())).willReturn(page);
+
+		mockMvc.perform(
+				get("/api/v1/games/baseball")
+					.param("page", "0")
+					.param("size", "10")
+			)
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("ok"))
+			.andExpect(jsonPath("$.message").value("성공"))
+			.andExpect(jsonPath("$.data.list[0].gameId").value(gameId.toString()))
+			.andExpect(jsonPath("$.data.totalCount").value(1))
+			.andExpect(jsonPath("$.data.totalPages").value(1));
+	}
+
+	@Test
+	@DisplayName("GET /api/v1/games/baseball/{gameId} - 경기 단건 조회 성공")
+	@WithMockUser
+	void 경기_단건조회_API_성공() throws Exception {
+		UUID gameId = UUID.randomUUID();
+		GameResponse response = new GameResponse(
+			gameId,
+			UUID.randomUUID(),
+			UUID.randomUUID(),
+			UUID.randomUUID(),
+			LocalDate.of(2026, 4, 10),
+			LocalTime.of(18, 30),
+			LeagueType.REGULAR,
+			ReservationAvailableStatus.PENDING,
+			LocalDateTime.of(2026, 4, 1, 14, 0),
+			LocalDateTime.of(2026, 4, 10, 17, 0)
+		);
+		given(baseballGameApplicationService.getGame(gameId)).willReturn(response);
+
+		mockMvc.perform(get("/api/v1/games/baseball/{gameId}", gameId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("ok"))
+			.andExpect(jsonPath("$.message").value("성공"))
+			.andExpect(jsonPath("$.data.gameId").value(gameId.toString()));
+	}
+
+	@Test
+	@DisplayName("GET /api/v1/games/baseball/{gameId} - 경기 미존재 시 404 반환")
+	@WithMockUser
+	void 경기_단건조회_API_실패_미존재() throws Exception {
+		UUID gameId = UUID.randomUUID();
+		given(baseballGameApplicationService.getGame(gameId))
+			.willThrow(new CustomException(ErrorCode.GAME_NOT_FOUND));
+
+		mockMvc.perform(get("/api/v1/games/baseball/{gameId}", gameId))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("CLIENT_ERROR"))
+			.andExpect(jsonPath("$.message").value(ErrorCode.GAME_NOT_FOUND.getMessage()));
 	}
 }


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#70 

<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
야구 경기 조회 기능(전체 조회/단건 조회)과 관련 API 테스트 코드 추가

<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
> 경기 전체 조회(getGames) 서비스 로직 구현
> 경기 단건 조회(getGame) 서비스 로직 구현

> 전체 조회 API(GET /api/v1/games/baseball) 추가
 단건 조회 API(GET /api/v1/games/baseball/{gameId}) 추가

> 전체/단건 조회 API 테스트 코드 추가


<br/>