### PR TITLE
[FEAT] 경기별 좌석 상태 조회 로직 구현

### DIFF
--- a/ticketing/src/main/java/com/goti/seat/controller/GameSeatStatusController.java
+++ b/ticketing/src/main/java/com/goti/seat/controller/GameSeatStatusController.java
@@ -29,7 +29,7 @@ public class GameSeatStatusController {
 
 	@Operation(
 		summary = "경기별 좌석 상태 조회",
-		description = "특정 경기의 특정 구역 좌석 상태 목록을 조회하는 API"
+		description = "특정 경기의 특정 구역 좌석 상태 목록 조회 API"
 	)
 	@GetMapping
 	public ResponseEntity<ApiSuccessResponse<List<GameSeatStatusResponse>>> list(

--- a/ticketing/src/main/java/com/goti/seat/controller/GameSeatStatusController.java
+++ b/ticketing/src/main/java/com/goti/seat/controller/GameSeatStatusController.java
@@ -1,0 +1,41 @@
+package com.goti.seat.controller;
+
+import static com.goti.global.api.ApiSuccessResponse.*;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.goti.global.api.ApiSuccessResponse;
+import com.goti.seat.dto.response.GameSeatStatusResponse;
+import com.goti.seat.service.domain.SeatStatusService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Game Seat Status", description = "경기별 좌석 상태 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/games/{gameId}/seat-statuses")
+public class GameSeatStatusController {
+	private final SeatStatusService seatStatusService;
+
+	@Operation(
+		summary = "경기별 좌석 상태 조회",
+		description = "특정 경기의 특정 구역 좌석 상태 목록을 조회하는 API"
+	)
+	@GetMapping
+	public ResponseEntity<ApiSuccessResponse<List<GameSeatStatusResponse>>> list(
+		@PathVariable UUID gameId,
+		@RequestParam UUID sectionId
+	) {
+		return wrap(seatStatusService.get(gameId, sectionId));
+	}
+}

--- a/ticketing/src/main/java/com/goti/seat/controller/GameSeatStatusController.java
+++ b/ticketing/src/main/java/com/goti/seat/controller/GameSeatStatusController.java
@@ -23,7 +23,7 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "Game Seat Status", description = "경기별 좌석 상태 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/games/{gameId}/seat-statuses")
+@RequestMapping("/api/v1/games")
 public class GameSeatStatusController {
 	private final SeatStatusService seatStatusService;
 
@@ -31,10 +31,10 @@ public class GameSeatStatusController {
 		summary = "경기별 좌석 상태 조회",
 		description = "특정 경기의 특정 구역 좌석 상태 목록 조회 API"
 	)
-	@GetMapping
+	@GetMapping("/{gameId}/sections/{sectionId}/seat-statuses")
 	public ResponseEntity<ApiSuccessResponse<List<GameSeatStatusResponse>>> list(
 		@PathVariable UUID gameId,
-		@RequestParam UUID sectionId
+		@PathVariable UUID sectionId
 	) {
 		return wrap(seatStatusService.get(gameId, sectionId));
 	}

--- a/ticketing/src/main/java/com/goti/seat/dto/response/GameSeatStatusResponse.java
+++ b/ticketing/src/main/java/com/goti/seat/dto/response/GameSeatStatusResponse.java
@@ -1,0 +1,23 @@
+package com.goti.seat.dto.response;
+
+import java.util.UUID;
+
+import com.goti.constants.SeatStatus;
+import com.goti.domain.entity.seat.SeatStatusEntity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record GameSeatStatusResponse(
+	@Schema(description = "좌석 ID", example = "44444444-4444-4444-4444-444444444444")
+	UUID seatId,
+
+	@Schema(description = "좌석 상태", example = "AVAILABLE")
+	SeatStatus status
+) {
+	public static GameSeatStatusResponse from(SeatStatusEntity seatStatus) {
+		return new GameSeatStatusResponse(
+			seatStatus.getSeat().getId(),
+			seatStatus.getStatus()
+		);
+	}
+}

--- a/ticketing/src/main/java/com/goti/seat/repository/SeatStatusRepository.java
+++ b/ticketing/src/main/java/com/goti/seat/repository/SeatStatusRepository.java
@@ -5,12 +5,24 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.goti.domain.entity.seat.SeatStatusEntity;
 
 @Repository
 public interface SeatStatusRepository extends JpaRepository<SeatStatusEntity, UUID> {
-	List<SeatStatusEntity> findAllByGame_IdAndSeat_SeatSection_Id(UUID gameId, UUID sectionId);
+
+	@Query("""
+		SELECT ss
+			FROM SeatStatusEntity ss
+		WHERE ss.game.id = :gameId
+  		AND ss.seat.seatSection.id = :sectionId
+	""")
+	List<SeatStatusEntity> findSeatStatuses(
+		@Param("gameId") UUID gameId,
+		@Param("sectionId") UUID sectionId
+	);
 	Optional<SeatStatusEntity> findByGame_IdAndSeat_Id(UUID gameId, UUID seatId);
 }

--- a/ticketing/src/main/java/com/goti/seat/repository/SeatStatusRepository.java
+++ b/ticketing/src/main/java/com/goti/seat/repository/SeatStatusRepository.java
@@ -4,6 +4,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.goti.domain.entity.game.GameScheduleEntity;
+
+import com.goti.domain.entity.seat.SeatEntity;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -24,5 +28,5 @@ public interface SeatStatusRepository extends JpaRepository<SeatStatusEntity, UU
 		@Param("gameId") UUID gameId,
 		@Param("sectionId") UUID sectionId
 	);
-	Optional<SeatStatusEntity> findByGame_IdAndSeat_Id(UUID gameId, UUID seatId);
+	Optional<SeatStatusEntity> findByGameAndSeat(GameScheduleEntity game, SeatEntity seat);
 }

