### PR TITLE
[FEAT] 구장 생성 서비스 구현 및 테스트 코드 추가

### DIFF
--- a/core/src/main/java/com/goti/domain/entity/stadium/StadiumEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/stadium/StadiumEntity.java
@@ -3,6 +3,7 @@ package com.goti.domain.entity.stadium;
 import static lombok.AccessLevel.*;
 
 import java.math.BigDecimal;
+import java.util.Map;
 
 import jakarta.persistence.Table;
 
@@ -49,7 +50,7 @@ public class StadiumEntity extends ModificationTimestampEntity {
 
 	@JdbcTypeCode(SqlTypes.JSON)
 	@Column(columnDefinition = "jsonb")
-	private String seatMapConfig;
+	private Map<String, Object> seatMapConfig;
 
 	private StadiumEntity(
 		String stadiumName,
@@ -60,7 +61,7 @@ public class StadiumEntity extends ModificationTimestampEntity {
 		BigDecimal latitude,
 		BigDecimal longitude,
 		Integer totalSeats,
-		String seatMapConfig
+		Map<String, Object> seatMapConfig
 	) {
 		this.stadiumName = stadiumName;
 		this.location = location;
@@ -82,7 +83,7 @@ public class StadiumEntity extends ModificationTimestampEntity {
 		BigDecimal latitude,
 		BigDecimal longitude,
 		Integer totalSeats,
-		String seatMapConfig
+		Map<String, Object> seatMapConfig
 	) {
 
 		validate(
@@ -93,7 +94,8 @@ public class StadiumEntity extends ModificationTimestampEntity {
 			roadAddress,
 			latitude,
 			longitude,
-			totalSeats);
+			totalSeats
+		);
 
 		return new StadiumEntity(
 			stadiumName,

--- a/core/src/test/java/stadium/StadiumEntityTest.java
+++ b/core/src/test/java/stadium/StadiumEntityTest.java
@@ -3,6 +3,7 @@ package stadium;
 import static org.assertj.core.api.Assertions.*;
 
 import java.math.BigDecimal;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -318,7 +319,7 @@ public class StadiumEntityTest {
 
 	@Test
 	void 구장_생성_성공_좌석맵_설정_있음() {
-		String seatMapConfig = "{\"sections\": []}";
+		Map<String, Object> seatMapConfig = Map.of("sections", "sectionTest");
 
 		StadiumEntity stadium = StadiumEntity.create(
 			"광주기아챔피언스필드",

--- a/stadium/build.gradle
+++ b/stadium/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
-
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/stadium/build.gradle
+++ b/stadium/build.gradle
@@ -15,6 +15,9 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'
 
+    /* Swagger */
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'
+
 
     implementation project(':core')
     implementation project(':common')

--- a/stadium/src/main/java/com/goti/dto/request/StadiumCreateRequest.java
+++ b/stadium/src/main/java/com/goti/dto/request/StadiumCreateRequest.java
@@ -1,0 +1,47 @@
+package com.goti.dto.request;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+public record StadiumCreateRequest(
+
+	@NotBlank(message = "구장명은 필수 항목입니다.")
+	String stadium_name,
+
+	@NotBlank(message = "구장 지역명은 필수 항목입니다.")
+	String location,
+
+	@NotBlank(message = "시/도 값은 필수 항목입니다.")
+	String city,
+
+	@NotBlank(message = "시/군/구 값은 필수 항목입니다.")
+	String district,
+
+	@NotBlank(message = "도로명주소는 필수 항목입니다.")
+	String roadAddress,
+
+	@NotNull(message = "구장의 위도 값은 필수 항목입니다.")
+	@DecimalMin(value = "-90.0", message = "위도 값은 -90에서 90 사이여야 합니다")
+	@DecimalMax(value = "90.0", message = "위도 값은 -90에서 90 사이여야 합니다")
+	BigDecimal latitude,
+
+	@NotNull(message = "구장의 경도 값은 필수 항목입니다.")
+	@DecimalMin(value = "-180.0", message = "경도 값은 -180에서 180 사이여야 합니다.")
+	@DecimalMax(value = "180.0", message = "경도 값은 -180에서 180 사이여야 합니다.")
+	BigDecimal longitude,
+
+	@NotNull(message = "구장 좌석수는 필수 항목입니다.")
+	@Positive(message = "구장 좌석수는 0보다 커야 합니다.")
+	Integer totalSeats,
+
+	@NotNull(message = "구장 좌석 배치 설정 정보는 필수 항목입니다.")
+	Map<String, Object> seatMapConfig
+
+) {
+}

--- a/stadium/src/main/java/com/goti/dto/request/StadiumCreateRequest.java
+++ b/stadium/src/main/java/com/goti/dto/request/StadiumCreateRequest.java
@@ -12,7 +12,7 @@ import java.util.Map;
 public record StadiumCreateRequest(
 
 	@NotBlank(message = "구장명은 필수 항목입니다.")
-	String stadium_name,
+	String stadiumName,
 
 	@NotBlank(message = "구장 지역명은 필수 항목입니다.")
 	String location,

--- a/stadium/src/main/java/com/goti/dto/request/StadiumCreateRequest.java
+++ b/stadium/src/main/java/com/goti/dto/request/StadiumCreateRequest.java
@@ -1,5 +1,6 @@
 package com.goti.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
@@ -11,35 +12,44 @@ import java.util.Map;
 
 public record StadiumCreateRequest(
 
+	@Schema(description = "구장명", example = "대구삼성라이온즈파크")
 	@NotBlank(message = "구장명은 필수 항목입니다.")
 	String stadiumName,
 
+	@Schema(description = "구장 지역명", example = "대구")
 	@NotBlank(message = "구장 지역명은 필수 항목입니다.")
 	String location,
 
+	@Schema(description = "시/도", example = "대구광역시")
 	@NotBlank(message = "시/도 값은 필수 항목입니다.")
 	String city,
 
+	@Schema(description = "시/군/구", example = "수성구")
 	@NotBlank(message = "시/군/구 값은 필수 항목입니다.")
 	String district,
 
+	@Schema(description = "도로명주소", example = "대구광역시 수성구 야구전설로 1")
 	@NotBlank(message = "도로명주소는 필수 항목입니다.")
 	String roadAddress,
 
+	@Schema(description = "위도", example = "35.8411")
 	@NotNull(message = "구장의 위도 값은 필수 항목입니다.")
 	@DecimalMin(value = "-90.0", message = "위도 값은 -90에서 90 사이여야 합니다")
 	@DecimalMax(value = "90.0", message = "위도 값은 -90에서 90 사이여야 합니다")
 	BigDecimal latitude,
 
+	@Schema(description = "경도", example = "128.6811")
 	@NotNull(message = "구장의 경도 값은 필수 항목입니다.")
 	@DecimalMin(value = "-180.0", message = "경도 값은 -180에서 180 사이여야 합니다.")
 	@DecimalMax(value = "180.0", message = "경도 값은 -180에서 180 사이여야 합니다.")
 	BigDecimal longitude,
 
+	@Schema(description = "총 좌석 수", example = "24000")
 	@NotNull(message = "구장 좌석수는 필수 항목입니다.")
 	@Positive(message = "구장 좌석수는 0보다 커야 합니다.")
 	Integer totalSeats,
 
+	@Schema(description = "좌석 배치 설정 정보", example = "{\"rows\": 10, \"cols\": 20}")
 	@NotNull(message = "구장 좌석 배치 설정 정보는 필수 항목입니다.")
 	Map<String, Object> seatMapConfig
 

--- a/stadium/src/main/java/com/goti/dto/response/StadiumCreateResponse.java
+++ b/stadium/src/main/java/com/goti/dto/response/StadiumCreateResponse.java
@@ -11,7 +11,7 @@ public record StadiumCreateResponse(
 	String roadAddress,
 	int totalSeats
 ) {
-	public static StadiumCreateResponse of(
+	public static StadiumCreateResponse from(
 		UUID stadiumId,
 		String stadiumName,
 		String location,

--- a/stadium/src/main/java/com/goti/dto/response/StadiumCreateResponse.java
+++ b/stadium/src/main/java/com/goti/dto/response/StadiumCreateResponse.java
@@ -1,0 +1,23 @@
+package com.goti.dto.response;
+
+public record StadiumCreateResponse(
+	String stadiumName,
+	String location,
+	String city,
+	String district,
+	String roadAddress,
+	int totalSeats
+) {
+	public static StadiumCreateResponse of(
+		String stadiumName,
+		String location,
+		String city,
+		String district,
+		String roadAddress,
+		int totalSeats
+	) {
+		return new StadiumCreateResponse(
+			stadiumName, location, city, district, roadAddress, totalSeats
+		);
+	}
+}

--- a/stadium/src/main/java/com/goti/dto/response/StadiumCreateResponse.java
+++ b/stadium/src/main/java/com/goti/dto/response/StadiumCreateResponse.java
@@ -1,6 +1,9 @@
 package com.goti.dto.response;
 
+import java.util.UUID;
+
 public record StadiumCreateResponse(
+	UUID stadiumId,
 	String stadiumName,
 	String location,
 	String city,
@@ -9,6 +12,7 @@ public record StadiumCreateResponse(
 	int totalSeats
 ) {
 	public static StadiumCreateResponse of(
+		UUID stadiumId,
 		String stadiumName,
 		String location,
 		String city,
@@ -17,7 +21,7 @@ public record StadiumCreateResponse(
 		int totalSeats
 	) {
 		return new StadiumCreateResponse(
-			stadiumName, location, city, district, roadAddress, totalSeats
+			stadiumId, stadiumName, location, city, district, roadAddress, totalSeats
 		);
 	}
 }

--- a/stadium/src/main/java/com/goti/dto/response/StadiumCreateResponse.java
+++ b/stadium/src/main/java/com/goti/dto/response/StadiumCreateResponse.java
@@ -1,5 +1,7 @@
 package com.goti.dto.response;
 
+import com.goti.domain.entity.stadium.StadiumEntity;
+
 import java.util.UUID;
 
 public record StadiumCreateResponse(
@@ -11,17 +13,15 @@ public record StadiumCreateResponse(
 	String roadAddress,
 	int totalSeats
 ) {
-	public static StadiumCreateResponse from(
-		UUID stadiumId,
-		String stadiumName,
-		String location,
-		String city,
-		String district,
-		String roadAddress,
-		int totalSeats
-	) {
+	public static StadiumCreateResponse from(StadiumEntity stadium) {
 		return new StadiumCreateResponse(
-			stadiumId, stadiumName, location, city, district, roadAddress, totalSeats
+			stadium.getId(),
+			stadium.getStadiumName(),
+			stadium.getLocation(),
+			stadium.getCity(),
+			stadium.getDistrict(),
+			stadium.getRoadAddress(),
+			stadium.getTotalSeats()
 		);
 	}
 }

--- a/stadium/src/main/java/com/goti/repository/StadiumRepository.java
+++ b/stadium/src/main/java/com/goti/repository/StadiumRepository.java
@@ -1,0 +1,12 @@
+package com.goti.repository;
+
+import com.goti.domain.entity.stadium.StadiumEntity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface StadiumRepository extends JpaRepository<StadiumEntity, UUID> {
+}

--- a/stadium/src/main/java/com/goti/service/domain/stadium/StadiumService.java
+++ b/stadium/src/main/java/com/goti/service/domain/stadium/StadiumService.java
@@ -1,0 +1,21 @@
+package com.goti.service.domain.stadium;
+
+import com.goti.dto.response.StadiumCreateResponse;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+public interface StadiumService {
+
+	StadiumCreateResponse create(
+		String stadiumName,
+		String location,
+		String city,
+		String district,
+		String roadAddress,
+		BigDecimal latitude,
+		BigDecimal longitude,
+		Integer totalSeats,
+		Map<String, Object> seatMapConfig
+	);
+}

--- a/stadium/src/main/java/com/goti/service/domain/stadium/StadiumServiceImpl.java
+++ b/stadium/src/main/java/com/goti/service/domain/stadium/StadiumServiceImpl.java
@@ -42,7 +42,7 @@ public class StadiumServiceImpl implements StadiumService {
 		);
 		stadiumRepository.save(stadium);
 
-		return StadiumCreateResponse.of(
+		return StadiumCreateResponse.from(
 			stadium.getId(),
 			stadium.getStadiumName(),
 			stadium.getLocation(),

--- a/stadium/src/main/java/com/goti/service/domain/stadium/StadiumServiceImpl.java
+++ b/stadium/src/main/java/com/goti/service/domain/stadium/StadiumServiceImpl.java
@@ -1,0 +1,55 @@
+package com.goti.service.domain.stadium;
+
+import com.goti.domain.entity.stadium.StadiumEntity;
+import com.goti.dto.response.StadiumCreateResponse;
+import com.goti.repository.StadiumRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class StadiumServiceImpl implements StadiumService {
+
+	private final StadiumRepository stadiumRepository;
+
+	@Override
+	public StadiumCreateResponse create(
+		String stadiumName,
+		String location,
+		String city,
+		String district,
+		String roadAddress,
+		BigDecimal latitude,
+		BigDecimal longitude,
+		Integer totalSeats,
+		Map<String, Object> seatMapConfig
+	) {
+		StadiumEntity stadium = StadiumEntity.create(
+			stadiumName,
+			location,
+			city,
+			district,
+			roadAddress,
+			latitude,
+			longitude,
+			totalSeats,
+			seatMapConfig
+		);
+		stadiumRepository.save(stadium);
+
+		return StadiumCreateResponse.of(
+			stadium.getId(),
+			stadium.getStadiumName(),
+			stadium.getLocation(),
+			stadium.getCity(),
+			stadium.getDistrict(),
+			stadium.getRoadAddress(),
+			stadium.getTotalSeats()
+		);
+	}
+}

--- a/stadium/src/main/java/com/goti/service/domain/stadium/StadiumServiceImpl.java
+++ b/stadium/src/main/java/com/goti/service/domain/stadium/StadiumServiceImpl.java
@@ -7,6 +7,7 @@ import com.goti.repository.StadiumRepository;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.util.Map;
@@ -18,6 +19,7 @@ public class StadiumServiceImpl implements StadiumService {
 	private final StadiumRepository stadiumRepository;
 
 	@Override
+	@Transactional
 	public StadiumCreateResponse create(
 		String stadiumName,
 		String location,
@@ -42,14 +44,6 @@ public class StadiumServiceImpl implements StadiumService {
 		);
 		stadiumRepository.save(stadium);
 
-		return StadiumCreateResponse.from(
-			stadium.getId(),
-			stadium.getStadiumName(),
-			stadium.getLocation(),
-			stadium.getCity(),
-			stadium.getDistrict(),
-			stadium.getRoadAddress(),
-			stadium.getTotalSeats()
-		);
+		return StadiumCreateResponse.from(stadium);
 	}
 }

--- a/stadium/src/test/java/com/goti/service/domain/stadium/StadiumServiceTest.java
+++ b/stadium/src/test/java/com/goti/service/domain/stadium/StadiumServiceTest.java
@@ -1,0 +1,251 @@
+package com.goti.service.domain.stadium;
+
+import com.goti.GotiStadiumApplication;
+import com.goti.dto.request.StadiumCreateRequest;
+
+import com.goti.dto.response.StadiumCreateResponse;
+
+import com.goti.exception.FieldValidationException;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+@Transactional
+@SpringBootTest(classes = GotiStadiumApplication.class)
+@ActiveProfiles("test")
+public class StadiumServiceTest {
+
+	@Autowired
+	StadiumService stadiumService;
+
+	StadiumCreateRequest stadiumCreateRequest;
+
+	@BeforeEach
+	void setup() {
+		stadiumCreateRequest = new StadiumCreateRequest(
+			"대구삼성라이온즈파크",
+			"대구",
+			"대구광역시",
+			"수성구",
+			"대구 수성구 야구전설로 1 대구삼성라이온즈파크",
+			BigDecimal.valueOf(35.84),
+			BigDecimal.valueOf(128.68),
+			24000,
+			null // 추후 디테일 정보 기입 예정
+		);
+	}
+
+	@Test
+	void 구장_생성_성공() {
+
+		StadiumCreateResponse response = stadiumService.create(
+			stadiumCreateRequest.stadiumName(),
+			stadiumCreateRequest.location(),
+			stadiumCreateRequest.city(),
+			stadiumCreateRequest.district(),
+			stadiumCreateRequest.roadAddress(),
+			stadiumCreateRequest.latitude(),
+			stadiumCreateRequest.longitude(),
+			stadiumCreateRequest.totalSeats(),
+			stadiumCreateRequest.seatMapConfig()
+		);
+		assertNotNull(response.stadiumId());
+		log.info("response stadiumId :: {}", response.stadiumId());
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	void 구장_생성_실패_stadiumName__null_또는_공백(String stadiumName) {
+		assertThatThrownBy(
+			() -> stadiumService.create(
+				stadiumName,
+				stadiumCreateRequest.location(),
+				stadiumCreateRequest.city(),
+				stadiumCreateRequest.district(),
+				stadiumCreateRequest.roadAddress(),
+				stadiumCreateRequest.latitude(),
+				stadiumCreateRequest.longitude(),
+				stadiumCreateRequest.totalSeats(),
+				stadiumCreateRequest.seatMapConfig()
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("StadiumName:Field-stadiumName invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 구장명은 비어 있을 수 없습니다.", ex.getMessage());
+			}
+		);
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	void 구장_생성_실패_location__null_또는_공백(String location) {
+		assertThatThrownBy(
+			() -> stadiumService.create(
+				stadiumCreateRequest.stadiumName(),
+				location,
+				stadiumCreateRequest.city(),
+				stadiumCreateRequest.district(),
+				stadiumCreateRequest.roadAddress(),
+				stadiumCreateRequest.latitude(),
+				stadiumCreateRequest.longitude(),
+				stadiumCreateRequest.totalSeats(),
+				stadiumCreateRequest.seatMapConfig()
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("StadiumName:Field-location invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 지역명은 비어 있을 수 없습니다.", ex.getMessage());
+			}
+		);
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	void 구장_생성_실패_city__null_또는_공백(String city) {
+		assertThatThrownBy(
+			() -> stadiumService.create(
+				stadiumCreateRequest.stadiumName(),
+				stadiumCreateRequest.location(),
+				city,
+				stadiumCreateRequest.district(),
+				stadiumCreateRequest.roadAddress(),
+				stadiumCreateRequest.latitude(),
+				stadiumCreateRequest.longitude(),
+				stadiumCreateRequest.totalSeats(),
+				stadiumCreateRequest.seatMapConfig()
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("StadiumName:Field-city invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 시/도는 비어 있을 수 없습니다.", ex.getMessage());
+			}
+		);
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	void 구장_생성_실패_district__null_또는_공백(String district) {
+		assertThatThrownBy(
+			() -> stadiumService.create(
+				stadiumCreateRequest.stadiumName(),
+				stadiumCreateRequest.location(),
+				stadiumCreateRequest.city(),
+				district,
+				stadiumCreateRequest.roadAddress(),
+				stadiumCreateRequest.latitude(),
+				stadiumCreateRequest.longitude(),
+				stadiumCreateRequest.totalSeats(),
+				stadiumCreateRequest.seatMapConfig()
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("StadiumName:Field-district invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 시/군/구는 비어 있을 수 없습니다.", ex.getMessage());
+			}
+		);
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	void 구장_생성_실패_roadAddress__null_또는_공백(String roadAddress) {
+		assertThatThrownBy(
+			() -> stadiumService.create(
+				stadiumCreateRequest.stadiumName(),
+				stadiumCreateRequest.location(),
+				stadiumCreateRequest.city(),
+				stadiumCreateRequest.district(),
+				roadAddress,
+				stadiumCreateRequest.latitude(),
+				stadiumCreateRequest.longitude(),
+				stadiumCreateRequest.totalSeats(),
+				stadiumCreateRequest.seatMapConfig()
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("StadiumName:Field-roadAddress invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 도로명 주소는 비어 있을 수 없습니다.", ex.getMessage());
+			}
+		);
+	}
+
+	@Test
+	void 구장_생성_실패_latitude__범위_미포함() {
+		assertThatThrownBy(
+			() -> stadiumService.create(
+				stadiumCreateRequest.stadiumName(),
+				stadiumCreateRequest.location(),
+				stadiumCreateRequest.city(),
+				stadiumCreateRequest.district(),
+				stadiumCreateRequest.roadAddress(),
+				BigDecimal.valueOf(100),
+				stadiumCreateRequest.longitude(),
+				stadiumCreateRequest.totalSeats(),
+				stadiumCreateRequest.seatMapConfig()
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("StadiumName:Field-latitude invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 위도는 -90에서 90 사이의 값이어야 합니다.", ex.getMessage());
+			}
+		);
+	}
+
+	@Test
+	void 구장_생성_실패_longitude__범위_미포함() {
+		assertThatThrownBy(
+			() -> stadiumService.create(
+				stadiumCreateRequest.stadiumName(),
+				stadiumCreateRequest.location(),
+				stadiumCreateRequest.city(),
+				stadiumCreateRequest.district(),
+				stadiumCreateRequest.roadAddress(),
+				stadiumCreateRequest.latitude(),
+				BigDecimal.valueOf(190),
+				stadiumCreateRequest.totalSeats(),
+				stadiumCreateRequest.seatMapConfig()
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("StadiumName:Field-longitude invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 경도는 -180에서 180 사이의 값이어야 합니다.", ex.getMessage());
+			}
+		);
+	}
+
+	@Test
+	void 구장_생성_실패_totalSeats__음수() {
+		assertThatThrownBy(
+			() -> stadiumService.create(
+				stadiumCreateRequest.stadiumName(),
+				stadiumCreateRequest.location(),
+				stadiumCreateRequest.city(),
+				stadiumCreateRequest.district(),
+				stadiumCreateRequest.roadAddress(),
+				stadiumCreateRequest.latitude(),
+				stadiumCreateRequest.longitude(),
+				0,
+				stadiumCreateRequest.seatMapConfig()
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("StadiumName:Field-totalSeats invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 총 좌석 수는 0보다 커야 합니다.", ex.getMessage());
+			}
+		);
+	}
+
+}

--- a/stadium/src/test/resources/application-test.yml
+++ b/stadium/src/test/resources/application-test.yml
@@ -1,0 +1,24 @@
+server:
+  port: 8080
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+  datasource:
+    url: ${DATASOURCE_URL}
+    username: ${DATASOURCE_USERNAME}
+    password: ${DATASOURCE_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+    hikari:
+      idle-timeout: 5000
+      max-lifetime: 420000
+      connection-timeout: 5000
+      validation-timeout: 3000
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+  config:
+    import:
+      - application-integration.yml
+      - optional:file:.env.test[.properties]


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#118 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
- 야구구장 생성 서비스 및 테스트 구현
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- test module 추가 및 application-test.yml 추가 (Stadium module)
- validation 라이브러리 추가 (in Stadium module build.gradle)
- 야구구장 생성(Create) 서비스 로직 구현 (Stadium module, StadiumService)
- 야구구장 생성 테스트 코드 추가 (생성 성공 & all field 실패 케이스)
- 야구구장 도메인 Entity 필드 타입 수정 (seatMapConfig : String -> Map)
- 현재 야구구장 요청 데이터 필드 위,경도값 -> 추후에 kakao 혹은 naver map api 활용 도로명주소 기반 위,경도 값 시스템내에서 기입 로직 구현 예정 ( 외부 라이브러리 (Map API)사전신청 필수 (외부서버 이슈))
<br/>