### PR TITLE
[FEAT] 좌석 도메인 엔티티 및 테스트 코드 구현

### DIFF
--- a/core/src/main/java/com/goti/constants/SeatHoldStatus.java
+++ b/core/src/main/java/com/goti/constants/SeatHoldStatus.java
@@ -8,8 +8,7 @@ import lombok.RequiredArgsConstructor;
 public enum SeatHoldStatus {
 
 	HOLDING("점유 중"),
-	RELEASED("점유 해제"),
-	CONVERTED_TO_ORDER("주문으로 전환됨");
+	RELEASED("점유 해제");
 
 	private final String description;
 }

--- a/core/src/main/java/com/goti/constants/SeatHoldStatus.java
+++ b/core/src/main/java/com/goti/constants/SeatHoldStatus.java
@@ -1,0 +1,15 @@
+package com.goti.constants;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SeatHoldStatus {
+
+	HOLDING("점유 중"),
+	RELEASED("점유 해제"),
+	CONVERTED_TO_ORDER("주문으로 전환됨");
+
+	private final String description;
+}

--- a/core/src/main/java/com/goti/constants/SeatStatus.java
+++ b/core/src/main/java/com/goti/constants/SeatStatus.java
@@ -1,0 +1,16 @@
+package com.goti.constants;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SeatStatus {
+
+	AVAILABLE("사용 가능"),
+	HELD("임시 점유"),
+	SOLD("판매 완료"),
+	BLOCKED("사용 불가");
+
+	private final String description;
+}

--- a/core/src/main/java/com/goti/domain/entity/seat/GameSeatInventoryEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/seat/GameSeatInventoryEntity.java
@@ -1,0 +1,104 @@
+package com.goti.domain.entity.seat;
+
+import com.goti.domain.base.ModificationTimestampEntity;
+import com.goti.global.validation.Preconditions;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+import static lombok.AccessLevel.*;
+
+@Getter
+@Entity
+@Table(
+	name = "game_seat_inventories",
+	uniqueConstraints = {
+		@UniqueConstraint(name = "uk_game_grade", columnNames = {"game_id", "seat_grade_id"})
+	},
+	indexes = {
+		@Index(name = "idx_game", columnList = "game_id")
+	}
+)
+@NoArgsConstructor(access = PROTECTED)
+public class GameSeatInventoryEntity extends ModificationTimestampEntity {
+
+	@Column(nullable = false)
+	private UUID gameId;
+
+	@Column(nullable = false)
+	private UUID seatGradeId;
+
+	@Column(nullable = false)
+	private Integer totalCount;
+
+	@Column(nullable = false)
+	private Integer availableCount;
+
+	@Column(nullable = false)
+	private Integer heldCount;
+
+	@Column(nullable = false)
+	private Integer soldCount;
+
+	@Column(nullable = false)
+	private Integer blockedCount;
+
+	private GameSeatInventoryEntity(
+		UUID gameId,
+		UUID seatGradeId,
+		Integer totalCount,
+		Integer availableCount
+	) {
+		this.gameId = gameId;
+		this.seatGradeId = seatGradeId;
+		this.totalCount = totalCount;
+		this.availableCount = availableCount;
+		this.heldCount = 0;
+		this.soldCount = 0;
+		this.blockedCount = 0;
+	}
+
+	public static GameSeatInventoryEntity create(
+		UUID gameId,
+		UUID seatGradeId,
+		Integer totalCount,
+		Integer availableCount
+	) {
+		validate(gameId, seatGradeId, totalCount, availableCount);
+		return new GameSeatInventoryEntity(gameId, seatGradeId, totalCount, availableCount);
+	}
+
+	private static void validate(
+		UUID gameId,
+		UUID seatGradeId,
+		Integer totalCount,
+		Integer availableCount
+	) {
+		Preconditions.domainValidate(
+			gameId != null,
+			"경기 ID는 필수입니다."
+		);
+		Preconditions.domainValidate(
+			seatGradeId != null,
+			"좌석 등급 ID는 필수입니다."
+		);
+		Preconditions.domainValidate(
+			totalCount != null && totalCount >= 0,
+			"전체 좌석 수는 0 이상이어야 합니다."
+		);
+		Preconditions.domainValidate(
+			availableCount != null && availableCount >= 0,
+			"잔여 좌석 수는 0 이상이어야 합니다."
+		);
+		Preconditions.domainValidate(
+			availableCount <= totalCount,
+			"잔여 좌석 수는 전체 좌석 수보다 클 수 없습니다."
+		);
+	}
+}

