### PR TITLE
[FEAT] 구장 생성 API 구현 및 API 테스트

### DIFF
--- a/stadium/build.gradle
+++ b/stadium/build.gradle
@@ -22,4 +22,5 @@ dependencies {
     implementation project(':core')
     implementation project(':common')
     implementation project(':integration')
+    implementation project(':user')
 }

--- a/stadium/src/main/java/com/goti/controller/BaseballTeamController.java
+++ b/stadium/src/main/java/com/goti/controller/BaseballTeamController.java
@@ -1,0 +1,14 @@
+package com.goti.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "BaseballTeam", description = "야구구단(팀) 관련 API")
+@RestController
+@RequestMapping("/api/v1/baseball-teams")
+@RequiredArgsConstructor
+public class BaseballTeamController {
+}

--- a/stadium/src/main/java/com/goti/controller/StadiumController.java
+++ b/stadium/src/main/java/com/goti/controller/StadiumController.java
@@ -20,7 +20,7 @@ import static com.goti.global.api.ApiSuccessResponse.wrap;
 
 @Tag(name = "Stadium", description = "야구구장 관련 API")
 @RestController
-@RequestMapping("/api/v1/stadium")
+@RequestMapping("/api/v1/stadiums")
 @RequiredArgsConstructor
 public class StadiumController {
 	

--- a/stadium/src/main/java/com/goti/controller/StadiumController.java
+++ b/stadium/src/main/java/com/goti/controller/StadiumController.java
@@ -1,0 +1,51 @@
+package com.goti.controller;
+
+import com.goti.dto.request.StadiumCreateRequest;
+import com.goti.dto.response.StadiumCreateResponse;
+import com.goti.global.api.ApiSuccessResponse;
+import com.goti.service.domain.stadium.StadiumService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.goti.global.api.ApiSuccessResponse.wrap;
+
+@Tag(name = "Stadium", description = "야구구장 관련 API")
+@RestController
+@RequestMapping("/api/v1/stadium")
+@RequiredArgsConstructor
+public class StadiumController {
+	
+	private final StadiumService stadiumService;
+
+	@Operation(
+		summary = "야구 구장 생성",
+		description = "야구 구장 생성 API"
+	)
+	@PostMapping
+	public ResponseEntity<ApiSuccessResponse<StadiumCreateResponse>> create(
+		@RequestBody @Valid StadiumCreateRequest request
+	) {
+		return wrap(
+			stadiumService.create(
+				request.stadiumName(),
+				request.location(),
+				request.city(),
+				request.district(),
+				request.roadAddress(),
+				request.latitude(),
+				request.longitude(),
+				request.totalSeats(),
+				request.seatMapConfig()
+			)
+		);
+	}
+}

--- a/stadium/src/test/java/com/goti/api/StadiumCreateApiTest.java
+++ b/stadium/src/test/java/com/goti/api/StadiumCreateApiTest.java
@@ -65,7 +65,13 @@ public class StadiumCreateApiTest {
 		)
 			.andDo(print())
 			.andExpectAll(
-				status().isOk()
+				status().isOk(),
+				jsonPath("$.code").value("ok"),
+				jsonPath("$.message").value("성공"),
+				jsonPath("$.data").exists(),
+				jsonPath("$.data.stadiumId").exists(),
+				jsonPath("$.data.stadiumName").value(STADIUM_NAME),
+				jsonPath("$.data.roadAddress").value(ROAD_ADDRESS)
 			);
 	}
 }

