### PR TITLE
[FEAT] 야구팀 생성 서비스 구현 및 서비스 테스트 코드 추가

### DIFF
--- a/common/src/main/java/com/goti/config/validator/PastYear.java
+++ b/common/src/main/java/com/goti/config/validator/PastYear.java
@@ -1,0 +1,19 @@
+package com.goti.config.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = PastYearValidator.class)
+public @interface PastYear {
+	String message() default "{yearName}은(는) 현재보다 미래일 수 없습니다.";
+	Class<?>[] groups() default {};
+	Class<? extends Payload>[] payload() default {};
+	String yearName() default "연도";
+}

--- a/common/src/main/java/com/goti/config/validator/PastYearValidator.java
+++ b/common/src/main/java/com/goti/config/validator/PastYearValidator.java
@@ -1,0 +1,16 @@
+package com.goti.config.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.time.LocalDate;
+
+public class PastYearValidator implements ConstraintValidator<PastYear, Integer> {
+	@Override
+	public boolean isValid(Integer value, ConstraintValidatorContext context) {
+		if (value == null) return true;
+
+		int currentYear = LocalDate.now().getYear();
+		return value <= currentYear;
+	}
+}

--- a/core/src/main/java/com/goti/constants/TeamCode.java
+++ b/core/src/main/java/com/goti/constants/TeamCode.java
@@ -1,14 +1,22 @@
 package com.goti.constants;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum TeamCode {
-	LG,
-	DO,
-	KIW,
-	HH,
-	KT,
-	SSG,
-	KIA,
-	LOT,
-	NC,
-	SS
+	LG("LG Twins"),
+	DO("Doosan Bears"),
+	KIW("Kiwoom Heroes"),
+	HH("Hanwha Eagles"),
+	KT("KT Wiz"),
+	SSG("SSG Landers"),
+	KIA("KIA Tigers"),
+	LOT("Lotte Giants"),
+	NC("NC Dinos"),
+	SS("Samsung Lions")
+	;
+
+	private final String description;
 }