--- a/core/src/main/java/com/goti/domain/entity/seat/SeatEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/seat/SeatEntity.java
@@ -1,0 +1,69 @@
+package com.goti.domain.entity.seat;
+
+import com.goti.domain.base.ModificationTimestampEntity;
+import com.goti.global.validation.Preconditions;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
+
+import static lombok.AccessLevel.*;
+
+@Getter
+@Entity
+@Table(name = "seats")
+@NoArgsConstructor(access = PROTECTED)
+public class SeatEntity extends ModificationTimestampEntity {
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "section_id", nullable = false)
+	private SeatSectionEntity seatSection;
+
+	@Column(name = "row_name", nullable = false)
+	private String rowName;
+
+	@Column(name = "seat_num", nullable = false)
+	private Integer seatNum;
+
+	@Column(name = "is_available", nullable = false)
+	private boolean available;
+
+	private SeatEntity(
+		SeatSectionEntity seatSection,
+		String rowName,
+		Integer seatNum,
+		boolean available
+	) {
+		this.seatSection = seatSection;
+		this.rowName = rowName;
+		this.seatNum = seatNum;
+		this.available = available;
+	}
+
+	public static SeatEntity create(
+		SeatSectionEntity seatSection,
+		String rowName,
+		Integer seatNum
+	) {
+		validate(rowName, seatNum);
+		return new SeatEntity(seatSection, rowName, seatNum, true);
+	}
+
+	private static void validate(
+		String rowName,
+		Integer seatNum
+	) {
+		Preconditions.domainValidate(
+			StringUtils.hasText(rowName),
+			"행 번호는 비어 있을 수 없습니다."
+		);
+		Preconditions.domainValidate(
+			seatNum != null && seatNum > 0,
+			"좌석 번호는 0보다 커야 합니다."
+		);
+	}
+}

--- a/core/src/main/java/com/goti/domain/entity/seat/SeatEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/seat/SeatEntity.java
@@ -35,13 +35,12 @@ public class SeatEntity extends ModificationTimestampEntity {
 	private SeatEntity(
 		SeatSectionEntity seatSection,
 		String rowName,
-		Integer seatNum,
-		boolean available
+		Integer seatNum
 	) {
 		this.seatSection = seatSection;
 		this.rowName = rowName;
 		this.seatNum = seatNum;
-		this.available = available;
+		this.available = true;
 	}
 
 	public static SeatEntity create(
@@ -50,7 +49,7 @@ public class SeatEntity extends ModificationTimestampEntity {
 		Integer seatNum
 	) {
 		validate(rowName, seatNum);
-		return new SeatEntity(seatSection, rowName, seatNum, true);
+		return new SeatEntity(seatSection, rowName, seatNum);
 	}
 
 	private static void validate(

--- a/core/src/main/java/com/goti/domain/entity/seat/SeatGradeEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/seat/SeatGradeEntity.java
@@ -1,0 +1,65 @@
+package com.goti.domain.entity.seat;
+
+import com.goti.domain.base.ModificationTimestampEntity;
+import com.goti.global.validation.Preconditions;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import org.springframework.util.StringUtils;
+
+import java.util.UUID;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.*;
+
+@Getter
+@Entity
+@Table(name = "seat_grades")
+@NoArgsConstructor(access = PROTECTED)
+public class SeatGradeEntity extends ModificationTimestampEntity {
+	@Column(nullable = false)
+	private UUID stadiumId;
+
+	@Column(nullable = false)
+	private String name;
+
+	@Column
+	private String displayColorHex;
+
+	private SeatGradeEntity(
+		UUID stadiumId,
+		String name,
+		String displayColorHex
+	) {
+		this.stadiumId = stadiumId;
+		this.name = name;
+		this.displayColorHex = displayColorHex;
+	}
+
+	public static SeatGradeEntity create(
+		UUID stadiumId,
+		String name,
+		String displayColorHex
+	) {
+		validate(stadiumId, name);
+		return new SeatGradeEntity(stadiumId, name, displayColorHex);
+	}
+
+	private static void validate(
+		UUID stadiumId,
+		String name
+	) {
+		Preconditions.domainValidate(
+			stadiumId != null,
+			"구장 ID는 필수입니다."
+		);
+
+		Preconditions.domainValidate(
+			StringUtils.hasText(name),
+			"좌석 등급명은 비어 있을 수 없습니다."
+		);
+	}
+}

--- a/core/src/main/java/com/goti/domain/entity/seat/SeatHoldEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/seat/SeatHoldEntity.java
@@ -101,6 +101,7 @@ public class SeatHoldEntity extends ModificationTimestampEntity {
 		);
 		Preconditions.domainValidate(
 			expiredAt != null,
-			"만료 시각은 필수입니다.");
+			"만료 시각은 필수입니다."
+		);
 	}
 }