--- a/stadium/src/test/java/com/goti/api/StadiumCreateApiTest.java
+++ b/stadium/src/test/java/com/goti/api/StadiumCreateApiTest.java
@@ -1,0 +1,71 @@
+package com.goti.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goti.GotiStadiumApplication;
+import com.goti.config.jwt.JwtAuthenticationFilter;
+import com.goti.config.security.SecurityConfig;
+import com.goti.dto.request.StadiumCreateRequest;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+@SpringBootTest(classes = GotiStadiumApplication.class)
+@Transactional
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DisplayName("장바구니 상품 추가 - POST /api/v1/stadium")
+public class StadiumCreateApiTest {
+
+	@Autowired
+	public MockMvc mockMvc;
+
+	@Autowired
+	public ObjectMapper objectMapper;
+
+	static final String STADIUM_NAME = "대구삼성라이온즈파크";
+	static final String ROAD_ADDRESS = "대구 수성구 야구전설로 1 대구삼성라이온즈파크";
+
+	@Test
+	void 야구구장_생성_성공__200_OK() throws Exception {
+		Map<String, Object> seatMapConfig = Map.of("sections", "test");
+		StadiumCreateRequest request = new StadiumCreateRequest(
+			STADIUM_NAME,
+			"대구",
+			"대구광역시",
+			"수성구",
+			ROAD_ADDRESS,
+			BigDecimal.valueOf(35.84),
+			BigDecimal.valueOf(128.68),
+			24000,
+			seatMapConfig
+		);
+
+		mockMvc.perform(
+			post("/api/v1/stadium")
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request))
+		)
+			.andDo(print())
+			.andExpectAll(
+				status().isOk()
+			);
+	}
+}

--- a/stadium/src/test/java/com/goti/api/StadiumCreateApiTest.java
+++ b/stadium/src/test/java/com/goti/api/StadiumCreateApiTest.java
@@ -30,7 +30,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 @Transactional
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-@DisplayName("장바구니 상품 추가 - POST /api/v1/stadium")
+@DisplayName("야구 구장 생성 - POST /api/v1/stadiums")
 public class StadiumCreateApiTest {
 
 	@Autowired
@@ -58,7 +58,7 @@ public class StadiumCreateApiTest {
 		);
 
 		mockMvc.perform(
-			post("/api/v1/stadium")
+			post("/api/v1/stadiums")
 				.with(csrf())
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request))

--- a/user/src/main/java/com/goti/config/security/SecurityConfig.java
+++ b/user/src/main/java/com/goti/config/security/SecurityConfig.java
@@ -31,6 +31,7 @@ public class SecurityConfig {
 
 	public static final String[] PERMIT_PUBLIC_PATH = {
 		"/api/v1/auth/**",
+		"/api/v1/stadium/**",
 		"/actuator/**",
 		"/swagger-ui/**",
 		"/v3/api-docs/**",
@@ -63,8 +64,8 @@ public class SecurityConfig {
 					.accessDeniedHandler(accessDeniedHandler)
 			).authorizeHttpRequests(
 				auth -> auth
-					.requestMatchers(PERMIT_MEMBER_PATH).hasRole("MEMBER")
 					.requestMatchers(PERMIT_PUBLIC_PATH).permitAll()
+					.requestMatchers(PERMIT_MEMBER_PATH).hasRole("MEMBER")
 					.anyRequest().authenticated()
 			).addFilterBefore(
 				jwtAuthenticationFilter,

--- a/user/src/main/java/com/goti/config/security/SecurityConfig.java
+++ b/user/src/main/java/com/goti/config/security/SecurityConfig.java
@@ -31,7 +31,7 @@ public class SecurityConfig {
 
 	public static final String[] PERMIT_PUBLIC_PATH = {
 		"/api/v1/auth/**",
-		"/api/v1/stadium/**",
+		"/api/v1/stadiums/**",
 		"/actuator/**",
 		"/swagger-ui/**",
 		"/v3/api-docs/**",


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#121 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
야구 구장 생성 API 구축 및 API 테스트 코드 추가
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- 야구 구장 생성 API 구축 및 API 테스트 코드 추가 (In Stadium Module)
- 작업 파일
  - 변경
    - build.gradle (stadium module)
    - SecurityConfig
  - 추가
    - StadiumController
    - StadiumCreateApiTest
<br/>