--- a/core/src/main/java/com/goti/domain/entity/team/BaseballTeamEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/team/BaseballTeamEntity.java
@@ -163,7 +163,7 @@ public class BaseballTeamEntity extends ModificationTimestampEntity {
 
 		Preconditions.domainValidate(
 			StringUtils.hasText(teamName),
-			"구단(팀)이름은 비어있을 수 없습니다."
+			"구단(팀)명은 비어있을 수 없습니다."
 		);
 
 		Preconditions.domainValidate(

--- a/core/src/main/java/com/goti/domain/entity/team/BaseballTeamEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/team/BaseballTeamEntity.java
@@ -183,7 +183,7 @@ public class BaseballTeamEntity extends ModificationTimestampEntity {
 
 		Preconditions.domainValidate(
 			foundedYear != null && foundedYear <= LocalDate.now().getYear(),
-			"창단년도는 비어있거나 현재 혹은 미래일 수 없습니다."
+			"창단년도는 비어있거나 현재연도와 같거나 미래일 수 없습니다."
 		);
 
 		Preconditions.domainValidate(

--- a/core/src/main/java/com/goti/domain/entity/team/BaseballTeamEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/team/BaseballTeamEntity.java
@@ -5,6 +5,8 @@ import static lombok.AccessLevel.*;
 import com.goti.constants.TeamCode;
 import com.goti.domain.base.ModificationTimestampEntity;
 
+import com.goti.global.validation.Preconditions;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -13,6 +15,10 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDate;
 
 @Getter
 @Entity
@@ -120,10 +126,92 @@ public class BaseballTeamEntity extends ModificationTimestampEntity {
 		String ceo,
 		String logoUrl
 	) {
+
+		validate(
+			teamCode, teamName, teamNameEn, sponsor,
+			homeGround, foundedYear, officeAddress, zipCode,
+			siteAddress, owner, generalManager, director
+		);
+
 		return new BaseballTeamEntity(
 			teamCode, teamName, teamNameEn, sponsor, homeGround, foundedYear,
 			officeAddress, zipCode, siteAddress, owner,
 			ownerAgency, ceo, generalManager, director, logoUrl
 		);
+
+	}
+
+	private static void validate(
+		TeamCode teamCode,
+		String teamName,
+		String teamNameEn,
+		String sponsor,
+		String homeGround,
+		Integer foundedYear,
+		String officeAddress,
+		String zipCode,
+		String siteAddress,
+		String owner,
+		String generalManager,
+		String director
+	) {
+
+		Preconditions.domainValidate(
+			teamCode != null,
+			"구단(팀)코드는 비어있을 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			StringUtils.hasText(teamName),
+			"구단(팀)이름은 비어있을 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			StringUtils.hasText(teamNameEn),
+			"구단(팀) 영문명은 비어있을 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			StringUtils.hasText(sponsor),
+			"스폰서는 비어있을 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			StringUtils.hasText(homeGround),
+			"연고지는 비어있을 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			foundedYear != null && foundedYear <= LocalDate.now().getYear(),
+			"창단년도는 비어있거나 현재 혹은 미래일 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			StringUtils.hasText(officeAddress),
+			"구단 사무실 도로명주소는 비어있을 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			StringUtils.hasText(zipCode),
+			"구단 사무실 우편주소는 비어있을 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			StringUtils.hasText(siteAddress),
+			"구단 사이트 주소는 비어있을 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			StringUtils.hasText(owner), "구단주명은 비어있을 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			StringUtils.hasText(generalManager), "단장명은 비어있을 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			StringUtils.hasText(director), "감독명은 비어있을 수 없습니다."
+		);
+
 	}
 }

--- a/core/src/test/java/stadium/BaseballTeamEntityTest.java
+++ b/core/src/test/java/stadium/BaseballTeamEntityTest.java
@@ -1,0 +1,401 @@
+package stadium;
+
+import com.goti.constants.TeamCode;
+import com.goti.domain.entity.team.BaseballTeamEntity;
+
+import com.goti.exception.FieldValidationException;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+@ActiveProfiles("test")
+public class BaseballTeamEntityTest {
+
+	BaseballTeamEntity baseballTeam;
+
+	@Test
+	void 구단_생성_성공() {
+		baseballTeam = BaseballTeamEntity.create(
+			TeamCode.SS,
+			"삼성라이온즈",
+			"Samsung Lions",
+			"삼성",
+			"대구",
+			1982,
+			"대구광역시 수성구 야구전설로 1",
+			"42250",
+			"https://www.samsunglions.com/",
+			"홍길동",
+			"삼성그룹",
+			"이재용",
+			"이종열",
+			"박진만",
+			"https://image.url/logo.png"
+		);
+		assertNotNull(baseballTeam);
+		log.info("baseballTeam teamName :: {}", baseballTeam.getTeamName());
+	}
+
+	@Test
+	void 구단_생성_실패_teamCode_null() {
+		assertThatThrownBy(
+			() -> BaseballTeamEntity.create(
+				null,
+				"삼성라이온즈",
+				"Samsung Lions",
+				"삼성",
+				"대구",
+				1982,
+				"대구광역시 수성구 야구전설로 1",
+				"42250",
+				"https://www.samsunglions.com/",
+				"홍길동",
+				"삼성그룹",
+				"이재용",
+				"이종열",
+				"박진만",
+				"https://image.url/logo.png"
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("BaseballTeamEntity:Field-teamCode invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 구단(팀)코드는 비어있을 수 없습니다.", ex.getMessage());
+			}
+		);
+	}
+
+	@NullAndEmptySource
+	@ParameterizedTest
+	void 구단_생성_실패_teamName_null_또는_공백(String teamName) {
+		assertThatThrownBy(
+			() -> BaseballTeamEntity.create(
+				TeamCode.SS,
+				teamName,
+				"Samsung Lions",
+				"삼성",
+				"대구",
+				1982,
+				"대구광역시 수성구 야구전설로 1",
+				"42250",
+				"https://www.samsunglions.com/",
+				"홍길동",
+				"삼성그룹",
+				"이재용",
+				"이종열",
+				"박진만",
+				"https://image.url/logo.png"
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("BaseballTeamEntity:Field-teamName invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 구단(팀)명은 비어있을 수 없습니다.", ex.getMessage());
+			}
+		);
+	}
+
+	@NullAndEmptySource
+	@ParameterizedTest
+	void 구단_생성_실패_teamNameEn_null_또는_공백(String teamNameEn) {
+		assertThatThrownBy(
+			() -> BaseballTeamEntity.create(
+				TeamCode.SS,
+				"삼성라이온즈",
+				teamNameEn,
+				"삼성",
+				"대구",
+				1982,
+				"대구광역시 수성구 야구전설로 1",
+				"42250",
+				"https://www.samsunglions.com/",
+				"홍길동",
+				"삼성그룹",
+				"이재용",
+				"이종열",
+				"박진만",
+				"https://image.url/logo.png"
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("BaseballTeamEntity:Field-teamNameEn invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 구단(팀) 영문명은 비어있을 수 없습니다.", ex.getMessage());
+			}
+		);
+	}
+
+	@NullAndEmptySource
+	@ParameterizedTest
+	void 구단_생성_실패_sponsor_null_또는_공백(String sponsor) {
+		assertThatThrownBy(
+			() -> BaseballTeamEntity.create(
+				TeamCode.SS,
+				"삼성라이온즈",
+				"Samsung Lions",
+				sponsor,
+				"대구",
+				1982,
+				"대구광역시 수성구 야구전설로 1",
+				"42250",
+				"https://www.samsunglions.com/",
+				"홍길동",
+				"삼성그룹",
+				"이재용",
+				"이종열",
+				"박진만",
+				"https://image.url/logo.png"
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("BaseballTeamEntity:Field-sponsor invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 스폰서는 비어있을 수 없습니다.", ex.getMessage());
+			}
+		);
+	}
+
+	@NullAndEmptySource
+	@ParameterizedTest
+	void 구단_생성_실패_homeGround_null_또는_공백(String homeGround) {
+		assertThatThrownBy(
+			() -> BaseballTeamEntity.create(
+				TeamCode.SS,
+				"삼성라이온즈",
+				"Samsung Lions",
+				"삼성",
+				homeGround,
+				1982,
+				"대구광역시 수성구 야구전설로 1",
+				"42250",
+				"https://www.samsunglions.com/",
+				"홍길동",
+				"삼성그룹",
+				"이재용",
+				"이종열",
+				"박진만",
+				"https://image.url/logo.png"
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("BaseballTeamEntity:Field-homeGround invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 연고지는 비어있을 수 없습니다.", ex.getMessage());
+			}
+		);
+	}
+
+	@ParameterizedTest
+	@NullSource
+	@MethodSource("invalidYears")
+	void 구단_생성_실패_foundedYear_유효하지_않음(Integer foundedYear) {
+		assertThatThrownBy(() ->
+			BaseballTeamEntity.create(
+				TeamCode.SS,
+				"삼성라이온즈",
+				"Samsung Lions",
+				"삼성",
+				"대구",
+				null,
+				"대구광역시 수성구 야구전설로 1",
+				"42250",
+				"https://www.samsunglions.com/",
+				"홍길동",
+				"삼성그룹",
+				"이재용",
+				"이종열",
+				"박진만",
+				"https://image.url/logo.png"
+			)
+		).isInstanceOfSatisfying(FieldValidationException.class, ex -> {
+			log.info("BaseballTeamEntity:Field-foundedYear invalid ErrorMessage : {}", ex.getMessage());
+			assertEquals("도메인 필드 오류 : 창단년도는 비어있거나 현재 혹은 미래일 수 없습니다.", ex.getMessage());
+		});
+	}
+
+	@NullAndEmptySource
+	@ParameterizedTest
+	void 구단_생성_실패_officeAddress_null_또는_공백(String officeAddress) {
+		assertThatThrownBy(
+			() -> BaseballTeamEntity.create(
+				TeamCode.SS,
+				"삼성라이온즈",
+				"Samsung Lions",
+				"삼성",
+				"대구",
+				1982,
+				officeAddress,
+				"42250",
+				"https://www.samsunglions.com/",
+				"홍길동",
+				"삼성그룹",
+				"이재용",
+				"이종열",
+				"박진만",
+				"https://image.url/logo.png"
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("BaseballTeamEntity:Field-officeAddress invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 구단 사무실 도로명주소는 비어있을 수 없습니다.", ex.getMessage());
+			}
+		);
+	}
+
+	@NullAndEmptySource
+	@ParameterizedTest
+	void 구단_생성_실패_zipCode_null_또는_공백(String zipCode) {
+		assertThatThrownBy(
+			() -> BaseballTeamEntity.create(
+				TeamCode.SS,
+				"삼성라이온즈",
+				"Samsung Lions",
+				"삼성",
+				"대구",
+				1982,
+				"대구광역시 수성구 야구전설로 1",
+				zipCode,
+				"https://www.samsunglions.com/",
+				"홍길동",
+				"삼성그룹",
+				"이재용",
+				"이종열",
+				"박진만",
+				"https://image.url/logo.png"
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("BaseballTeamEntity:Field-zipCode invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 구단 사무실 우편주소는 비어있을 수 없습니다.", ex.getMessage());
+			}
+		);
+	}
+
+	@NullAndEmptySource
+	@ParameterizedTest
+	void 구단_생성_실패_siteAddress_null_또는_공백(String siteAddress) {
+		assertThatThrownBy(
+			() -> BaseballTeamEntity.create(
+				TeamCode.SS,
+				"삼성라이온즈",
+				"Samsung Lions",
+				"삼성",
+				"대구",
+				1982,
+				"대구광역시 수성구 야구전설로 1",
+				"42250",
+				siteAddress,
+				"이재용",
+				"삼성그룹",
+				"홍길동",
+				"이종열",
+				"박진만",
+				"https://image.url/logo.png"
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("BaseballTeamEntity:Field-siteAddress invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 구단 사이트 주소는 비어있을 수 없습니다.", ex.getMessage());
+			}
+		);
+	}
+
+	@NullAndEmptySource
+	@ParameterizedTest
+	void 구단_생성_실패_owner_null_또는_공백(String owner) {
+		assertThatThrownBy(
+			() -> BaseballTeamEntity.create(
+				TeamCode.SS,
+				"삼성라이온즈",
+				"Samsung Lions",
+				"삼성",
+				"대구",
+				1982,
+				"대구광역시 수성구 야구전설로 1",
+				"42250",
+				"https://www.samsunglions.com/",
+				owner,
+				"삼성그룹",
+				"홍길동",
+				"이종열",
+				"박진만",
+				"https://image.url/logo.png"
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("BaseballTeamEntity:Field-owner invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 구단주명은 비어있을 수 없습니다.", ex.getMessage());
+			}
+		);
+	}
+
+	@NullAndEmptySource
+	@ParameterizedTest
+	void 구단_생성_실패_generalManager_null_또는_공백(String generalManager) {
+		assertThatThrownBy(
+			() -> BaseballTeamEntity.create(
+				TeamCode.SS,
+				"삼성라이온즈",
+				"Samsung Lions",
+				"삼성",
+				"대구",
+				1982,
+				"대구광역시 수성구 야구전설로 1",
+				"42250",
+				"https://www.samsunglions.com/",
+				"이재용",
+				generalManager,
+				"홍길동",
+				"이종열",
+				"박진만",
+				"https://image.url/logo.png"
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("BaseballTeamEntity:Field-generalManager invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 단장명은 비어있을 수 없습니다.", ex.getMessage());
+			}
+		);
+	}
+
+	@NullAndEmptySource
+	@ParameterizedTest
+	void 구단_생성_실패_director_null_또는_공백(String director) {
+		assertThatThrownBy(
+			() -> BaseballTeamEntity.create(
+				TeamCode.SS,
+				"삼성라이온즈",
+				"Samsung Lions",
+				"삼성",
+				"대구",
+				1982,
+				"대구광역시 수성구 야구전설로 1",
+				"42250",
+				"https://www.samsunglions.com/",
+				"홍길동",
+				"삼성그룹",
+				director,
+				"이종열",
+				"박진만",
+				"https://image.url/logo.png"
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("BaseballTeamEntity:Field-director invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 감독명은 비어있을 수 없습니다.", ex.getMessage());
+			}
+		);
+	}
+
+	static Stream<Integer> invalidYears() {
+		return Stream.of(LocalDate.now().getYear() + 1);
+	}
+}

--- a/core/src/test/java/stadium/BaseballTeamEntityTest.java
+++ b/core/src/test/java/stadium/BaseballTeamEntityTest.java
@@ -217,7 +217,7 @@ public class BaseballTeamEntityTest {
 			)
 		).isInstanceOfSatisfying(FieldValidationException.class, ex -> {
 			log.info("BaseballTeamEntity:Field-foundedYear invalid ErrorMessage : {}", ex.getMessage());
-			assertEquals("도메인 필드 오류 : 창단년도는 비어있거나 현재 혹은 미래일 수 없습니다.", ex.getMessage());
+			assertEquals("도메인 필드 오류 : 창단년도는 비어있거나 현재연도와 같거나 미래일 수 없습니다.", ex.getMessage());
 		});
 	}
 

--- a/stadium/src/main/java/com/goti/dto/request/BaseballTeamCreateRequest.java
+++ b/stadium/src/main/java/com/goti/dto/request/BaseballTeamCreateRequest.java
@@ -34,11 +34,11 @@ public record BaseballTeamCreateRequest(
 	@NotNull(message = "구단(팀) 창단년도는 필수 항목입니다.")
 	Integer foundedYear,
 
-	@Schema(description = "창단년도", example = "대구광역시 수성구 야구전설로 1")
+	@Schema(description = "도로명주소", example = "대구광역시 수성구 야구전설로 1")
 	@NotBlank(message = "구단(팀) 사무실 도로명 주소는 필수 항목입니다.")
 	String officeAddress,
 
-	@Schema(description = "구단사무실 우편주소", example = "42250")
+	@Schema(description = "구단 사무실 우편주소", example = "42250")
 	@NotBlank(message = "구단(팀) 사무실 우편주소는 필수 항목입니다.")
 	String zipCode,
 

--- a/stadium/src/main/java/com/goti/dto/request/BaseballTeamCreateRequest.java
+++ b/stadium/src/main/java/com/goti/dto/request/BaseballTeamCreateRequest.java
@@ -9,23 +9,23 @@ import jakarta.validation.constraints.NotNull;
 
 public record BaseballTeamCreateRequest(
 
-	@Schema(description = "구단코드", example = "SS, KIA")
+	@Schema(description = "구단코드", example = "SS")
 	@NotNull(message = "구단(팀) 코드는 필수 항목입니다.")
 	TeamCode teamCode,
 
-	@Schema(description = "구단명", example = "삼성라이온즈, 기아타이거즈")
+	@Schema(description = "구단명", example = "삼성라이온즈")
 	@NotBlank(message = "구단(팀)이름은 필수 항목입니다.")
 	String teamName,
 
-	@Schema(description = "구단명(영문)", example = "Samsung Lions, Kia Tigers")
+	@Schema(description = "구단명(영문)", example = "Samsung Lions")
 	@NotBlank(message = "구단(팀)이름은(영문) 필수 항목입니다.")
 	String teamNameEn,
 
-	@Schema(description = "스폰서", example = "삼성, 기아")
+	@Schema(description = "스폰서", example = "삼성")
 	@NotBlank(message = "구단(팀)의 스폰서는 필수 항목입니다.")
 	String sponsor,
 
-	@Schema(description = "연고지", example = "대구, 광주")
+	@Schema(description = "연고지", example = "대구")
 	@NotBlank(message = "구단(팀) 연고지는 필수 항목입니다.")
 	String homeGround,
 
@@ -50,7 +50,10 @@ public record BaseballTeamCreateRequest(
 	@NotBlank(message = "구단주명은 필수 항목입니다.")
 	String owner,
 
+	@Schema(description = "구단주 대행", example = "홍길동")
 	String ownerAgency,
+
+	@Schema(description = "대표이사", example = "홍길동")
 	String ceo,
 
 	@Schema(description = "단장", example = "홍길동")
@@ -61,6 +64,11 @@ public record BaseballTeamCreateRequest(
 	@NotBlank(message = "구단(팀)의 감독명은 필수 항목입니다.")
 	String director,
 
+
+	@Schema(
+		description = "구단 로고 이미지 URL",
+		example = "https://image.goti.com/logos/samsung_lions.png"
+	)
 	String logoUrl
 ) {
 }

--- a/stadium/src/main/java/com/goti/dto/request/BaseballTeamCreateRequest.java
+++ b/stadium/src/main/java/com/goti/dto/request/BaseballTeamCreateRequest.java
@@ -1,0 +1,66 @@
+package com.goti.dto.request;
+
+import com.goti.config.validator.PastYear;
+import com.goti.constants.TeamCode;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record BaseballTeamCreateRequest(
+
+	@Schema(description = "구단코드", example = "SS, KIA")
+	@NotNull(message = "구단(팀) 코드는 필수 항목입니다.")
+	TeamCode teamCode,
+
+	@Schema(description = "구단명", example = "삼성라이온즈, 기아타이거즈")
+	@NotBlank(message = "구단(팀)이름은 필수 항목입니다.")
+	String teamName,
+
+	@Schema(description = "구단명(영문)", example = "Samsung Lions, Kia Tigers")
+	@NotBlank(message = "구단(팀)이름은(영문) 필수 항목입니다.")
+	String teamNameEn,
+
+	@Schema(description = "스폰서", example = "삼성, 기아")
+	@NotBlank(message = "구단(팀)의 스폰서는 필수 항목입니다.")
+	String sponsor,
+
+	@Schema(description = "스폰서", example = "대구, 광주")
+	@NotBlank(message = "구단(팀) 연고지는 필수 항목입니다.")
+	String homeGround,
+
+	@Schema(description = "창단년도", example = "1995")
+	@PastYear(yearName = "창단년도")
+	@NotNull(message = "구단(팀) 창단년도는 필수 항목입니다.")
+	Integer foundedYear,
+
+	@Schema(description = "창단년도", example = "대구광역시 수성구 야구전설로 1")
+	@NotBlank(message = "구단(팀) 사무실 도로명 주소는 필수 항목입니다.")
+	String officeAddress,
+
+	@Schema(description = "구단사무실 우편주소", example = "42250")
+	@NotBlank(message = "구단(팀) 사무실 우편주소는 필수 항목입니다.")
+	String zipCode,
+
+	@Schema(description = "구단 사이트 주소", example = "https://www.samsunglions.com/")
+	@NotBlank(message = "구단(팀) 사이트 주소는 필수 항목입니다.")
+	String siteAddress,
+
+	@Schema(description = "구단주", example = "홍길동")
+	@NotBlank(message = "구단주명은 필수 항목입니다.")
+	String owner,
+
+	String ownerAgency,
+	String ceo,
+
+	@Schema(description = "단장", example = "홍길동")
+	@NotBlank(message = "구단(팀)의 단장명은 필수 항목입니다.")
+	String generalManager,
+
+	@Schema(description = "감독", example = "홍길동")
+	@NotBlank(message = "구단(팀)의 감독명은 필수 항목입니다.")
+	String director,
+
+	String logoUrl
+) {
+}

--- a/stadium/src/main/java/com/goti/dto/request/BaseballTeamCreateRequest.java
+++ b/stadium/src/main/java/com/goti/dto/request/BaseballTeamCreateRequest.java
@@ -25,7 +25,7 @@ public record BaseballTeamCreateRequest(
 	@NotBlank(message = "구단(팀)의 스폰서는 필수 항목입니다.")
 	String sponsor,
 
-	@Schema(description = "스폰서", example = "대구, 광주")
+	@Schema(description = "연고지", example = "대구, 광주")
 	@NotBlank(message = "구단(팀) 연고지는 필수 항목입니다.")
 	String homeGround,
 

--- a/stadium/src/main/java/com/goti/dto/response/BaseballTeamCreateResponse.java
+++ b/stadium/src/main/java/com/goti/dto/response/BaseballTeamCreateResponse.java
@@ -1,0 +1,29 @@
+package com.goti.dto.response;
+
+import com.goti.constants.TeamCode;
+
+import java.util.UUID;
+
+public record BaseballTeamCreateResponse(
+	UUID teamId,
+	TeamCode teamCode,
+	String teamName,
+	String teamNameEn,
+	String homeGround,
+	String owner,
+	String director
+) {
+	public static BaseballTeamCreateResponse from(
+		UUID teamId,
+		TeamCode teamCode,
+		String teamName,
+		String teamNameEn,
+		String homeGround,
+		String owner,
+		String director
+	) {
+		return new BaseballTeamCreateResponse(
+			teamId, teamCode, teamName, teamNameEn, homeGround, owner, director
+		);
+	}
+}

--- a/stadium/src/main/java/com/goti/repository/BaseballTeamRepository.java
+++ b/stadium/src/main/java/com/goti/repository/BaseballTeamRepository.java
@@ -1,0 +1,12 @@
+package com.goti.repository;
+
+import com.goti.domain.entity.team.BaseballTeamEntity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface BaseballTeamRepository extends JpaRepository<BaseballTeamEntity, UUID> {
+}

--- a/stadium/src/main/java/com/goti/service/domain/baseballteam/BaseballTeamService.java
+++ b/stadium/src/main/java/com/goti/service/domain/baseballteam/BaseballTeamService.java
@@ -1,0 +1,25 @@
+package com.goti.service.domain.baseballteam;
+
+import com.goti.constants.TeamCode;
+import com.goti.dto.response.BaseballTeamCreateResponse;
+
+public interface BaseballTeamService {
+
+	BaseballTeamCreateResponse create(
+		TeamCode teamCode,
+		String teamName,
+		String teamNameEn,
+		String sponsor,
+		String homeGround,
+		Integer foundedYear,
+		String officeAddress,
+		String zipCode,
+		String siteAddress,
+		String owner,
+		String ownerAgency,
+		String ceo,
+		String generalManager,
+		String director,
+		String logoUrl
+	);
+}

--- a/stadium/src/main/java/com/goti/service/domain/baseballteam/BaseballTeamServiceImpl.java
+++ b/stadium/src/main/java/com/goti/service/domain/baseballteam/BaseballTeamServiceImpl.java
@@ -1,0 +1,54 @@
+package com.goti.service.domain.baseballteam;
+
+import com.goti.constants.TeamCode;
+import com.goti.domain.entity.team.BaseballTeamEntity;
+import com.goti.dto.response.BaseballTeamCreateResponse;
+
+import com.goti.repository.BaseballTeamRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BaseballTeamServiceImpl implements BaseballTeamService {
+
+	private final BaseballTeamRepository baseballTeamRepository;
+
+	@Override
+	public BaseballTeamCreateResponse create(
+		TeamCode teamCode,
+		String teamName,
+		String teamNameEn,
+		String sponsor,
+		String homeGround,
+		Integer foundedYear,
+		String officeAddress,
+		String zipCode,
+		String siteAddress,
+		String owner,
+		String ownerAgency,
+		String ceo,
+		String generalManager,
+		String director,
+		String logoUrl
+	) {
+		BaseballTeamEntity baseballTeam = BaseballTeamEntity.create(
+			teamCode, teamName, teamNameEn, sponsor, homeGround, foundedYear, officeAddress,
+			zipCode, siteAddress, owner, ownerAgency, ceo, generalManager, director, logoUrl
+		);
+		baseballTeamRepository.save(baseballTeam);
+
+		return BaseballTeamCreateResponse.from(
+			baseballTeam.getId(),
+			baseballTeam.getTeamCode(),
+			baseballTeam.getTeamName(),
+			baseballTeam.getTeamNameEn(),
+			baseballTeam.getHomeGround(),
+			baseballTeam.getOwner(),
+			baseballTeam.getDirector()
+		);
+	}
+}
+

--- a/stadium/src/main/java/com/goti/service/domain/baseballteam/BaseballTeamServiceImpl.java
+++ b/stadium/src/main/java/com/goti/service/domain/baseballteam/BaseballTeamServiceImpl.java
@@ -9,6 +9,7 @@ import com.goti.repository.BaseballTeamRepository;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +18,7 @@ public class BaseballTeamServiceImpl implements BaseballTeamService {
 	private final BaseballTeamRepository baseballTeamRepository;
 
 	@Override
+	@Transactional
 	public BaseballTeamCreateResponse create(
 		TeamCode teamCode,
 		String teamName,

--- a/stadium/src/test/java/com/goti/service/domain/baseballteam/BaseballTeamServiceTest.java
+++ b/stadium/src/test/java/com/goti/service/domain/baseballteam/BaseballTeamServiceTest.java
@@ -1,0 +1,78 @@
+package com.goti.service.domain.baseballteam;
+
+import com.goti.GotiStadiumApplication;
+
+import com.goti.constants.TeamCode;
+import com.goti.dto.request.BaseballTeamCreateRequest;
+import com.goti.dto.response.BaseballTeamCreateResponse;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@Slf4j
+@Transactional
+@SpringBootTest(classes = GotiStadiumApplication.class)
+@ActiveProfiles("test")
+public class BaseballTeamServiceTest {
+
+	@Autowired
+	BaseballTeamService baseballTeamService;
+
+	BaseballTeamCreateRequest baseballTeamCreateRequest;
+
+	@BeforeEach
+	void setup() {
+		baseballTeamCreateRequest = new BaseballTeamCreateRequest(
+			TeamCode.SS,
+			"삼성라이온즈",
+			"Samsung Lions",
+			"삼성",
+			"대구",
+			1982,
+			"대구광역시 수성구 야구전설로 1",
+			"42250",
+			"https://www.samsunglions.com/",
+			"홍길동",
+			"삼성그룹",
+			"이재용",
+			"이종열",
+			"박진만",
+			"https://image.url/logo.png"
+		);
+	}
+
+	@Test
+	void 야구구단_생성_성공() {
+		BaseballTeamCreateResponse response = baseballTeamService.create(
+			baseballTeamCreateRequest.teamCode(),
+			baseballTeamCreateRequest.teamName(),
+			baseballTeamCreateRequest.teamNameEn(),
+			baseballTeamCreateRequest.sponsor(),
+			baseballTeamCreateRequest.homeGround(),
+			baseballTeamCreateRequest.foundedYear(),
+			baseballTeamCreateRequest.officeAddress(),
+			baseballTeamCreateRequest.zipCode(),
+			baseballTeamCreateRequest.siteAddress(),
+			baseballTeamCreateRequest.owner(),
+			baseballTeamCreateRequest.generalManager(),
+			baseballTeamCreateRequest.director(),
+			baseballTeamCreateRequest.ownerAgency(),
+			baseballTeamCreateRequest.ceo(),
+			baseballTeamCreateRequest.logoUrl()
+		);
+
+		assertNotNull(response.teamId());
+		log.info("response teamId :: {}", response.teamId());
+		log.info("response teamName :: {}", response.teamName());
+
+	}
+
+}


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#131 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
야구구단 생성 서비스 로직 구현 및 서비스 테스트 코드 추가
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- 야구구단 엔티티 (BaseballTeamEntity validate 도메인 검증 추가)
- 야구구단 생성 요청 dto 추가
- 과거날짜 검증 custom annotation 추가 (PastYear 및 Validator)
- 야구구단 Create Domain 서비스 추가 및 로직 구현 (BaseballTeamService)
- 야구구단 도메인 Repository 추가
- 야구구단 생성 응답 ResponseDto 생성 (BaseballTeamCreateResponse)
- 야구구단 생성 서비스 테스트 코드 추가 (성공 - 실패케이스 -> 도메인테스트로 대체)
- 야구구단 도메인 테스트 코드 추가 (성공 및 실패 케이스 추가)
<br/>