--- a/core/src/main/java/com/goti/domain/entity/seat/SeatHoldEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/seat/SeatHoldEntity.java
@@ -1,0 +1,106 @@
+package com.goti.domain.entity.seat;
+
+import static lombok.AccessLevel.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.springframework.util.StringUtils;
+
+import com.goti.constants.SeatHoldStatus;
+import com.goti.domain.base.ModificationTimestampEntity;
+import com.goti.domain.entity.game.BaseballGameEntity;
+import com.goti.global.validation.Preconditions;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+	name = "seat_holds",
+	indexes = {
+		@Index(name = "idx_user_status", columnList = "user_id, status"),
+		@Index(name = "idx_expires", columnList = "status, expired_at")
+	}
+)
+@NoArgsConstructor(access = PROTECTED)
+public class SeatHoldEntity extends ModificationTimestampEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "seat_id", nullable = false)
+	private SeatEntity seat;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "game_id", nullable = false)
+	private BaseballGameEntity game;
+
+	@Column(nullable = false)
+	private UUID userId;
+
+	@Column(nullable = false)
+	private String queueTokenJti;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private SeatHoldStatus status;
+
+	@Column(nullable = false)
+	private Instant expiredAt;
+
+	private Instant releasedAt;
+
+	private SeatHoldEntity(
+		SeatEntity seat,
+		BaseballGameEntity game,
+		UUID userId,
+		String queueTokenJti,
+		Instant expiredAt
+	) {
+		this.seat = seat;
+		this.game = game;
+		this.userId = userId;
+		this.queueTokenJti = queueTokenJti;
+		this.status = SeatHoldStatus.HOLDING;
+		this.expiredAt = expiredAt;
+		this.releasedAt = null;
+	}
+
+	public static SeatHoldEntity create(
+		SeatEntity seat,
+		BaseballGameEntity game,
+		UUID userId,
+		String queueTokenJti,
+		Instant expiredAt
+	) {
+		validate(userId, queueTokenJti, expiredAt);
+		return new SeatHoldEntity(seat, game, userId, queueTokenJti, expiredAt);
+	}
+
+	private static void validate(
+		UUID userId,
+		String queueTokenJti,
+		Instant expiredAt
+	) {
+		Preconditions.domainValidate(
+			userId != null,
+			"유저 ID는 필수입니다."
+		);
+		Preconditions.domainValidate(
+			StringUtils.hasText(queueTokenJti),
+			"큐 토큰 식별자는 비어 있을 수 없습니다."
+		);
+		Preconditions.domainValidate(
+			expiredAt != null,
+			"만료 시각은 필수입니다.");
+	}
+}

--- a/core/src/main/java/com/goti/domain/entity/seat/SeatSectionEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/seat/SeatSectionEntity.java
@@ -1,0 +1,79 @@
+package com.goti.domain.entity.seat;
+
+import com.goti.domain.base.CreationTimestampEntity;
+import com.goti.domain.base.ModificationTimestampEntity;
+import com.goti.global.validation.Preconditions;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
+
+import java.util.UUID;
+
+import static lombok.AccessLevel.*;
+
+@Getter
+@Entity
+@Table(name = "seat_sections")
+@NoArgsConstructor(access = PROTECTED)
+public class SeatSectionEntity extends ModificationTimestampEntity {
+
+	@JoinColumn(name = "grade_id", nullable = false)
+	@ManyToOne(fetch = FetchType.LAZY)
+	private SeatGradeEntity seatGrade;
+
+	@Column(nullable = false)
+	private UUID stadiumId;
+
+	@Column(nullable = false, length = 255)
+	private String sectionCode;
+
+	@Column(nullable = false)
+	private Integer capacity;
+
+	private SeatSectionEntity(
+		SeatGradeEntity seatGrade,
+		UUID stadiumId,
+		String sectionCode,
+		Integer capacity
+	) {
+		this.seatGrade = seatGrade;
+		this.stadiumId = stadiumId;
+		this.sectionCode = sectionCode;
+		this.capacity = capacity;
+	}
+
+	public static SeatSectionEntity create(
+		SeatGradeEntity seatGrade,
+		UUID stadiumId,
+		String sectionCode,
+		Integer capacity
+	) {
+		validate(stadiumId, sectionCode, capacity);
+		return new SeatSectionEntity(seatGrade, stadiumId, sectionCode, capacity);
+	}
+
+	private static void validate(
+		UUID stadiumId,
+		String sectionCode,
+		Integer capacity
+	) {
+		Preconditions.domainValidate(
+			stadiumId != null,
+			"구장 ID는 필수입니다."
+		);
+		Preconditions.domainValidate(
+			StringUtils.hasText(sectionCode),
+			"구역 코드는 비어 있을 수 없습니다."
+		);
+		Preconditions.domainValidate(
+			capacity != null && capacity > 0,
+			"수용 인원은 0보다 커야 합니다."
+		);
+	}
+}

