### PR TITLE
[BUG] JWT_SOCIAL_VERIFY_TIME 환경변수 기본값 누락 수정

### DIFF
--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -40,7 +40,7 @@ jwt:
   secret: ${JWT_SECRET_KEY}
   access-valid-time: ${JWT_ACCESS_TIME}
   refresh-valid-time: ${JWT_REFRESH_TIME}
-  social-verify-valid-time: ${JWT_SOCIAL_VERIFY_TIME}
+  social-verify-valid-time: ${JWT_SOCIAL_VERIFY_TIME:300000}
 
 management:
   endpoints:

--- a/docker/docker-compose.app.yml
+++ b/docker/docker-compose.app.yml
@@ -16,6 +16,7 @@ services:
       JWT_SECRET_KEY: ${JWT_SECRET_KEY:-local-dev-secret-key-minimum-32-chars-long}
       JWT_ACCESS_TIME: ${JWT_ACCESS_TIME:-3600000}
       JWT_REFRESH_TIME: ${JWT_REFRESH_TIME:-604800000}
+      JWT_SOCIAL_VERIFY_TIME: ${JWT_SOCIAL_VERIFY_TIME:-300000}
       KAKAO_CLIENT: ${KAKAO_CLIENT:-not-set}
       KAKAO_SECRET: ${KAKAO_SECRET:-not-set}
       KAKAO_REDIRECT_URI: ${KAKAO_REDIRECT_URI:-http://localhost:8080/callback}


### PR DESCRIPTION
## #️⃣ 관련 이슈
- Closes #95 
<br/>

## 🔎 개요
`JWT_SOCIAL_VERIFY_TIME` 환경변수에 기본값이 없어 `.env` 파일 없이 Docker 기동 시 Spring Boot Duration 파싱 실패로 컨테이너가 반복 재시작되는 버그 수정
<br/>


## 📋 작업 내용
- `docker/docker-compose.app.yml`: `JWT_SOCIAL_VERIFY_TIME` 기본값(300000ms = 5분) 추가
- `api/src/main/resources/application.yml`: Spring property 기본값 추가 (Docker 없이 직접 실행 시에도 동작)

<br/>