--- a/ticketing/src/main/java/com/goti/seat/repository/SeatStatusRepository.java
+++ b/ticketing/src/main/java/com/goti/seat/repository/SeatStatusRepository.java
@@ -1,13 +1,16 @@
 package com.goti.seat.repository;
 
-import com.goti.domain.entity.seat.SeatStatusEntity;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.goti.domain.entity.seat.SeatStatusEntity;
+
 @Repository
 public interface SeatStatusRepository extends JpaRepository<SeatStatusEntity, UUID> {
+	List<SeatStatusEntity> findAllByGame_IdAndSeat_SeatSection_Id(UUID gameId, UUID sectionId);
 	Optional<SeatStatusEntity> findByGame_IdAndSeat_Id(UUID gameId, UUID seatId);
 }

--- a/ticketing/src/main/java/com/goti/seat/service/application/SeatHoldExpiryTransactionalService.java
+++ b/ticketing/src/main/java/com/goti/seat/service/application/SeatHoldExpiryTransactionalService.java
@@ -28,10 +28,10 @@ public class SeatHoldExpiryTransactionalService {
 		SeatHoldEntity seatHold = seatHoldRepository.findById(holdId)
 			.orElseThrow(() -> new CustomException(ErrorCode.SEAT_HOLD_NOT_FOUND));
 
-		UUID gameId = seatHold.getGameSchedule().getId();
-		UUID seatId = seatHold.getSeat().getId();
-
-		SeatStatusEntity seatStatus = seatStatusRepository.findByGame_IdAndSeat_Id(gameId, seatId)
+		SeatStatusEntity seatStatus = seatStatusRepository.findByGameAndSeat(
+			seatHold.getGameSchedule(),
+			seatHold.getSeat()
+		)
 			.orElseThrow(() -> new CustomException(ErrorCode.SEAT_STATUS_NOT_FOUND));
 
 		seatHoldExpiryService.expire(seatStatus, seatHold, now);

--- a/ticketing/src/main/java/com/goti/seat/service/application/SeatHoldTransactionalService.java
+++ b/ticketing/src/main/java/com/goti/seat/service/application/SeatHoldTransactionalService.java
@@ -10,9 +10,11 @@ import com.goti.constants.messages.ErrorCode;
 import com.goti.domain.entity.seat.SeatHoldEntity;
 import com.goti.domain.entity.seat.SeatStatusEntity;
 import com.goti.exception.CustomException;
+import com.goti.game.repository.GameScheduleRepository;
 import com.goti.global.validation.Preconditions;
 import com.goti.seat.config.properties.SeatHoldProperties;
 import com.goti.seat.repository.SeatHoldRepository;
+import com.goti.seat.repository.SeatRepository;
 import com.goti.seat.repository.SeatStatusRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -20,13 +22,18 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class SeatHoldTransactionalService {
+	private final GameScheduleRepository gameScheduleRepository;
+	private final SeatRepository seatRepository;
 	private final SeatStatusRepository seatStatusRepository;
 	private final SeatHoldRepository seatHoldRepository;
 	private final SeatHoldProperties seatHoldProperties;
 
 	@Transactional
 	public UUID hold(UUID gameId, UUID seatId, UUID userId, String queueTokenJti) {
-		SeatStatusEntity seatStatus = seatStatusRepository.findByGame_IdAndSeat_Id(gameId, seatId)
+		SeatStatusEntity seatStatus = seatStatusRepository.findByGameAndSeat(
+				gameScheduleRepository.getReferenceById(gameId),
+				seatRepository.getReferenceById(seatId)
+			)
 			.orElseThrow(() -> new CustomException(ErrorCode.SEAT_STATUS_NOT_FOUND));
 
 		seatStatus.hold();
@@ -54,9 +61,9 @@ public class SeatHoldTransactionalService {
 			ErrorCode.AUTH_PERMISSION_DENIED
 		);
 
-		SeatStatusEntity seatStatus = seatStatusRepository.findByGame_IdAndSeat_Id(
-			seatHold.getGameSchedule().getId(),
-			seatHold.getSeat().getId()
+		SeatStatusEntity seatStatus = seatStatusRepository.findByGameAndSeat(
+			seatHold.getGameSchedule(),
+			seatHold.getSeat()
 		).orElseThrow(() -> new CustomException(ErrorCode.SEAT_STATUS_NOT_FOUND));
 
 		seatStatus.release();

--- a/ticketing/src/main/java/com/goti/seat/service/domain/SeatStatusService.java
+++ b/ticketing/src/main/java/com/goti/seat/service/domain/SeatStatusService.java
@@ -1,0 +1,10 @@
+package com.goti.seat.service.domain;
+
+import java.util.List;
+import java.util.UUID;
+
+import com.goti.seat.dto.response.GameSeatStatusResponse;
+
+public interface SeatStatusService {
+	List<GameSeatStatusResponse> get(UUID gameId, UUID sectionId);
+}

--- a/ticketing/src/main/java/com/goti/seat/service/domain/SeatStatusServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/seat/service/domain/SeatStatusServiceImpl.java
@@ -22,7 +22,7 @@ public class SeatStatusServiceImpl implements SeatStatusService {
 		UUID gameId,
 		UUID sectionId
 	) {
-		return seatStatusRepository.findAllByGame_IdAndSeat_SeatSection_Id(gameId, sectionId).stream()
+		return seatStatusRepository.findSeatStatuses(gameId, sectionId).stream()
 			.map(GameSeatStatusResponse::from)
 			.toList();
 	}

--- a/ticketing/src/main/java/com/goti/seat/service/domain/SeatStatusServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/seat/service/domain/SeatStatusServiceImpl.java
@@ -1,0 +1,29 @@
+package com.goti.seat.service.domain;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goti.seat.dto.response.GameSeatStatusResponse;
+import com.goti.seat.repository.SeatStatusRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SeatStatusServiceImpl implements SeatStatusService {
+	private final SeatStatusRepository seatStatusRepository;
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<GameSeatStatusResponse> get(
+		UUID gameId,
+		UUID sectionId
+	) {
+		return seatStatusRepository.findAllByGame_IdAndSeat_SeatSection_Id(gameId, sectionId).stream()
+			.map(GameSeatStatusResponse::from)
+			.toList();
+	}
+}


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#123 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
경기별 좌석 상태 조회 로직 구현
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
> 특정 경기 구역별 좌석 상태 조회 응답 DTO 구현
특정 경기 구역별 좌석 상태 조회 서비스 로직 구현
특정 경기 구역별 좌석 상태 조회 API 엔드포인트 구현

<br/>