--- a/core/src/main/java/com/goti/domain/entity/seat/SeatSectionEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/seat/SeatSectionEntity.java
@@ -30,7 +30,7 @@ public class SeatSectionEntity extends ModificationTimestampEntity {
 	@Column(nullable = false)
 	private UUID stadiumId;
 
-	@Column(nullable = false, length = 255)
+	@Column(nullable = false)
 	private String sectionCode;
 
 	@Column(nullable = false)

--- a/core/src/main/java/com/goti/domain/entity/seat/SeatStatusEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/seat/SeatStatusEntity.java
@@ -1,0 +1,63 @@
+package com.goti.domain.entity.seat;
+
+import static lombok.AccessLevel.*;
+
+import com.goti.constants.SeatStatus;
+import com.goti.domain.base.ModificationTimestampEntity;
+import com.goti.domain.entity.game.BaseballGameEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+	name = "seat_statuses",
+	uniqueConstraints = {
+		@UniqueConstraint(name = "uk_game_seat", columnNames = {"game_id", "seat_id"})
+	},
+	indexes = {
+		@Index(name = "idx_game_status", columnList = "game_id, status")
+	}
+)
+@NoArgsConstructor(access = PROTECTED)
+public class SeatStatusEntity extends ModificationTimestampEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "game_id", nullable = false)
+	private BaseballGameEntity game;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "seat_id", nullable = false)
+	private SeatEntity seat;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private SeatStatus status;
+
+	private SeatStatusEntity(
+		BaseballGameEntity game,
+		SeatEntity seat
+	) {
+		this.game = game;
+		this.seat = seat;
+		this.status = SeatStatus.AVAILABLE;
+	}
+
+	public static SeatStatusEntity create(
+		BaseballGameEntity game,
+		SeatEntity seat
+	) {
+		return new SeatStatusEntity(game, seat);
+	}
+}

