### PR TITLE
[CHORE] OTel 설정 환경변수 기반 전환

### DIFF
--- a/api/src/main/resources/application-prod.yml
+++ b/api/src/main/resources/application-prod.yml
@@ -20,11 +20,3 @@ management:
   tracing:
     sampling:
       probability: 0.1
-
-otel:
-  exporter:
-    otlp:
-      enabled: true
-      endpoint: http://otel-collector.monitoring:4318
-  sdk:
-    disabled: false

--- a/api/src/main/resources/application-prod.yml
+++ b/api/src/main/resources/application-prod.yml
@@ -20,3 +20,11 @@ management:
   tracing:
     sampling:
       probability: 0.1
+
+otel:
+  exporter:
+    otlp:
+      enabled: ${OTEL_EXPORTER_ENABLED:true}
+      endpoint: ${OTEL_EXPORTER_ENDPOINT:http://alloy.monitoring.svc:4318}
+  sdk:
+    disabled: ${OTEL_SDK_DISABLED:false}

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -57,9 +57,10 @@ management:
 otel:
   exporter:
     otlp:
-      enabled: false
+      enabled: ${OTEL_EXPORTER_ENABLED:false}
+      endpoint: ${OTEL_EXPORTER_ENDPOINT:http://localhost:4318}
   sdk:
-    disabled: true
+    disabled: ${OTEL_SDK_DISABLED:true}
 
 logging:
   pattern:


### PR DESCRIPTION
## #️⃣ 관련 이슈
- close #86
<br/>

## 🔎 개요
OTel 설정을 하드코딩에서 환경변수 플레이스홀더로 전환하여,
로컬 개발 환경에서는 OTel OFF, K8s 배포 환경에서는 환경변수 주입만으로 OTel ON이 되도록 개선합니다.

<br/>


## 📋 작업 내용
### application.yml
- `otel.exporter.otlp.enabled`: `false` → `${OTEL_EXPORTER_ENABLED:false}`
- `otel.exporter.otlp.endpoint`: 신규 추가
`${OTEL_EXPORTER_ENDPOINT:http://localhost:4318}`
- `otel.sdk.disabled`: `true` → `${OTEL_SDK_DISABLED:true}`
- 기본값이 OFF이므로 로컬 개발 시 환경변수 설정 불필요

### application-prod.yml
- `otel` 블록 제거 (환경변수로 통합 제어, 프로파일 하드코딩 제거)

### 환경별 동작
| 환경 | OTel | 설정 방법 |
|------|------|----------|
| 로컬 PC | OFF | 기본값 (환경변수 불필요) |
| Kind dev | ON | K8s env vars 주입 |
| EKS prod | ON | K8s env vars 주입 |


<br/>