### PR TITLE
[FEAT] OTel 메트릭 확장 — HikariCP, Buffer Pool, System CPU, Active Requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,16 @@ GOOGLE_CLIENT=your-google-client-id
 GOOGLE_SECRET=your-google-client-secret
 GOOGLE_REDIRECT_URI=http://localhost:8080/api/v1/auth/google/callback
 
+# === SMS (CoolSMS) ===
+SMS_API_KEY=your-coolsms-api-key
+SMS_API_SECRET=your-coolsms-api-secret
+SMS_API_SENDER=01000000000
+SMS_API_DOMAIN=https://api.coolsms.co.kr
+
+# === OTel (모니터링, 로컬 개발 시 비활성화) ===
+OTEL_SDK_DISABLED=true
+OTEL_EXPORTER_ENABLED=false
+
 # === Docker Compose (db-up 전용) ===
 POSTGRES_DB=goti
 POSTGRES_USER=goti

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -15,6 +15,9 @@ dependencies {
     // OpenTelemetry (metrics + traces + logs 자동 설정)
     implementation 'io.opentelemetry.instrumentation:opentelemetry-spring-boot-starter'
 
+    // Micrometer → OTel metrics bridge (HikariCP 등 Spring Boot 자동 등록 메트릭을 OTel로 전달)
+    implementation 'io.opentelemetry.instrumentation:opentelemetry-micrometer-1.5'
+
     implementation(project(":common"))
     implementation(project(":core"))
     implementation(project(":integration"))

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -4,6 +4,7 @@ dependencyManagement {
     imports {
         mavenBom 'io.opentelemetry:opentelemetry-bom:1.59.0'
         mavenBom 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:2.25.0'
+        // alpha BOM: hikaricp-3.0 OTel 계측 전용. GA 승격 시 제거 예정
         mavenBom 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.25.0-alpha'
     }
 }

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -4,6 +4,7 @@ dependencyManagement {
     imports {
         mavenBom 'io.opentelemetry:opentelemetry-bom:1.59.0'
         mavenBom 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:2.25.0'
+        mavenBom 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.25.0-alpha'
     }
 }
 

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -16,8 +16,8 @@ dependencies {
     // OpenTelemetry (metrics + traces + logs 자동 설정)
     implementation 'io.opentelemetry.instrumentation:opentelemetry-spring-boot-starter'
 
-    // Micrometer → OTel metrics bridge (HikariCP 등 Spring Boot 자동 등록 메트릭을 OTel로 전달)
-    implementation 'io.opentelemetry.instrumentation:opentelemetry-micrometer-1.5'
+    // HikariCP 커넥션 풀 메트릭을 OTel로 직접 계측 (Micrometer 브릿지 없이 순수 OTel)
+    implementation 'io.opentelemetry.instrumentation:opentelemetry-hikaricp-3.0'
 
     implementation(project(":common"))
     implementation(project(":core"))

--- a/api/src/main/java/com/goti/config/observability/ActiveRequestsFilter.java
+++ b/api/src/main/java/com/goti/config/observability/ActiveRequestsFilter.java
@@ -1,0 +1,43 @@
+package com.goti.config.observability;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.metrics.LongUpDownCounter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class ActiveRequestsFilter extends OncePerRequestFilter {
+
+    private final LongUpDownCounter activeRequests;
+
+    public ActiveRequestsFilter(OpenTelemetry openTelemetry) {
+        this.activeRequests = openTelemetry.getMeter("goti-server")
+                .upDownCounterBuilder("http.server.active_requests")
+                .setDescription("Number of active HTTP server requests")
+                .setUnit("{requests}")
+                .build();
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        activeRequests.add(1);
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            activeRequests.add(-1);
+        }
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return path.startsWith("/actuator");
+    }
+}

--- a/api/src/main/java/com/goti/config/observability/ActiveRequestsFilter.java
+++ b/api/src/main/java/com/goti/config/observability/ActiveRequestsFilter.java
@@ -1,24 +1,52 @@
 package com.goti.config.observability;
 
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongUpDownCounter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.List;
 
+/**
+ * 현재 처리 중인 HTTP 요청 수를 추적하는 서블릿 필터.
+ *
+ * <p>OTel Spring Boot Starter는 요청 duration(히스토그램)만 제공하고
+ * active request count는 제공하지 않으므로, UpDownCounter로 직접 계측한다.</p>
+ *
+ * <p>Prometheus 메트릭: {@code goti_http_server_active_requests}
+ * <br>레이블: {@code http_request_method} (GET, POST, ...)</p>
+ *
+ * <p>actuator, swagger 등 내부 경로는 계측에서 제외한다.</p>
+ *
+ * @see <a href="https://opentelemetry.io/docs/specs/semconv/http/http-metrics/">OTel HTTP Semantic Conventions</a>
+ */
 @Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 10)
 public class ActiveRequestsFilter extends OncePerRequestFilter {
+
+    private static final String METER_NAME = "goti-server";
+    private static final String METRIC_NAME = "goti.http.server.active_requests";
+    private static final AttributeKey<String> METHOD_KEY = AttributeKey.stringKey("http.request.method");
+
+    /** 계측 대상에서 제외할 경로 접두사 (운영/문서용 엔드포인트) */
+    private static final List<String> EXCLUDED_PREFIXES = List.of(
+            "/actuator", "/swagger-ui", "/v3/api-docs"
+    );
 
     private final LongUpDownCounter activeRequests;
 
     public ActiveRequestsFilter(OpenTelemetry openTelemetry) {
-        this.activeRequests = openTelemetry.getMeter("goti-server")
-                .upDownCounterBuilder("http.server.active_requests")
+        this.activeRequests = openTelemetry.getMeter(METER_NAME)
+                .upDownCounterBuilder(METRIC_NAME)
                 .setDescription("Number of active HTTP server requests")
                 .setUnit("{requests}")
                 .build();
@@ -27,17 +55,19 @@ public class ActiveRequestsFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
-        activeRequests.add(1);
+        Attributes attrs = Attributes.of(METHOD_KEY, request.getMethod());
+        activeRequests.add(1, attrs);
         try {
             filterChain.doFilter(request, response);
         } finally {
-            activeRequests.add(-1);
+            activeRequests.add(-1, attrs);
         }
     }
 
+    /** actuator, swagger 등 내부 경로는 active request 계측에서 제외 */
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getRequestURI();
-        return path.startsWith("/actuator");
+        return EXCLUDED_PREFIXES.stream().anyMatch(path::startsWith);
     }
 }