--- a/core/src/test/java/seat/GameSeatInventoryEntityTest.java
+++ b/core/src/test/java/seat/GameSeatInventoryEntityTest.java
@@ -1,0 +1,153 @@
+package seat;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.goti.domain.entity.seat.GameSeatInventoryEntity;
+import com.goti.exception.FieldValidationException;
+
+@ActiveProfiles("test")
+public class GameSeatInventoryEntityTest {
+
+	UUID gameId;
+	UUID seatGradeId;
+	Integer totalCount;
+	Integer availableCount;
+
+	@BeforeEach
+	void setup() {
+		gameId = UUID.randomUUID();
+		seatGradeId = UUID.randomUUID();
+		totalCount = 100;
+		availableCount = 100;
+	}
+
+	@Test
+	void 좌석재고요약_생성_성공() {
+		GameSeatInventoryEntity inventory = GameSeatInventoryEntity.create(
+			gameId,
+			seatGradeId,
+			totalCount,
+			availableCount
+		);
+
+		assertNotNull(inventory);
+		assertThat(inventory.getGameId()).isEqualTo(gameId);
+		assertThat(inventory.getSeatGradeId()).isEqualTo(seatGradeId);
+		assertThat(inventory.getTotalCount()).isEqualTo(totalCount);
+		assertThat(inventory.getAvailableCount()).isEqualTo(availableCount);
+		assertThat(inventory.getHeldCount()).isZero();
+		assertThat(inventory.getSoldCount()).isZero();
+		assertThat(inventory.getBlockedCount()).isZero();
+	}
+
+	@Test
+	void 좌석재고요약_생성_성공_경계값_0() {
+		GameSeatInventoryEntity inventory = GameSeatInventoryEntity.create(
+			gameId,
+			seatGradeId,
+			0,
+			0
+		);
+
+		assertThat(inventory.getTotalCount()).isZero();
+		assertThat(inventory.getAvailableCount()).isZero();
+	}
+
+	@Test
+	void 좌석재고요약_생성_실패_경기ID_null() {
+		assertThatThrownBy(
+			() -> GameSeatInventoryEntity.create(
+				null,
+				seatGradeId,
+				totalCount,
+				availableCount
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("경기 ID는 필수입니다.");
+	}
+
+	@Test
+	void 좌석재고요약_생성_실패_좌석등급ID_null() {
+		assertThatThrownBy(
+			() -> GameSeatInventoryEntity.create(
+				gameId,
+				null,
+				totalCount,
+				availableCount
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("좌석 등급 ID는 필수입니다.");
+	}
+
+	@Test
+	void 좌석재고요약_생성_실패_전체좌석수_null() {
+		assertThatThrownBy(
+			() -> GameSeatInventoryEntity.create(
+				gameId,
+				seatGradeId,
+				null,
+				availableCount
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("전체 좌석 수는 0 이상이어야 합니다.");
+	}
+
+	@Test
+	void 좌석재고요약_생성_실패_전체좌석수_음수() {
+		assertThatThrownBy(
+			() -> GameSeatInventoryEntity.create(
+				gameId,
+				seatGradeId,
+				-1,
+				availableCount
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("전체 좌석 수는 0 이상이어야 합니다.");
+	}
+
+	@Test
+	void 좌석재고요약_생성_실패_잔여좌석수_null() {
+		assertThatThrownBy(
+			() -> GameSeatInventoryEntity.create(
+				gameId,
+				seatGradeId,
+				totalCount,
+				null
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("잔여 좌석 수는 0 이상이어야 합니다.");
+	}
+
+	@Test
+	void 좌석재고요약_생성_실패_잔여좌석수_음수() {
+		assertThatThrownBy(
+			() -> GameSeatInventoryEntity.create(
+				gameId,
+				seatGradeId,
+				totalCount,
+				-1
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("잔여 좌석 수는 0 이상이어야 합니다.");
+	}
+
+	@Test
+	void 좌석재고요약_생성_실패_잔여좌석수가_전체보다_큼() {
+		assertThatThrownBy(
+			() -> GameSeatInventoryEntity.create(
+				gameId,
+				seatGradeId,
+				100,
+				101
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("잔여 좌석 수는 전체 좌석 수보다 클 수 없습니다.");
+	}
+}

--- a/core/src/test/java/seat/SeatEntityTest.java
+++ b/core/src/test/java/seat/SeatEntityTest.java
@@ -1,0 +1,118 @@
+package seat;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.goti.domain.entity.seat.SeatEntity;
+import com.goti.domain.entity.seat.SeatGradeEntity;
+import com.goti.domain.entity.seat.SeatSectionEntity;
+import com.goti.exception.FieldValidationException;
+
+@ActiveProfiles("test")
+public class SeatEntityTest {
+
+	SeatSectionEntity seatSection;
+	String rowName;
+	Integer seatNum;
+
+	@BeforeEach
+	void setup() {
+		SeatGradeEntity seatGrade = SeatGradeEntity.create(UUID.randomUUID(), "VIP", "#FFAA00");
+		seatSection = SeatSectionEntity.create(seatGrade, UUID.randomUUID(), "101", 120);
+		rowName = "A";
+		seatNum = 1;
+	}
+
+	@Test
+	void 좌석_생성_성공() {
+		SeatEntity seat = SeatEntity.create(
+			seatSection,
+			rowName,
+			seatNum
+		);
+
+		assertNotNull(seat);
+		assertThat(seat.getSeatSection()).isEqualTo(seatSection);
+		assertThat(seat.getRowName()).isEqualTo(rowName);
+		assertThat(seat.getSeatNum()).isEqualTo(seatNum);
+		assertThat(seat.isAvailable()).isTrue();
+	}
+
+	@Test
+	void 좌석_생성_실패_행번호_null() {
+		assertThatThrownBy(
+			() -> SeatEntity.create(
+				seatSection,
+				null,
+				seatNum
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("행 번호는 비어 있을 수 없습니다.");
+	}
+
+	@Test
+	void 좌석_생성_실패_행번호_빈문자열() {
+		assertThatThrownBy(
+			() -> SeatEntity.create(
+				seatSection,
+				"",
+				seatNum
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("행 번호는 비어 있을 수 없습니다.");
+	}
+
+	@Test
+	void 좌석_생성_실패_행번호_공백() {
+		assertThatThrownBy(
+			() -> SeatEntity.create(
+				seatSection,
+				"   ",
+				seatNum
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("행 번호는 비어 있을 수 없습니다.");
+	}
+
+	@Test
+	void 좌석_생성_실패_좌석번호_null() {
+		assertThatThrownBy(
+			() -> SeatEntity.create(
+				seatSection,
+				rowName,
+				null
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("좌석 번호는 0보다 커야 합니다.");
+	}
+
+	@Test
+	void 좌석_생성_실패_좌석번호_0() {
+		assertThatThrownBy(
+			() -> SeatEntity.create(
+				seatSection,
+				rowName,
+				0
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("좌석 번호는 0보다 커야 합니다.");
+	}
+
+	@Test
+	void 좌석_생성_실패_좌석번호_음수() {
+		assertThatThrownBy(
+			() -> SeatEntity.create(
+				seatSection,
+				rowName,
+				-1
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("좌석 번호는 0보다 커야 합니다.");
+	}
+}

--- a/core/src/test/java/seat/SeatGradeEntityTest.java
+++ b/core/src/test/java/seat/SeatGradeEntityTest.java
@@ -1,0 +1,109 @@
+package seat;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.goti.domain.entity.seat.SeatGradeEntity;
+import com.goti.exception.FieldValidationException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@ActiveProfiles("test")
+public class SeatGradeEntityTest {
+
+	UUID stadiumId;
+	String name;
+	String displayColorHex;
+
+	@BeforeEach
+	void setup() {
+		stadiumId = UUID.randomUUID();
+		name = "VIP";
+		displayColorHex = "#FFAA00";
+	}
+
+	@Test
+	void 좌석등급_생성_성공() {
+		SeatGradeEntity seatGrade = SeatGradeEntity.create(
+			stadiumId,
+			name,
+			displayColorHex
+		);
+
+		assertNotNull(seatGrade);
+		assertThat(seatGrade.getStadiumId()).isEqualTo(stadiumId);
+		assertThat(seatGrade.getName()).isEqualTo(name);
+		assertThat(seatGrade.getDisplayColorHex()).isEqualTo(displayColorHex);
+
+		log.info("seat grade name: {}", seatGrade.getName());
+		log.info("seat grade color: {}", seatGrade.getDisplayColorHex());
+	}
+
+	@Test
+	void 좌석등급_생성_성공_표시색상_null() {
+		SeatGradeEntity seatGrade = SeatGradeEntity.create(
+			stadiumId,
+			name,
+			null
+		);
+
+		assertThat(seatGrade.getStadiumId()).isEqualTo(stadiumId);
+		assertThat(seatGrade.getName()).isEqualTo(name);
+		assertThat(seatGrade.getDisplayColorHex()).isNull();
+	}
+
+	@Test
+	void 좌석등급_생성_실패_구장_ID_null() {
+		assertThatThrownBy(
+			() -> SeatGradeEntity.create(
+				null,
+				name,
+				displayColorHex
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("구장 ID는 필수입니다.");
+	}
+
+	@Test
+	void 좌석등급_생성_실패_등급명_null() {
+		assertThatThrownBy(
+			() -> SeatGradeEntity.create(
+				stadiumId,
+				null,
+				displayColorHex
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("좌석 등급명은 비어 있을 수 없습니다.");
+	}
+
+	@Test
+	void 좌석등급_생성_실패_등급명_빈문자열() {
+		assertThatThrownBy(
+			() -> SeatGradeEntity.create(
+				stadiumId,
+				"",
+				displayColorHex
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("좌석 등급명은 비어 있을 수 없습니다.");
+	}
+
+	@Test
+	void 좌석등급_생성_실패_등급명_공백() {
+		assertThatThrownBy(
+			() -> SeatGradeEntity.create(
+				stadiumId,
+				"   ",
+				displayColorHex
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("좌석 등급명은 비어 있을 수 없습니다.");
+	}
+}

--- a/core/src/test/java/seat/SeatHoldEntityTest.java
+++ b/core/src/test/java/seat/SeatHoldEntityTest.java
@@ -1,0 +1,143 @@
+package seat;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.goti.constants.SeatHoldStatus;
+import com.goti.domain.entity.game.BaseballGameEntity;
+import com.goti.domain.entity.seat.SeatEntity;
+import com.goti.domain.entity.seat.SeatGradeEntity;
+import com.goti.domain.entity.seat.SeatHoldEntity;
+import com.goti.domain.entity.seat.SeatSectionEntity;
+import com.goti.exception.FieldValidationException;
+
+@ActiveProfiles("test")
+public class SeatHoldEntityTest {
+
+	SeatEntity seat;
+	BaseballGameEntity game;
+	UUID userId;
+	String queueTokenJti;
+	Instant expiredAt;
+
+	@BeforeEach
+	void setup() {
+		SeatGradeEntity seatGrade = SeatGradeEntity.create(UUID.randomUUID(), "VIP", "#FFAA00");
+		SeatSectionEntity seatSection = SeatSectionEntity.create(seatGrade, UUID.randomUUID(), "101", 120);
+		seat = SeatEntity.create(seatSection, "A", 1);
+
+		game = BaseballGameEntity.create(
+			UUID.randomUUID(),
+			UUID.randomUUID(),
+			UUID.randomUUID(),
+			LocalDate.of(2026, 4, 1),
+			LocalTime.of(18, 30),
+			LocalDateTime.of(2026, 3, 25, 14, 0),
+			LocalDateTime.of(2026, 4, 1, 17, 0)
+		);
+
+		userId = UUID.randomUUID();
+		queueTokenJti = "queue-token-jti-123";
+		expiredAt = Instant.now().plusSeconds(600);
+	}
+
+	@Test
+	void 좌석임시점유_생성_성공() {
+		SeatHoldEntity seatHold = SeatHoldEntity.create(
+			seat,
+			game,
+			userId,
+			queueTokenJti,
+			expiredAt
+		);
+
+		assertNotNull(seatHold);
+		assertThat(seatHold.getSeat()).isEqualTo(seat);
+		assertThat(seatHold.getGame()).isEqualTo(game);
+		assertThat(seatHold.getUserId()).isEqualTo(userId);
+		assertThat(seatHold.getQueueTokenJti()).isEqualTo(queueTokenJti);
+		assertThat(seatHold.getStatus()).isEqualTo(SeatHoldStatus.HOLDING);
+		assertThat(seatHold.getExpiredAt()).isEqualTo(expiredAt);
+		assertThat(seatHold.getReleasedAt()).isNull();
+	}
+
+	@Test
+	void 좌석임시점유_생성_실패_유저ID_null() {
+		assertThatThrownBy(
+			() -> SeatHoldEntity.create(
+				seat,
+				game,
+				null,
+				queueTokenJti,
+				expiredAt
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("유저 ID는 필수입니다.");
+	}
+
+	@Test
+	void 좌석임시점유_생성_실패_큐토큰_null() {
+		assertThatThrownBy(
+			() -> SeatHoldEntity.create(
+				seat,
+				game,
+				userId,
+				null,
+				expiredAt
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("큐 토큰 식별자는 비어 있을 수 없습니다.");
+	}
+
+	@Test
+	void 좌석임시점유_생성_실패_큐토큰_빈문자열() {
+		assertThatThrownBy(
+			() -> SeatHoldEntity.create(
+				seat,
+				game,
+				userId,
+				"",
+				expiredAt
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("큐 토큰 식별자는 비어 있을 수 없습니다.");
+	}
+
+	@Test
+	void 좌석임시점유_생성_실패_큐토큰_공백() {
+		assertThatThrownBy(
+			() -> SeatHoldEntity.create(
+				seat,
+				game,
+				userId,
+				"   ",
+				expiredAt
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("큐 토큰 식별자는 비어 있을 수 없습니다.");
+	}
+
+	@Test
+	void 좌석임시점유_생성_실패_만료시각_null() {
+		assertThatThrownBy(
+			() -> SeatHoldEntity.create(
+				seat,
+				game,
+				userId,
+				queueTokenJti,
+				null
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("만료 시각은 필수입니다.");
+	}
+}

--- a/core/src/test/java/seat/SeatSectionEntityTest.java
+++ b/core/src/test/java/seat/SeatSectionEntityTest.java
@@ -1,0 +1,138 @@
+package seat;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.goti.domain.entity.seat.SeatGradeEntity;
+import com.goti.domain.entity.seat.SeatSectionEntity;
+import com.goti.exception.FieldValidationException;
+
+@ActiveProfiles("test")
+public class SeatSectionEntityTest {
+
+	SeatGradeEntity seatGrade;
+	UUID stadiumId;
+	String sectionCode;
+	Integer capacity;
+
+	@BeforeEach
+	void setup() {
+		seatGrade = SeatGradeEntity.create(UUID.randomUUID(), "VIP", "#FFAA00");
+		stadiumId = UUID.randomUUID();
+		sectionCode = "101";
+		capacity = 120;
+	}
+
+	@Test
+	void 좌석구역_생성_성공() {
+		SeatSectionEntity seatSection = SeatSectionEntity.create(
+			seatGrade,
+			stadiumId,
+			sectionCode,
+			capacity
+		);
+
+		assertNotNull(seatSection);
+		assertThat(seatSection.getSeatGrade()).isEqualTo(seatGrade);
+		assertThat(seatSection.getStadiumId()).isEqualTo(stadiumId);
+		assertThat(seatSection.getSectionCode()).isEqualTo(sectionCode);
+		assertThat(seatSection.getCapacity()).isEqualTo(capacity);
+	}
+
+	@Test
+	void 좌석구역_생성_실패_구장_ID_null() {
+		assertThatThrownBy(
+			() -> SeatSectionEntity.create(
+				seatGrade,
+				null,
+				sectionCode,
+				capacity
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("구장 ID는 필수입니다.");
+	}
+
+	@Test
+	void 좌석구역_생성_실패_구역코드_null() {
+		assertThatThrownBy(
+			() -> SeatSectionEntity.create(
+				seatGrade,
+				stadiumId,
+				null,
+				capacity
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("구역 코드는 비어 있을 수 없습니다.");
+	}
+
+	@Test
+	void 좌석구역_생성_실패_구역코드_빈문자열() {
+		assertThatThrownBy(
+			() -> SeatSectionEntity.create(
+				seatGrade,
+				stadiumId,
+				"",
+				capacity
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("구역 코드는 비어 있을 수 없습니다.");
+	}
+
+	@Test
+	void 좌석구역_생성_실패_구역코드_공백() {
+		assertThatThrownBy(
+			() -> SeatSectionEntity.create(
+				seatGrade,
+				stadiumId,
+				"   ",
+				capacity
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("구역 코드는 비어 있을 수 없습니다.");
+	}
+
+	@Test
+	void 좌석구역_생성_실패_수용인원_null() {
+		assertThatThrownBy(
+			() -> SeatSectionEntity.create(
+				seatGrade,
+				stadiumId,
+				sectionCode,
+				null
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("수용 인원은 0보다 커야 합니다.");
+	}
+
+	@Test
+	void 좌석구역_생성_실패_수용인원_0() {
+		assertThatThrownBy(
+			() -> SeatSectionEntity.create(
+				seatGrade,
+				stadiumId,
+				sectionCode,
+				0
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("수용 인원은 0보다 커야 합니다.");
+	}
+
+	@Test
+	void 좌석구역_생성_실패_수용인원_음수() {
+		assertThatThrownBy(
+			() -> SeatSectionEntity.create(
+				seatGrade,
+				stadiumId,
+				sectionCode,
+				-1
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("수용 인원은 0보다 커야 합니다.");
+	}
+}

--- a/core/src/test/java/seat/SeatStatusEntityTest.java
+++ b/core/src/test/java/seat/SeatStatusEntityTest.java
@@ -1,0 +1,54 @@
+package seat;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.goti.constants.SeatStatus;
+import com.goti.domain.entity.game.BaseballGameEntity;
+import com.goti.domain.entity.seat.SeatEntity;
+import com.goti.domain.entity.seat.SeatGradeEntity;
+import com.goti.domain.entity.seat.SeatSectionEntity;
+import com.goti.domain.entity.seat.SeatStatusEntity;
+
+@ActiveProfiles("test")
+public class SeatStatusEntityTest {
+
+	BaseballGameEntity game;
+	SeatEntity seat;
+
+	@BeforeEach
+	void setup() {
+		game = BaseballGameEntity.create(
+			UUID.randomUUID(),
+			UUID.randomUUID(),
+			UUID.randomUUID(),
+			LocalDate.of(2026, 4, 1),
+			LocalTime.of(18, 30),
+			LocalDateTime.of(2026, 3, 25, 14, 0),
+			LocalDateTime.of(2026, 4, 1, 17, 0)
+		);
+
+		SeatGradeEntity seatGrade = SeatGradeEntity.create(UUID.randomUUID(), "VIP", "#FFAA00");
+		SeatSectionEntity seatSection = SeatSectionEntity.create(seatGrade, UUID.randomUUID(), "101", 120);
+		seat = SeatEntity.create(seatSection, "A", 1);
+	}
+
+	@Test
+	void 좌석상태_생성_성공() {
+		SeatStatusEntity seatStatus = SeatStatusEntity.create(game, seat);
+
+		assertNotNull(seatStatus);
+		assertThat(seatStatus.getGame()).isEqualTo(game);
+		assertThat(seatStatus.getSeat()).isEqualTo(seat);
+		assertThat(seatStatus.getStatus()).isEqualTo(SeatStatus.AVAILABLE);
+	}
+}


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#79 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
좌석 도메인 엔티티 및 테스트 코드 구현
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
> SeatGradeEntity 작성 (seat_grades)
> SeatSectionEntity 작성 (seat_sections)
> SeatEntity 작성 (seats)
> SeatStatusEntity 작성 (seat_statuses)
> SeatHoldEntity 작성 (seat_holds)
> GameSeatInventoryEntity 작성 (game_seat_inventories)

> 좌석 상태 enum 추가
>> SeatStatus, SeatHoldStatus

> 도메인 테스트 코드 추가

- 파일 변경이 많아서 커밋 단위로 봐주시면 감사하겠습니다!
<br/>