--- a/api/src/main/java/com/goti/config/observability/ActiveRequestsFilter.java
+++ b/api/src/main/java/com/goti/config/observability/ActiveRequestsFilter.java
@@ -35,7 +35,7 @@ import java.util.List;
 @Order(Ordered.HIGHEST_PRECEDENCE + 10)
 public class ActiveRequestsFilter extends OncePerRequestFilter {
 
-    // MSA 전환 시 서비스별로 분리 필요 → @Value 주입으로 전환 검토
+    // TODO: MSA 전환 시 서비스별로 분리 필요 → @Value 주입으로 전환 검토
     private static final String METER_NAME = "goti-server";
     private static final String METRIC_NAME = "goti.http.server.active_requests";
     private static final AttributeKey<String> METHOD_KEY = AttributeKey.stringKey("http.request.method");

--- a/api/src/main/java/com/goti/config/observability/ActiveRequestsFilter.java
+++ b/api/src/main/java/com/goti/config/observability/ActiveRequestsFilter.java
@@ -4,6 +4,8 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongUpDownCounter;
+import jakarta.servlet.AsyncEvent;
+import jakarta.servlet.AsyncListener;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -33,6 +35,7 @@ import java.util.List;
 @Order(Ordered.HIGHEST_PRECEDENCE + 10)
 public class ActiveRequestsFilter extends OncePerRequestFilter {
 
+    // MSA 전환 시 서비스별로 분리 필요 → @Value 주입으로 전환 검토
     private static final String METER_NAME = "goti-server";
     private static final String METRIC_NAME = "goti.http.server.active_requests";
     private static final AttributeKey<String> METHOD_KEY = AttributeKey.stringKey("http.request.method");
@@ -60,7 +63,11 @@ public class ActiveRequestsFilter extends OncePerRequestFilter {
         try {
             filterChain.doFilter(request, response);
         } finally {
-            activeRequests.add(-1, attrs);
+            if (request.isAsyncStarted()) {
+                request.getAsyncContext().addListener(new AsyncDecrementListener(attrs));
+            } else {
+                activeRequests.add(-1, attrs);
+            }
         }
     }
 
@@ -69,5 +76,35 @@ public class ActiveRequestsFilter extends OncePerRequestFilter {
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getRequestURI();
         return EXCLUDED_PREFIXES.stream().anyMatch(path::startsWith);
+    }
+
+    /** 비동기 요청 완료 시 active request 카운터를 감소시키는 리스너 */
+    private class AsyncDecrementListener implements AsyncListener {
+
+        private final Attributes attrs;
+
+        AsyncDecrementListener(Attributes attrs) {
+            this.attrs = attrs;
+        }
+
+        @Override
+        public void onComplete(AsyncEvent event) {
+            activeRequests.add(-1, attrs);
+        }
+
+        @Override
+        public void onTimeout(AsyncEvent event) {
+            activeRequests.add(-1, attrs);
+        }
+
+        @Override
+        public void onError(AsyncEvent event) {
+            activeRequests.add(-1, attrs);
+        }
+
+        @Override
+        public void onStartAsync(AsyncEvent event) {
+            // no-op
+        }
     }
 }

--- a/api/src/main/java/com/goti/config/observability/HikariOtelConfig.java
+++ b/api/src/main/java/com/goti/config/observability/HikariOtelConfig.java
@@ -3,6 +3,9 @@ package com.goti.config.observability;
 import com.zaxxer.hikari.HikariDataSource;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.hikaricp.v3_0.HikariTelemetry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,7 +15,7 @@ import org.springframework.context.annotation.Configuration;
  *
  * <p>Micrometer 브릿지 없이 OTel DB Pool 시맨틱 컨벤션으로 메트릭을 수집한다.</p>
  *
- * <p>수집 메트릭 (Prometheus 변환명):
+ * <p>수집 메트릭 (Prometheus 변환명):</p>
  * <ul>
  *   <li>{@code db_client_connections_usage} — active/idle 커넥션 수</li>
  *   <li>{@code db_client_connections_max} — 최대 커넥션 수</li>
@@ -26,14 +29,27 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class HikariOtelConfig {
 
+    private static final Logger log = LoggerFactory.getLogger(HikariOtelConfig.class);
+
+    /**
+     * static 팩토리: Config 클래스 조기 초기화 방지.
+     * ObjectProvider: OpenTelemetry 빈 지연 로딩으로 BeanPostProcessor 경고 제거.
+     * postProcessBeforeInitialization: OTel DataSourcePostProcessor가 프록시로 감싸기 전에 실행.
+     */
     @Bean
-    public BeanPostProcessor hikariMetricsPostProcessor(OpenTelemetry openTelemetry) {
-        HikariTelemetry telemetry = HikariTelemetry.create(openTelemetry);
+    static BeanPostProcessor hikariMetricsPostProcessor(ObjectProvider<OpenTelemetry> openTelemetryProvider) {
         return new BeanPostProcessor() {
             @Override
-            public Object postProcessAfterInitialization(Object bean, String beanName) {
+            public Object postProcessBeforeInitialization(Object bean, String beanName) {
                 if (bean instanceof HikariDataSource ds) {
-                    ds.setMetricsTrackerFactory(telemetry.createMetricsTrackerFactory());
+                    OpenTelemetry openTelemetry = openTelemetryProvider.getIfAvailable();
+                    if (openTelemetry != null) {
+                        HikariTelemetry telemetry = HikariTelemetry.create(openTelemetry);
+                        ds.setMetricsTrackerFactory(telemetry.createMetricsTrackerFactory());
+                        log.info("OTel HikariCP metrics attached to {}", beanName);
+                    } else {
+                        log.warn("OpenTelemetry not available, skipping HikariCP metrics for {}", beanName);
+                    }
                 }
                 return bean;
             }

--- a/api/src/main/java/com/goti/config/observability/HikariOtelConfig.java
+++ b/api/src/main/java/com/goti/config/observability/HikariOtelConfig.java
@@ -1,0 +1,42 @@
+package com.goti.config.observability;
+
+import com.zaxxer.hikari.HikariDataSource;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.hikaricp.v3_0.HikariTelemetry;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * HikariCP 커넥션 풀 메트릭을 OTel로 직접 계측하는 설정.
+ *
+ * <p>Micrometer 브릿지 없이 OTel DB Pool 시맨틱 컨벤션으로 메트릭을 수집한다.</p>
+ *
+ * <p>수집 메트릭 (Prometheus 변환명):
+ * <ul>
+ *   <li>{@code db_client_connections_usage} — active/idle 커넥션 수</li>
+ *   <li>{@code db_client_connections_max} — 최대 커넥션 수</li>
+ *   <li>{@code db_client_connections_pending_requests} — 대기 중 스레드</li>
+ *   <li>{@code db_client_connections_timeouts_total} — 타임아웃 횟수</li>
+ *   <li>{@code db_client_connections_create_time} — 커넥션 생성 시간</li>
+ *   <li>{@code db_client_connections_wait_time} — 커넥션 획득 대기 시간</li>
+ *   <li>{@code db_client_connections_use_time} — 커넥션 사용 시간</li>
+ * </ul>
+ */
+@Configuration
+public class HikariOtelConfig {
+
+    @Bean
+    public BeanPostProcessor hikariMetricsPostProcessor(OpenTelemetry openTelemetry) {
+        HikariTelemetry telemetry = HikariTelemetry.create(openTelemetry);
+        return new BeanPostProcessor() {
+            @Override
+            public Object postProcessAfterInitialization(Object bean, String beanName) {
+                if (bean instanceof HikariDataSource ds) {
+                    ds.setMetricsTrackerFactory(telemetry.createMetricsTrackerFactory());
+                }
+                return bean;
+            }
+        };
+    }
+}

--- a/docker/docker-compose.deploy.yml
+++ b/docker/docker-compose.deploy.yml
@@ -10,6 +10,8 @@ services:
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://goti-alloy:4318"
       OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
       OTEL_RESOURCE_ATTRIBUTES: "service.namespace=goti,deployment.environment=dev"
+      # Experimental JVM metrics: buffer pool, system CPU
+      OTEL_INSTRUMENTATION_RUNTIME_TELEMETRY_EMIT_EXPERIMENTAL_TELEMETRY: "true"
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker/docker-compose.deploy.yml
+++ b/docker/docker-compose.deploy.yml
@@ -7,13 +7,13 @@ services:
     env_file:
       - .env
     environment:
-      OTEL_SDK_DISABLED: "false"
-      OTEL_EXPORTER_ENABLED: "true"
+      OTEL_SDK_DISABLED: "${OTEL_SDK_DISABLED:-false}"
+      OTEL_EXPORTER_ENABLED: "${OTEL_EXPORTER_ENABLED:-true}"
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://goti-alloy:4318"
       OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
       OTEL_RESOURCE_ATTRIBUTES: "service.namespace=goti,deployment.environment=dev"
       # Experimental JVM metrics: buffer pool, system CPU
-      OTEL_INSTRUMENTATION_RUNTIME_TELEMETRY_EMIT_EXPERIMENTAL_TELEMETRY: "true"
+      OTEL_INSTRUMENTATION_RUNTIME_TELEMETRY_EMIT_EXPERIMENTAL_TELEMETRY: "${OTEL_EMIT_EXPERIMENTAL:-true}"
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker/docker-compose.deploy.yml
+++ b/docker/docker-compose.deploy.yml
@@ -7,6 +7,8 @@ services:
     env_file:
       - .env
     environment:
+      OTEL_SDK_DISABLED: "false"
+      OTEL_EXPORTER_ENABLED: "true"
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://goti-alloy:4318"
       OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
       OTEL_RESOURCE_ATTRIBUTES: "service.namespace=goti,deployment.environment=dev"


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #132

<br/>

## 🔎 개요
Grafana 대시보드에 선반영된 HikariCP·Buffer Pool·System CPU·Active Requests 패널을 위한 서버 측 메트릭 수집 설정 추가.

<br/>


## 📋 작업 내용
1. **Micrometer→OTel bridge** (`opentelemetry-micrometer-1.5`) 의존성 추가
   - Spring Boot가 자동 등록하는 HikariCP Micrometer 메트릭을 OTel로 전달
   - 수집 메트릭: `hikaricp_connections_active`, `hikaricp_connections_idle`, `hikaricp_connections_pending`, `hikaricp_connections_acquire_seconds`, `hikaricp_connections_usage_seconds`, `hikaricp_connections_timeout_total`

2. **Experimental JVM metrics** 환경변수 추가 (`docker-compose.deploy.yml`)
   - `OTEL_INSTRUMENTATION_RUNTIME_TELEMETRY_EMIT_EXPERIMENTAL_TELEMETRY=true`
   - 수집 메트릭: `jvm_buffer_memory_used_bytes`, `jvm_buffer_count`, `jvm_system_cpu_utilization_ratio`

3. **ActiveRequestsFilter** 신규 (`api/.../config/observability/`)
   - OTel UpDownCounter 기반 HTTP active requests 커스텀 계측
   - `/actuator` 경로 제외
   - 수집 메트릭: `http_server_active_requests`

<br/>