### PR TITLE
[REFACTOR] 야구 게임 상태 (BaseballGameStatusEntity) 네이밍 수정 및 엔티티 생성로직 개선

### DIFF
--- a/common/src/main/java/com/goti/config/validator/PastYear.java
+++ b/common/src/main/java/com/goti/config/validator/PastYear.java
@@ -1,0 +1,19 @@
+package com.goti.config.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = PastYearValidator.class)
+public @interface PastYear {
+	String message() default "{yearName}은(는) 현재보다 미래일 수 없습니다.";
+	Class<?>[] groups() default {};
+	Class<? extends Payload>[] payload() default {};
+	String yearName() default "연도";
+}

--- a/common/src/main/java/com/goti/config/validator/PastYearValidator.java
+++ b/common/src/main/java/com/goti/config/validator/PastYearValidator.java
@@ -1,0 +1,16 @@
+package com.goti.config.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.time.LocalDate;
+
+public class PastYearValidator implements ConstraintValidator<PastYear, Integer> {
+	@Override
+	public boolean isValid(Integer value, ConstraintValidatorContext context) {
+		if (value == null) return true;
+
+		int currentYear = LocalDate.now().getYear();
+		return value <= currentYear;
+	}
+}

--- a/common/src/main/java/com/goti/constants/messages/ErrorCode.java
+++ b/common/src/main/java/com/goti/constants/messages/ErrorCode.java
@@ -62,6 +62,7 @@ public enum ErrorCode {
 	SEAT_BULK_CREATE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "한 번에 생성할 수 있는 좌석 수를 초과했습니다."),
 	SEAT_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 생성된 좌석이 포함되어 있습니다."),
 	SEAT_SECTION_CAPACITY_EXCEEDED(HttpStatus.BAD_REQUEST, "좌석 구역의 수용 인원을 초과할 수 없습니다."),
+	TICKET_PRICE_CONDITION_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 동일한 티켓 가격 조건이 존재합니다."),
 
 	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
 	SOCIAL_PROVIDER_ALREADY_LINKED(HttpStatus.BAD_REQUEST, "해당 소셜 계정은 이미 다른 회원과 연동되어 있습니다."),

--- a/core/src/main/java/com/goti/constants/GameResult.java
+++ b/core/src/main/java/com/goti/constants/GameResult.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum GameResult {
 
-	PENDING("경기 미종료"),
+	NONE("결과 없음"),
 	HOME_WIN("홈팀 승리"),
 	AWAY_WIN("원정팀 승리"),
 	DRAW("무승부"),

--- a/core/src/main/java/com/goti/constants/OrderCancelDenyReason.java
+++ b/core/src/main/java/com/goti/constants/OrderCancelDenyReason.java
@@ -1,0 +1,15 @@
+package com.goti.constants;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderCancelDenyReason {
+
+	USED("티켓 사용 완료"),
+	EXPIRED("취소 가능 기간 초과"),
+	NOT_REFUNDABLE("리셀 티켓 환불 불가");
+
+	private final String description;
+}

--- a/core/src/main/java/com/goti/constants/OrderCancellationRequestType.java
+++ b/core/src/main/java/com/goti/constants/OrderCancellationRequestType.java
@@ -1,0 +1,16 @@
+package com.goti.constants;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderCancellationRequestType {
+
+	USER_PARTIAL("부분 취소"),
+	USER_FULL("전체 취소"),
+	GAME_CANCELED("경기 취소"),
+	SCHEDULE_CHANGED("경기 일정 변경");
+
+	private final String description;
+}

--- a/core/src/main/java/com/goti/constants/OrderCancellationStatus.java
+++ b/core/src/main/java/com/goti/constants/OrderCancellationStatus.java
@@ -1,0 +1,18 @@
+package com.goti.constants;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderCancellationStatus {
+
+	REQUESTED("요청 접수"),
+	VALIDATED("요청 검증 통과"),
+	APPROVAL_PENDING("운영자 승인 대기"),
+	REFUNDING("PG 환불 중"),
+	COMPLETED("취소/환불 완료"),
+	FAILED("실패");
+
+	private final String description;
+}

--- a/core/src/main/java/com/goti/constants/OrderItemStatus.java
+++ b/core/src/main/java/com/goti/constants/OrderItemStatus.java
@@ -1,0 +1,16 @@
+package com.goti.constants;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderItemStatus {
+
+	RESERVED("예약"),
+	PAID("결제 완료"),
+	CANCELED("취소"),
+	CANCEL_FAILED("취소 실패");
+
+	private final String description;
+}

--- a/core/src/main/java/com/goti/constants/OrderStatus.java
+++ b/core/src/main/java/com/goti/constants/OrderStatus.java
@@ -1,0 +1,16 @@
+package com.goti.constants;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderStatus {
+
+	PENDING("주문 대기"),
+	CONFIRMED("주문 확정"),
+	CANCELED("주문 취소"),
+	PARTIALLY_CANCELED("부분 취소");
+
+	private final String description;
+}

--- a/core/src/main/java/com/goti/constants/TeamCode.java
+++ b/core/src/main/java/com/goti/constants/TeamCode.java
@@ -1,14 +1,22 @@
 package com.goti.constants;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum TeamCode {
-	LG,
-	DO,
-	KIW,
-	HH,
-	KT,
-	SSG,
-	KIA,
-	LOT,
-	NC,
-	SS
+	LG("LG Twins"),
+	DO("Doosan Bears"),
+	KIW("Kiwoom Heroes"),
+	HH("Hanwha Eagles"),
+	KT("KT Wiz"),
+	SSG("SSG Landers"),
+	KIA("KIA Tigers"),
+	LOT("Lotte Giants"),
+	NC("NC Dinos"),
+	SS("Samsung Lions")
+	;
+
+	private final String description;
 }

--- a/core/src/main/java/com/goti/constants/TicketPricingDayType.java
+++ b/core/src/main/java/com/goti/constants/TicketPricingDayType.java
@@ -1,0 +1,14 @@
+package com.goti.constants;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TicketPricingDayType {
+
+	WEEKDAY("평일"),
+	WEEKEND("주말");
+
+	private final String description;
+}

--- a/core/src/main/java/com/goti/constants/TicketPricingMatchType.java
+++ b/core/src/main/java/com/goti/constants/TicketPricingMatchType.java
@@ -1,0 +1,15 @@
+package com.goti.constants;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TicketPricingMatchType {
+
+	EXHIBITION("시범 경기"),
+	REGULAR("정규리그"),
+	POST_SEASON("포스트시즌");
+
+	private final String description;
+}

--- a/core/src/main/java/com/goti/constants/TicketType.java
+++ b/core/src/main/java/com/goti/constants/TicketType.java
@@ -1,0 +1,13 @@
+package com.goti.constants;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TicketType {
+
+	ADULT("성인");
+
+	private final String description;
+}

--- a/core/src/main/java/com/goti/domain/entity/game/GameStatusEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/game/GameStatusEntity.java
@@ -6,13 +6,14 @@ import com.goti.constants.GameResult;
 import com.goti.constants.GameStatus;
 import com.goti.domain.base.ModificationTimestampEntity;
 
+import com.goti.global.validation.Preconditions;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
@@ -20,9 +21,9 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "baseball_game_statuses")
+@Table(name = "game_statuses")
 @NoArgsConstructor(access = PROTECTED)
-public class BaseballGameStatusEntity extends ModificationTimestampEntity {
+public class GameStatusEntity extends ModificationTimestampEntity {
 
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "game_schedule_id", nullable = false)
@@ -42,21 +43,23 @@ public class BaseballGameStatusEntity extends ModificationTimestampEntity {
 	@Column(nullable = false)
 	private GameResult gameResult;
 
-	private BaseballGameStatusEntity(
-		GameScheduleEntity gameSchedule,
-		GameStatus gameStatus,
-		GameResult gameResult
-	) {
+	private GameStatusEntity(GameScheduleEntity gameSchedule) {
 		this.gameSchedule = gameSchedule;
-		this.gameStatus = gameStatus;
+		this.gameStatus = GameStatus.SCHEDULED;
 		this.homeTeamScore = 0;
 		this.awayTeamScore = 0;
-		this.gameResult = gameResult;
+		this.gameResult = GameResult.NONE;
 	}
 
-	// TODO: 추후 점수 변경 시 메서드로 변경
+	public static GameStatusEntity create(GameScheduleEntity gameSchedule) {
+		validate(gameSchedule);
+		return new GameStatusEntity(gameSchedule);
+	}
 
-	public static BaseballGameStatusEntity init(GameScheduleEntity game) {
-		return new BaseballGameStatusEntity(game, GameStatus.SCHEDULED, GameResult.PENDING);
+	private static void validate(GameScheduleEntity gameSchedule) {
+		Preconditions.domainValidate(
+			gameSchedule != null,
+			"게임일정 값은 비어있을 수 없습니다."
+		);
 	}
 }

--- a/core/src/main/java/com/goti/domain/entity/order/OrderCancellationEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/order/OrderCancellationEntity.java
@@ -1,0 +1,146 @@
+package com.goti.domain.entity.order;
+
+import static lombok.AccessLevel.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.springframework.util.StringUtils;
+
+import com.goti.constants.OrderCancelDenyReason;
+import com.goti.constants.OrderCancellationRequestType;
+import com.goti.constants.OrderCancellationStatus;
+import com.goti.domain.base.ModificationTimestampEntity;
+import com.goti.global.validation.Preconditions;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+	name = "order_cancellations",
+	indexes = {
+		@Index(name = "idx_order_cancellations_order_id", columnList = "order_id")
+	}
+)
+@NoArgsConstructor(access = PROTECTED)
+public class OrderCancellationEntity extends ModificationTimestampEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "order_id", nullable = false)
+	private OrderEntity order;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private OrderCancellationStatus status;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private OrderCancellationRequestType requestType;
+
+	@Enumerated(EnumType.STRING)
+	private OrderCancelDenyReason denyReasonCode;
+
+	@Column(nullable = false)
+	private UUID requestedBy;
+
+	private UUID approvedBy;
+
+	private LocalDateTime approvedAt;
+
+	@Column(nullable = false)
+	private Integer refundAmountTotal;
+
+	@Column(nullable = false)
+	private Integer feeAmountTotal;
+
+	private LocalDateTime completedAt;
+
+	@Column(nullable = false, unique = true)
+	private String idempotencyKey;
+
+	private OrderCancellationEntity(
+		OrderEntity order,
+		OrderCancellationRequestType requestType,
+		UUID requestedBy,
+		Integer refundAmountTotal,
+		Integer feeAmountTotal,
+		String idempotencyKey
+	) {
+		this.order = order;
+		this.status = OrderCancellationStatus.REQUESTED;
+		this.requestType = requestType;
+		this.denyReasonCode = null;
+		this.requestedBy = requestedBy;
+		this.approvedBy = null;
+		this.approvedAt = null;
+		this.refundAmountTotal = refundAmountTotal;
+		this.feeAmountTotal = feeAmountTotal;
+		this.completedAt = null;
+		this.idempotencyKey = idempotencyKey;
+	}
+
+	public static OrderCancellationEntity create(
+		OrderEntity order,
+		OrderCancellationRequestType requestType,
+		UUID requestedBy,
+		Integer refundAmountTotal,
+		Integer feeAmountTotal,
+		String idempotencyKey
+	) {
+		validate(
+			requestType,
+			requestedBy,
+			refundAmountTotal,
+			feeAmountTotal,
+			idempotencyKey
+		);
+		return new OrderCancellationEntity(
+			order,
+			requestType,
+			requestedBy,
+			refundAmountTotal,
+			feeAmountTotal,
+			idempotencyKey
+		);
+	}
+
+	private static void validate(
+		OrderCancellationRequestType requestType,
+		UUID requestedBy,
+		Integer refundAmountTotal,
+		Integer feeAmountTotal,
+		String idempotencyKey
+	) {
+		Preconditions.domainValidate(
+			requestType != null,
+			"취소 요청 타입은 필수입니다."
+		);
+		Preconditions.domainValidate(
+			requestedBy != null,
+			"요청자는 필수입니다."
+		);
+		Preconditions.domainValidate(
+			refundAmountTotal != null && refundAmountTotal >= 0,
+			"총 환불액은 0 이상이어야 합니다."
+		);
+		Preconditions.domainValidate(
+			feeAmountTotal != null && feeAmountTotal >= 0,
+			"총 수수료는 0 이상이어야 합니다."
+		);
+		Preconditions.domainValidate(
+			StringUtils.hasText(idempotencyKey),
+			"멱등 키는 비어 있을 수 없습니다."
+		);
+	}
+}

--- a/core/src/main/java/com/goti/domain/entity/order/OrderCancellationItemEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/order/OrderCancellationItemEntity.java
@@ -1,0 +1,89 @@
+package com.goti.domain.entity.order;
+
+import static lombok.AccessLevel.*;
+
+import java.time.LocalDateTime;
+
+import com.goti.domain.base.ModificationTimestampEntity;
+import com.goti.global.validation.Preconditions;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+	name = "order_cancellation_items",
+	indexes = {
+		@Index(name = "idx_order_cancellation_items_cancellation_id", columnList = "cancellation_id"),
+		@Index(name = "idx_order_cancellation_items_item_id", columnList = "item_id")
+	}
+)
+@NoArgsConstructor(access = PROTECTED)
+public class OrderCancellationItemEntity extends ModificationTimestampEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "cancellation_id", nullable = false)
+	private OrderCancellationEntity cancellation;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "item_id", nullable = false)
+	private OrderItemEntity item;
+
+	@Column(nullable = false)
+	private Integer refundAmount;
+
+	@Column(nullable = false)
+	private Integer feeAmount;
+
+	private LocalDateTime cancelledAt;
+
+	private OrderCancellationItemEntity(
+		OrderCancellationEntity cancellation,
+		OrderItemEntity item,
+		Integer refundAmount,
+		Integer feeAmount
+	) {
+		this.cancellation = cancellation;
+		this.item = item;
+		this.refundAmount = refundAmount;
+		this.feeAmount = feeAmount;
+		this.cancelledAt = null;
+	}
+
+	public static OrderCancellationItemEntity create(
+		OrderCancellationEntity cancellation,
+		OrderItemEntity item,
+		Integer refundAmount,
+		Integer feeAmount
+	) {
+		validate(refundAmount, feeAmount);
+		return new OrderCancellationItemEntity(
+			cancellation,
+			item,
+			refundAmount,
+			feeAmount
+		);
+	}
+
+	private static void validate(
+		Integer refundAmount,
+		Integer feeAmount
+	) {
+		Preconditions.domainValidate(
+			refundAmount != null && refundAmount >= 0,
+			"환불액은 0 이상이어야 합니다."
+		);
+		Preconditions.domainValidate(
+			feeAmount != null && feeAmount >= 0,
+			"수수료는 0 이상이어야 합니다."
+		);
+	}
+}

--- a/core/src/main/java/com/goti/domain/entity/order/OrderEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/order/OrderEntity.java
@@ -1,0 +1,120 @@
+package com.goti.domain.entity.order;
+
+import static lombok.AccessLevel.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.springframework.util.StringUtils;
+
+import com.goti.constants.OrderStatus;
+import com.goti.domain.base.ModificationTimestampEntity;
+import com.goti.domain.entity.game.GameScheduleEntity;
+import com.goti.global.validation.Preconditions;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+	name = "orders",
+	indexes = {
+		@Index(name = "idx_orders_user_id", columnList = "user_id"),
+		@Index(name = "idx_orders_game_schedule_id", columnList = "game_schedule_id")
+	}
+)
+@NoArgsConstructor(access = PROTECTED)
+public class OrderEntity extends ModificationTimestampEntity {
+
+	@Column(nullable = false, unique = true)
+	private String orderNumber;
+
+	@Column(nullable = false)
+	private UUID userId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "game_schedule_id", nullable = false)
+	private GameScheduleEntity gameSchedule;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private OrderStatus orderStatus;
+
+	@Column(nullable = false)
+	private Integer totalQuantity;
+
+	@Column(nullable = false)
+	private Integer totalAmount;
+
+	private LocalDateTime confirmedAt;
+
+	private LocalDateTime canceledAt;
+
+	private OrderEntity(
+		String orderNumber,
+		UUID userId,
+		GameScheduleEntity gameSchedule,
+		Integer totalQuantity,
+		Integer totalAmount
+	) {
+		this.orderNumber = orderNumber;
+		this.userId = userId;
+		this.gameSchedule = gameSchedule;
+		this.orderStatus = OrderStatus.PENDING;
+		this.totalQuantity = totalQuantity;
+		this.totalAmount = totalAmount;
+		this.confirmedAt = null;
+		this.canceledAt = null;
+	}
+
+	public static OrderEntity create(
+		String orderNumber,
+		UUID userId,
+		GameScheduleEntity gameSchedule,
+		Integer totalQuantity,
+		Integer totalAmount
+	) {
+		validate(orderNumber, userId, totalQuantity, totalAmount);
+		return new OrderEntity(
+			orderNumber,
+			userId,
+			gameSchedule,
+			totalQuantity,
+			totalAmount
+		);
+	}
+
+	private static void validate(
+		String orderNumber,
+		UUID userId,
+		Integer totalQuantity,
+		Integer totalAmount
+	) {
+		Preconditions.domainValidate(
+			StringUtils.hasText(orderNumber),
+			"주문 번호는 비어 있을 수 없습니다."
+		);
+		Preconditions.domainValidate(
+			userId != null,
+			"유저 ID는 필수입니다."
+		);
+		Preconditions.domainValidate(
+			totalQuantity != null && totalQuantity > 0,
+			"총 수량은 0보다 커야 합니다."
+		);
+		Preconditions.domainValidate(
+			totalAmount != null && totalAmount > 0,
+			"총 금액은 0보다 커야 합니다."
+		);
+	}
+}

--- a/core/src/main/java/com/goti/domain/entity/order/OrderItemEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/order/OrderItemEntity.java
@@ -1,0 +1,94 @@
+package com.goti.domain.entity.order;
+
+import static lombok.AccessLevel.*;
+
+import com.goti.constants.OrderItemStatus;
+import com.goti.constants.TicketType;
+import com.goti.domain.base.CreationTimestampEntity;
+import com.goti.domain.base.ModificationTimestampEntity;
+import com.goti.domain.entity.seat.SeatEntity;
+import com.goti.global.validation.Preconditions;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+	name = "order_items",
+	indexes = {
+		@Index(name = "idx_order_items_order_id", columnList = "order_id")
+	},
+	uniqueConstraints = {
+		@UniqueConstraint(name = "uk_order_items_order_id_seat_id", columnNames = {"order_id", "seat_id"})
+	}
+)
+@NoArgsConstructor(access = PROTECTED)
+public class OrderItemEntity extends ModificationTimestampEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "order_id", nullable = false)
+	private OrderEntity order;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "seat_id", nullable = false)
+	private SeatEntity seat;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private TicketType ticketType;
+
+	@Column(nullable = false)
+	private Integer ticketPrice;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private OrderItemStatus itemStatus;
+
+	private OrderItemEntity(
+		OrderEntity order,
+		SeatEntity seat,
+		TicketType ticketType,
+		Integer ticketPrice
+	) {
+		this.order = order;
+		this.seat = seat;
+		this.ticketType = ticketType;
+		this.ticketPrice = ticketPrice;
+		this.itemStatus = OrderItemStatus.RESERVED;
+	}
+
+	public static OrderItemEntity create(
+		OrderEntity order,
+		SeatEntity seat,
+		TicketType ticketType,
+		Integer ticketPrice
+	) {
+		validate(ticketType, ticketPrice);
+		return new OrderItemEntity(order, seat, ticketType, ticketPrice);
+	}
+
+	private static void validate(
+		TicketType ticketType,
+		Integer ticketPrice
+	) {
+		Preconditions.domainValidate(
+			ticketType != null,
+			"권종은 필수입니다."
+		);
+		Preconditions.domainValidate(
+			ticketPrice != null && ticketPrice >= 0,
+			"티켓 가격은 0원 보다 커야합니다"
+		);
+	}
+}

--- a/core/src/main/java/com/goti/domain/entity/order/OrdererEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/order/OrdererEntity.java
@@ -1,0 +1,84 @@
+package com.goti.domain.entity.order;
+
+import static lombok.AccessLevel.*;
+
+import org.springframework.util.StringUtils;
+
+import com.goti.domain.base.ModificationTimestampEntity;
+import com.goti.global.validation.Preconditions;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+	name = "orderers",
+	uniqueConstraints = {
+		@UniqueConstraint(name = "uk_orderers_order_id", columnNames = "order_id")
+	}
+)
+@NoArgsConstructor(access = PROTECTED)
+public class OrdererEntity extends ModificationTimestampEntity {
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "order_id", nullable = false)
+	private OrderEntity order;
+
+	@Column(nullable = false)
+	private String name;
+
+	@Column(nullable = false)
+	private String mobile;
+
+	@Column(nullable = false)
+	private String email;
+
+	private OrdererEntity(
+		OrderEntity order,
+		String name,
+		String mobile,
+		String email
+	) {
+		this.order = order;
+		this.name = name;
+		this.mobile = mobile;
+		this.email = email;
+	}
+
+	public static OrdererEntity create(
+		OrderEntity order,
+		String name,
+		String mobile,
+		String email
+	) {
+		validate(name, mobile, email);
+		return new OrdererEntity(order, name, mobile, email);
+	}
+
+	private static void validate(
+		String name,
+		String mobile,
+		String email
+	) {
+		Preconditions.domainValidate(
+			StringUtils.hasText(name),
+			"구매자 이름은 비어 있을 수 없습니다."
+		);
+		Preconditions.domainValidate(
+			StringUtils.hasText(mobile),
+			"구매자 연락처는 비어 있을 수 없습니다."
+		);
+		Preconditions.domainValidate(
+			StringUtils.hasText(email),
+			"구매자 이메일은 비어 있을 수 없습니다."
+		);
+	}
+}

--- a/core/src/main/java/com/goti/domain/entity/pricing/TicketPriceEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/pricing/TicketPriceEntity.java
@@ -58,17 +58,13 @@ public class TicketPriceEntity extends ModificationTimestampEntity {
 	@Column(nullable = false)
 	private Integer price;
 
-	@Column(nullable = false)
-	private UUID createdBy;
-
 	private TicketPriceEntity(
 		SeatGradeEntity grade,
 		TicketPricingPolicyEntity policy,
 		TicketType ticketType,
 		TicketPricingDayType dayType,
 		TicketPricingMatchType matchType,
-		Integer price,
-		UUID createdBy
+		Integer price
 	) {
 		this.grade = grade;
 		this.policy = policy;
@@ -76,7 +72,6 @@ public class TicketPriceEntity extends ModificationTimestampEntity {
 		this.dayType = dayType;
 		this.matchType = matchType;
 		this.price = price;
-		this.createdBy = createdBy;
 	}
 
 	public static TicketPriceEntity create(
@@ -85,18 +80,16 @@ public class TicketPriceEntity extends ModificationTimestampEntity {
 		TicketType ticketType,
 		TicketPricingDayType dayType,
 		TicketPricingMatchType matchType,
-		Integer price,
-		UUID createdBy
+		Integer price
 	) {
-		validate(ticketType, dayType, matchType, price, createdBy);
+		validate(ticketType, dayType, matchType, price);
 		return new TicketPriceEntity(
 			grade,
 			policy,
 			ticketType,
 			dayType,
 			matchType,
-			price,
-			createdBy
+			price
 		);
 	}
 
@@ -104,8 +97,7 @@ public class TicketPriceEntity extends ModificationTimestampEntity {
 		TicketType ticketType,
 		TicketPricingDayType dayType,
 		TicketPricingMatchType matchType,
-		Integer price,
-		UUID createdBy
+		Integer price
 	) {
 		Preconditions.domainValidate(
 			ticketType != null,
@@ -122,10 +114,6 @@ public class TicketPriceEntity extends ModificationTimestampEntity {
 		Preconditions.domainValidate(
 			price != null && price >= 0,
 			"가격은 0 이상이어야 합니다."
-		);
-		Preconditions.domainValidate(
-			createdBy != null,
-			"생성자 ID는 필수입니다."
 		);
 	}
 }

--- a/core/src/main/java/com/goti/domain/entity/pricing/TicketPriceEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/pricing/TicketPriceEntity.java
@@ -1,0 +1,131 @@
+package com.goti.domain.entity.pricing;
+
+import static lombok.AccessLevel.*;
+
+import java.util.UUID;
+
+import com.goti.constants.TicketPricingDayType;
+import com.goti.constants.TicketPricingMatchType;
+import com.goti.constants.TicketType;
+import com.goti.domain.base.ModificationTimestampEntity;
+import com.goti.domain.entity.seat.SeatGradeEntity;
+import com.goti.global.validation.Preconditions;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+	name = "ticket_prices",
+	indexes = {
+		@Index(name = "idx_ticket_prices_grade_id", columnList = "grade_id"),
+		@Index(name = "idx_ticket_prices_policy_id", columnList = "policy_id")
+	}
+)
+@NoArgsConstructor(access = PROTECTED)
+public class TicketPriceEntity extends ModificationTimestampEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "grade_id", nullable = false)
+	private SeatGradeEntity grade;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "policy_id", nullable = false)
+	private TicketPricingPolicyEntity policy;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private TicketType ticketType;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private TicketPricingDayType dayType;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private TicketPricingMatchType matchType;
+
+	@Column(nullable = false)
+	private Integer price;
+
+	@Column(nullable = false)
+	private UUID createdBy;
+
+	private TicketPriceEntity(
+		SeatGradeEntity grade,
+		TicketPricingPolicyEntity policy,
+		TicketType ticketType,
+		TicketPricingDayType dayType,
+		TicketPricingMatchType matchType,
+		Integer price,
+		UUID createdBy
+	) {
+		this.grade = grade;
+		this.policy = policy;
+		this.ticketType = ticketType;
+		this.dayType = dayType;
+		this.matchType = matchType;
+		this.price = price;
+		this.createdBy = createdBy;
+	}
+
+	public static TicketPriceEntity create(
+		SeatGradeEntity grade,
+		TicketPricingPolicyEntity policy,
+		TicketType ticketType,
+		TicketPricingDayType dayType,
+		TicketPricingMatchType matchType,
+		Integer price,
+		UUID createdBy
+	) {
+		validate(ticketType, dayType, matchType, price, createdBy);
+		return new TicketPriceEntity(
+			grade,
+			policy,
+			ticketType,
+			dayType,
+			matchType,
+			price,
+			createdBy
+		);
+	}
+
+	private static void validate(
+		TicketType ticketType,
+		TicketPricingDayType dayType,
+		TicketPricingMatchType matchType,
+		Integer price,
+		UUID createdBy
+	) {
+		Preconditions.domainValidate(
+			ticketType != null,
+			"권종은 필수입니다."
+		);
+		Preconditions.domainValidate(
+			dayType != null,
+			"요일 유형은 필수입니다."
+		);
+		Preconditions.domainValidate(
+			matchType != null,
+			"매치 유형은 필수입니다."
+		);
+		Preconditions.domainValidate(
+			price != null && price >= 0,
+			"가격은 0 이상이어야 합니다."
+		);
+		Preconditions.domainValidate(
+			createdBy != null,
+			"생성자 ID는 필수입니다."
+		);
+	}
+}

--- a/core/src/main/java/com/goti/domain/entity/pricing/TicketPricingPolicyEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/pricing/TicketPricingPolicyEntity.java
@@ -32,42 +32,34 @@ public class TicketPricingPolicyEntity extends ModificationTimestampEntity {
 	@Column(nullable = false)
 	private boolean isActive;
 
-	@Column(nullable = false)
-	private UUID createdBy;
-
 	private TicketPricingPolicyEntity(
 		UUID teamId,
 		LocalDate policyStartAt,
-		LocalDate policyEndAt,
-		UUID createdBy
+		LocalDate policyEndAt
 	) {
 		this.teamId = teamId;
 		this.policyStartAt = policyStartAt;
 		this.policyEndAt = policyEndAt;
 		this.isActive = true;
-		this.createdBy = createdBy;
 	}
 
 	public static TicketPricingPolicyEntity create(
 		UUID teamId,
 		LocalDate policyStartAt,
-		LocalDate policyEndAt,
-		UUID createdBy
+		LocalDate policyEndAt
 	) {
-		validate(teamId, policyStartAt, policyEndAt, createdBy);
+		validate(teamId, policyStartAt, policyEndAt);
 		return new TicketPricingPolicyEntity(
 			teamId,
 			policyStartAt,
-			policyEndAt,
-			createdBy
+			policyEndAt
 		);
 	}
 
 	private static void validate(
 		UUID teamId,
 		LocalDate policyStartAt,
-		LocalDate policyEndAt,
-		UUID createdBy
+		LocalDate policyEndAt
 	) {
 		Preconditions.domainValidate(
 			teamId != null,
@@ -84,10 +76,6 @@ public class TicketPricingPolicyEntity extends ModificationTimestampEntity {
 		Preconditions.domainValidate(
 			!policyEndAt.isBefore(policyStartAt),
 			"정책 종료일은 시작일보다 빠를 수 없습니다."
-		);
-		Preconditions.domainValidate(
-			createdBy != null,
-			"생성자 ID는 필수입니다."
 		);
 	}
 }

--- a/core/src/main/java/com/goti/domain/entity/pricing/TicketPricingPolicyEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/pricing/TicketPricingPolicyEntity.java
@@ -1,0 +1,93 @@
+package com.goti.domain.entity.pricing;
+
+import static lombok.AccessLevel.*;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import com.goti.domain.base.ModificationTimestampEntity;
+import com.goti.global.validation.Preconditions;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "ticket_pricing_policies")
+@NoArgsConstructor(access = PROTECTED)
+public class TicketPricingPolicyEntity extends ModificationTimestampEntity {
+
+	@Column(nullable = false)
+	private UUID teamId;
+
+	@Column(nullable = false)
+	private LocalDate policyStartAt;
+
+	@Column(nullable = false)
+	private LocalDate policyEndAt;
+
+	@Column(nullable = false)
+	private boolean isActive;
+
+	@Column(nullable = false)
+	private UUID createdBy;
+
+	private TicketPricingPolicyEntity(
+		UUID teamId,
+		LocalDate policyStartAt,
+		LocalDate policyEndAt,
+		UUID createdBy
+	) {
+		this.teamId = teamId;
+		this.policyStartAt = policyStartAt;
+		this.policyEndAt = policyEndAt;
+		this.isActive = true;
+		this.createdBy = createdBy;
+	}
+
+	public static TicketPricingPolicyEntity create(
+		UUID teamId,
+		LocalDate policyStartAt,
+		LocalDate policyEndAt,
+		UUID createdBy
+	) {
+		validate(teamId, policyStartAt, policyEndAt, createdBy);
+		return new TicketPricingPolicyEntity(
+			teamId,
+			policyStartAt,
+			policyEndAt,
+			createdBy
+		);
+	}
+
+	private static void validate(
+		UUID teamId,
+		LocalDate policyStartAt,
+		LocalDate policyEndAt,
+		UUID createdBy
+	) {
+		Preconditions.domainValidate(
+			teamId != null,
+			"팀 ID는 필수입니다."
+		);
+		Preconditions.domainValidate(
+			policyStartAt != null,
+			"정책 시작일은 필수입니다."
+		);
+		Preconditions.domainValidate(
+			policyEndAt != null,
+			"정책 종료일은 필수입니다."
+		);
+		Preconditions.domainValidate(
+			!policyEndAt.isBefore(policyStartAt),
+			"정책 종료일은 시작일보다 빠를 수 없습니다."
+		);
+		Preconditions.domainValidate(
+			createdBy != null,
+			"생성자 ID는 필수입니다."
+		);
+	}
+}

--- a/core/src/main/java/com/goti/domain/entity/seat/SeatStatusEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/seat/SeatStatusEntity.java
@@ -25,17 +25,17 @@ import lombok.NoArgsConstructor;
 @Table(
 	name = "seat_statuses",
 	uniqueConstraints = {
-		@UniqueConstraint(name = "uk_game_seat", columnNames = {"game_id", "seat_id"})
+		@UniqueConstraint(name = "uk_game_seat", columnNames = {"game_schedule_id", "seat_id"})
 	},
 	indexes = {
-		@Index(name = "idx_game_status", columnList = "game_id, status")
+		@Index(name = "idx_game_status", columnList = "game_schedule_id, status")
 	}
 )
 @NoArgsConstructor(access = PROTECTED)
 public class SeatStatusEntity extends ModificationTimestampEntity {
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "game_id", nullable = false)
+	@JoinColumn(name = "game_schedule_id", nullable = false)
 	private GameScheduleEntity game;
 
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/core/src/main/java/com/goti/domain/entity/team/BaseballTeamEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/team/BaseballTeamEntity.java
@@ -5,6 +5,8 @@ import static lombok.AccessLevel.*;
 import com.goti.constants.TeamCode;
 import com.goti.domain.base.ModificationTimestampEntity;
 
+import com.goti.global.validation.Preconditions;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -13,6 +15,10 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDate;
 
 @Getter
 @Entity
@@ -120,10 +126,92 @@ public class BaseballTeamEntity extends ModificationTimestampEntity {
 		String ceo,
 		String logoUrl
 	) {
+
+		validate(
+			teamCode, teamName, teamNameEn, sponsor,
+			homeGround, foundedYear, officeAddress, zipCode,
+			siteAddress, owner, generalManager, director
+		);
+
 		return new BaseballTeamEntity(
 			teamCode, teamName, teamNameEn, sponsor, homeGround, foundedYear,
 			officeAddress, zipCode, siteAddress, owner,
 			ownerAgency, ceo, generalManager, director, logoUrl
 		);
+
+	}
+
+	private static void validate(
+		TeamCode teamCode,
+		String teamName,
+		String teamNameEn,
+		String sponsor,
+		String homeGround,
+		Integer foundedYear,
+		String officeAddress,
+		String zipCode,
+		String siteAddress,
+		String owner,
+		String generalManager,
+		String director
+	) {
+
+		Preconditions.domainValidate(
+			teamCode != null,
+			"구단(팀)코드는 비어있을 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			StringUtils.hasText(teamName),
+			"구단(팀)명은 비어있을 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			StringUtils.hasText(teamNameEn),
+			"구단(팀) 영문명은 비어있을 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			StringUtils.hasText(sponsor),
+			"스폰서는 비어있을 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			StringUtils.hasText(homeGround),
+			"연고지는 비어있을 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			foundedYear != null && foundedYear <= LocalDate.now().getYear(),
+			"창단년도는 비어있거나 현재연도와 같거나 미래일 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			StringUtils.hasText(officeAddress),
+			"구단 사무실 도로명주소는 비어있을 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			StringUtils.hasText(zipCode),
+			"구단 사무실 우편주소는 비어있을 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			StringUtils.hasText(siteAddress),
+			"구단 사이트 주소는 비어있을 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			StringUtils.hasText(owner), "구단주명은 비어있을 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			StringUtils.hasText(generalManager), "단장명은 비어있을 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			StringUtils.hasText(director), "감독명은 비어있을 수 없습니다."
+		);
+
 	}
 }

--- a/core/src/test/java/game/GameStatusEntityTest.java
+++ b/core/src/test/java/game/GameStatusEntityTest.java
@@ -7,6 +7,8 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.UUID;
 
+import com.goti.exception.FieldValidationException;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
@@ -22,11 +24,11 @@ import lombok.extern.slf4j.Slf4j;
 @ActiveProfiles("test")
 public class GameStatusEntityTest {
 
-	GameScheduleEntity baseballGame;
+	GameScheduleEntity gameSchedule;
 
 	@BeforeEach
 	void setup() {
-		baseballGame = GameScheduleEntity.create(
+		gameSchedule = GameScheduleEntity.create(
 			UUID.randomUUID(),
 			UUID.randomUUID(),
 			UUID.randomUUID(),
@@ -36,11 +38,11 @@ public class GameStatusEntityTest {
 	}
 
 	@Test
-	void 경기상태_init_성공() {
-		GameStatusEntity gameStatus = GameStatusEntity.create(baseballGame);
+	void 경기상태_생성_성공() {
+		GameStatusEntity gameStatus = GameStatusEntity.create(gameSchedule);
 
 		assertNotNull(gameStatus);
-		assertThat(gameStatus.getGameSchedule()).isEqualTo(baseballGame);
+		assertThat(gameStatus.getGameSchedule()).isEqualTo(gameSchedule);
 		assertThat(gameStatus.getGameStatus()).isEqualTo(GameStatus.SCHEDULED);
 		assertThat(gameStatus.getHomeTeamScore()).isEqualTo(0);
 		assertThat(gameStatus.getAwayTeamScore()).isEqualTo(0);
@@ -51,12 +53,15 @@ public class GameStatusEntityTest {
 	}
 
 	@Test
-	void 경기상태_init_기본값_적용() {
-		GameStatusEntity gameStatus = GameStatusEntity.create(baseballGame);
+	void 경기상태_생성_실패_gameSchedule_null() {
 
-		assertThat(gameStatus.getGameStatus()).isEqualTo(GameStatus.SCHEDULED);
-		assertThat(gameStatus.getGameResult()).isEqualTo(GameResult.NONE);
-		assertThat(gameStatus.getHomeTeamScore()).isEqualTo(0);
-		assertThat(gameStatus.getAwayTeamScore()).isEqualTo(0);
+		assertThatThrownBy(
+			() -> GameStatusEntity.create(gameSchedule)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("경기상태 엔티티 : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 게임일정 값은 비어있을 수 없습니다.", ex.getMessage());
+			}
+		);
 	}
 }

--- a/core/src/test/java/game/GameStatusEntityTest.java
+++ b/core/src/test/java/game/GameStatusEntityTest.java
@@ -56,7 +56,7 @@ public class GameStatusEntityTest {
 	void 경기상태_생성_실패_gameSchedule_null() {
 
 		assertThatThrownBy(
-			() -> GameStatusEntity.create(gameSchedule)
+			() -> GameStatusEntity.create(null)
 		).isInstanceOfSatisfying(
 			FieldValidationException.class, ex -> {
 				log.info("경기상태 엔티티 : {}", ex.getMessage());

--- a/core/src/test/java/game/GameStatusEntityTest.java
+++ b/core/src/test/java/game/GameStatusEntityTest.java
@@ -14,13 +14,13 @@ import org.springframework.test.context.ActiveProfiles;
 import com.goti.constants.GameResult;
 import com.goti.constants.GameStatus;
 import com.goti.domain.entity.game.GameScheduleEntity;
-import com.goti.domain.entity.game.BaseballGameStatusEntity;
+import com.goti.domain.entity.game.GameStatusEntity;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @ActiveProfiles("test")
-public class BaseballGameStatusEntityTest {
+public class GameStatusEntityTest {
 
 	GameScheduleEntity baseballGame;
 
@@ -37,14 +37,14 @@ public class BaseballGameStatusEntityTest {
 
 	@Test
 	void 경기상태_init_성공() {
-		BaseballGameStatusEntity gameStatus = BaseballGameStatusEntity.init(baseballGame);
+		GameStatusEntity gameStatus = GameStatusEntity.create(baseballGame);
 
 		assertNotNull(gameStatus);
 		assertThat(gameStatus.getGameSchedule()).isEqualTo(baseballGame);
 		assertThat(gameStatus.getGameStatus()).isEqualTo(GameStatus.SCHEDULED);
 		assertThat(gameStatus.getHomeTeamScore()).isEqualTo(0);
 		assertThat(gameStatus.getAwayTeamScore()).isEqualTo(0);
-		assertThat(gameStatus.getGameResult()).isEqualTo(GameResult.PENDING);
+		assertThat(gameStatus.getGameResult()).isEqualTo(GameResult.NONE);
 
 		log.info("gameStatus : {}", gameStatus.getGameStatus());
 		log.info("score : {}:{}", gameStatus.getHomeTeamScore(), gameStatus.getAwayTeamScore());
@@ -52,10 +52,10 @@ public class BaseballGameStatusEntityTest {
 
 	@Test
 	void 경기상태_init_기본값_적용() {
-		BaseballGameStatusEntity gameStatus = BaseballGameStatusEntity.init(baseballGame);
+		GameStatusEntity gameStatus = GameStatusEntity.create(baseballGame);
 
 		assertThat(gameStatus.getGameStatus()).isEqualTo(GameStatus.SCHEDULED);
-		assertThat(gameStatus.getGameResult()).isEqualTo(GameResult.PENDING);
+		assertThat(gameStatus.getGameResult()).isEqualTo(GameResult.NONE);
 		assertThat(gameStatus.getHomeTeamScore()).isEqualTo(0);
 		assertThat(gameStatus.getAwayTeamScore()).isEqualTo(0);
 	}

--- a/core/src/test/java/order/OrderCancellationEntityTest.java
+++ b/core/src/test/java/order/OrderCancellationEntityTest.java
@@ -1,0 +1,133 @@
+package order;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.goti.constants.OrderCancellationRequestType;
+import com.goti.constants.OrderCancellationStatus;
+import com.goti.domain.entity.game.GameScheduleEntity;
+import com.goti.domain.entity.order.OrderCancellationEntity;
+import com.goti.domain.entity.order.OrderEntity;
+import com.goti.exception.FieldValidationException;
+
+@ActiveProfiles("test")
+class OrderCancellationEntityTest {
+
+	private OrderEntity order;
+	private UUID requestedBy;
+	private Integer refundAmountTotal;
+	private Integer feeAmountTotal;
+	private String idempotencyKey;
+
+	@BeforeEach
+	void setup() {
+		GameScheduleEntity gameSchedule = GameScheduleEntity.create(
+			UUID.randomUUID(),
+			UUID.randomUUID(),
+			UUID.randomUUID(),
+			LocalDate.of(2026, 4, 1),
+			LocalTime.of(18, 30)
+		);
+		order = OrderEntity.create("ORD-20260309-0001", UUID.randomUUID(), gameSchedule, 2, 24000);
+		requestedBy = UUID.randomUUID();
+		refundAmountTotal = 12000;
+		feeAmountTotal = 1000;
+		idempotencyKey = "cancel-idempotency-key";
+	}
+
+	@Test
+	void 주문취소_생성_성공() {
+		OrderCancellationEntity cancellation = OrderCancellationEntity.create(
+			order,
+			OrderCancellationRequestType.USER_PARTIAL,
+			requestedBy,
+			refundAmountTotal,
+			feeAmountTotal,
+			idempotencyKey
+		);
+
+		assertThat(cancellation.getOrder()).isEqualTo(order);
+		assertThat(cancellation.getStatus()).isEqualTo(OrderCancellationStatus.REQUESTED);
+		assertThat(cancellation.getRequestType()).isEqualTo(OrderCancellationRequestType.USER_PARTIAL);
+		assertThat(cancellation.getDenyReasonCode()).isNull();
+		assertThat(cancellation.getRequestedBy()).isEqualTo(requestedBy);
+		assertThat(cancellation.getRefundAmountTotal()).isEqualTo(refundAmountTotal);
+		assertThat(cancellation.getFeeAmountTotal()).isEqualTo(feeAmountTotal);
+		assertThat(cancellation.getIdempotencyKey()).isEqualTo(idempotencyKey);
+		assertThat(cancellation.getApprovedBy()).isNull();
+		assertThat(cancellation.getApprovedAt()).isNull();
+		assertThat(cancellation.getCompletedAt()).isNull();
+	}
+
+	@Test
+	void 주문취소_생성_실패_요청타입_null() {
+		assertThatThrownBy(
+			() -> OrderCancellationEntity.create(
+				order,
+				null,
+				requestedBy,
+				refundAmountTotal,
+				feeAmountTotal,
+				idempotencyKey
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("취소 요청 타입은 필수입니다.");
+	}
+
+	@Test
+	void 주문취소_생성_실패_요청자_null() {
+		assertThatThrownBy(
+			() -> OrderCancellationEntity.create(
+				order,
+				OrderCancellationRequestType.USER_PARTIAL,
+				null,
+				refundAmountTotal,
+				feeAmountTotal,
+				idempotencyKey
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("요청자는 필수입니다.");
+	}
+
+	@Test
+	void 주문취소_생성_실패_총환불액_음수() {
+		assertThatThrownBy(
+			() -> OrderCancellationEntity.create(
+				order,
+				OrderCancellationRequestType.USER_PARTIAL,
+				requestedBy,
+				-1,
+				feeAmountTotal,
+				idempotencyKey
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("총 환불액은 0 이상이어야 합니다.");
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	@ValueSource(strings = {" ", "   "})
+	void 주문취소_생성_실패_멱등키_공백(String invalidIdempotencyKey) {
+		assertThatThrownBy(
+			() -> OrderCancellationEntity.create(
+				order,
+				OrderCancellationRequestType.USER_PARTIAL,
+				requestedBy,
+				refundAmountTotal,
+				feeAmountTotal,
+				invalidIdempotencyKey
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("멱등 키는 비어 있을 수 없습니다.");
+	}
+}

--- a/core/src/test/java/order/OrderCancellationItemEntityTest.java
+++ b/core/src/test/java/order/OrderCancellationItemEntityTest.java
@@ -1,0 +1,86 @@
+package order;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.goti.constants.OrderCancellationRequestType;
+import com.goti.domain.entity.game.GameScheduleEntity;
+import com.goti.domain.entity.order.OrderCancellationEntity;
+import com.goti.domain.entity.order.OrderCancellationItemEntity;
+import com.goti.domain.entity.order.OrderEntity;
+import com.goti.domain.entity.order.OrderItemEntity;
+import com.goti.domain.entity.seat.SeatEntity;
+import com.goti.domain.entity.seat.SeatGradeEntity;
+import com.goti.domain.entity.seat.SeatSectionEntity;
+import com.goti.exception.FieldValidationException;
+
+@ActiveProfiles("test")
+class OrderCancellationItemEntityTest {
+
+	private OrderCancellationEntity cancellation;
+	private OrderItemEntity item;
+
+	@BeforeEach
+	void setup() {
+		GameScheduleEntity gameSchedule = GameScheduleEntity.create(
+			UUID.randomUUID(),
+			UUID.randomUUID(),
+			UUID.randomUUID(),
+			LocalDate.of(2026, 4, 1),
+			LocalTime.of(18, 30)
+		);
+		OrderEntity order = OrderEntity.create("ORD-20260309-0001", UUID.randomUUID(), gameSchedule, 2, 24000);
+		cancellation = OrderCancellationEntity.create(
+			order,
+			OrderCancellationRequestType.USER_PARTIAL,
+			UUID.randomUUID(),
+			12000,
+			1000,
+			"cancel-idempotency-key"
+		);
+
+		SeatGradeEntity seatGrade = SeatGradeEntity.create(UUID.randomUUID(), "VIP", "#FFAA00");
+		SeatSectionEntity seatSection = SeatSectionEntity.create(seatGrade, UUID.randomUUID(), "101", 120);
+		SeatEntity seat = SeatEntity.create(seatSection, "A", 1);
+		item = OrderItemEntity.create(order, seat, com.goti.constants.TicketType.ADULT, 12000);
+	}
+
+	@Test
+	void 주문취소상세_생성_성공() {
+		OrderCancellationItemEntity cancellationItem = OrderCancellationItemEntity.create(
+			cancellation,
+			item,
+			11000,
+			1000
+		);
+
+		assertThat(cancellationItem.getCancellation()).isEqualTo(cancellation);
+		assertThat(cancellationItem.getItem()).isEqualTo(item);
+		assertThat(cancellationItem.getRefundAmount()).isEqualTo(11000);
+		assertThat(cancellationItem.getFeeAmount()).isEqualTo(1000);
+		assertThat(cancellationItem.getCancelledAt()).isNull();
+	}
+
+	@Test
+	void 주문취소상세_생성_실패_환불액_음수() {
+		assertThatThrownBy(
+			() -> OrderCancellationItemEntity.create(cancellation, item, -1, 1000)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("환불액은 0 이상이어야 합니다.");
+	}
+
+	@Test
+	void 주문취소상세_생성_실패_수수료_음수() {
+		assertThatThrownBy(
+			() -> OrderCancellationItemEntity.create(cancellation, item, 11000, -1)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("수수료는 0 이상이어야 합니다.");
+	}
+}

--- a/core/src/test/java/order/OrderEntityTest.java
+++ b/core/src/test/java/order/OrderEntityTest.java
@@ -1,0 +1,122 @@
+package order;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.goti.constants.OrderStatus;
+import com.goti.domain.entity.game.GameScheduleEntity;
+import com.goti.domain.entity.order.OrderEntity;
+import com.goti.exception.FieldValidationException;
+
+@ActiveProfiles("test")
+class OrderEntityTest {
+
+	private String orderNumber;
+	private UUID userId;
+	private GameScheduleEntity gameSchedule;
+	private Integer totalQuantity;
+	private Integer totalAmount;
+
+	@BeforeEach
+	void setup() {
+		orderNumber = "ORD-20260309-0001";
+		userId = UUID.randomUUID();
+		gameSchedule = GameScheduleEntity.create(
+			UUID.randomUUID(),
+			UUID.randomUUID(),
+			UUID.randomUUID(),
+			LocalDate.of(2026, 4, 1),
+			LocalTime.of(18, 30)
+		);
+		totalQuantity = 2;
+		totalAmount = 24000;
+	}
+
+	@Test
+	void 주문_생성_성공() {
+		OrderEntity order = OrderEntity.create(
+			orderNumber,
+			userId,
+			gameSchedule,
+			totalQuantity,
+			totalAmount
+		);
+
+		assertThat(order.getOrderNumber()).isEqualTo(orderNumber);
+		assertThat(order.getUserId()).isEqualTo(userId);
+		assertThat(order.getGameSchedule()).isEqualTo(gameSchedule);
+		assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.PENDING);
+		assertThat(order.getTotalQuantity()).isEqualTo(totalQuantity);
+		assertThat(order.getTotalAmount()).isEqualTo(totalAmount);
+		assertThat(order.getConfirmedAt()).isNull();
+		assertThat(order.getCanceledAt()).isNull();
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	@ValueSource(strings = {" ", "   "})
+	void 주문_생성_실패_주문번호_빈값(String invalidOrderNumber) {
+		assertThatThrownBy(
+			() -> OrderEntity.create(
+				invalidOrderNumber,
+				userId,
+				gameSchedule,
+				totalQuantity,
+				totalAmount
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("주문 번호는 비어 있을 수 없습니다.");
+	}
+
+	@Test
+	void 주문_생성_실패_유저ID_null() {
+		assertThatThrownBy(
+			() -> OrderEntity.create(
+				orderNumber,
+				null,
+				gameSchedule,
+				totalQuantity,
+				totalAmount
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("유저 ID는 필수입니다.");
+	}
+
+	@Test
+	void 주문_생성_실패_총수량_0() {
+		assertThatThrownBy(
+			() -> OrderEntity.create(
+				orderNumber,
+				userId,
+				gameSchedule,
+				0,
+				totalAmount
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("총 수량은 0보다 커야 합니다.");
+	}
+
+	@Test
+	void 주문_생성_실패_총금액_음수() {
+		assertThatThrownBy(
+			() -> OrderEntity.create(
+				orderNumber,
+				userId,
+				gameSchedule,
+				totalQuantity,
+				-1
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("총 금액은 0보다 커야 합니다.");
+	}
+}

--- a/core/src/test/java/order/OrderItemEntityTest.java
+++ b/core/src/test/java/order/OrderItemEntityTest.java
@@ -1,0 +1,71 @@
+package order;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.goti.constants.OrderItemStatus;
+import com.goti.constants.TicketType;
+import com.goti.domain.entity.game.GameScheduleEntity;
+import com.goti.domain.entity.order.OrderEntity;
+import com.goti.domain.entity.order.OrderItemEntity;
+import com.goti.domain.entity.seat.SeatEntity;
+import com.goti.domain.entity.seat.SeatGradeEntity;
+import com.goti.domain.entity.seat.SeatSectionEntity;
+import com.goti.exception.FieldValidationException;
+
+@ActiveProfiles("test")
+class OrderItemEntityTest {
+
+	OrderEntity order;
+	SeatEntity seat;
+
+	@BeforeEach
+	void setup() {
+		GameScheduleEntity gameSchedule = GameScheduleEntity.create(
+			UUID.randomUUID(),
+			UUID.randomUUID(),
+			UUID.randomUUID(),
+			LocalDate.of(2026, 4, 1),
+			LocalTime.of(18, 30)
+		);
+		order = OrderEntity.create("ORD-20260309-0001", UUID.randomUUID(), gameSchedule, 2, 24000);
+
+		SeatGradeEntity seatGrade = SeatGradeEntity.create(UUID.randomUUID(), "VIP", "#FFAA00");
+		SeatSectionEntity seatSection = SeatSectionEntity.create(seatGrade, UUID.randomUUID(), "101", 120);
+		seat = SeatEntity.create(seatSection, "A", 1);
+	}
+
+	@Test
+	void 주문상세_생성_성공() {
+		OrderItemEntity item = OrderItemEntity.create(order, seat, TicketType.ADULT, 12000);
+
+		assertThat(item.getOrder()).isEqualTo(order);
+		assertThat(item.getSeat()).isEqualTo(seat);
+		assertThat(item.getTicketType()).isEqualTo(TicketType.ADULT);
+		assertThat(item.getTicketPrice()).isEqualTo(12000);
+		assertThat(item.getItemStatus()).isEqualTo(OrderItemStatus.RESERVED);
+	}
+
+	@Test
+	void 주문상세_생성_실패_권종_null() {
+		assertThatThrownBy(
+			() -> OrderItemEntity.create(order, seat, null, 12000)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("권종은 필수입니다.");
+	}
+
+	@Test
+	void 주문상세_생성_실패_판매금액_음수() {
+		assertThatThrownBy(
+			() -> OrderItemEntity.create(order, seat, TicketType.ADULT, -1)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("티켓 가격은 0원 보다 커야합니다");
+	}
+}

--- a/core/src/test/java/order/OrdererEntityTest.java
+++ b/core/src/test/java/order/OrdererEntityTest.java
@@ -1,0 +1,90 @@
+package order;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.goti.domain.entity.game.GameScheduleEntity;
+import com.goti.domain.entity.order.OrderEntity;
+import com.goti.domain.entity.order.OrdererEntity;
+import com.goti.exception.FieldValidationException;
+
+@ActiveProfiles("test")
+class OrdererEntityTest {
+
+	OrderEntity order;
+	String name;
+	String mobile;
+	String email;
+
+	@BeforeEach
+	void setup() {
+		GameScheduleEntity gameSchedule = GameScheduleEntity.create(
+			UUID.randomUUID(),
+			UUID.randomUUID(),
+			UUID.randomUUID(),
+			LocalDate.of(2026, 4, 1),
+			LocalTime.of(18, 30)
+		);
+
+		order = OrderEntity.create(
+			"ORD-20260309-0001",
+			UUID.randomUUID(),
+			gameSchedule,
+			2,
+			24000
+		);
+		name = "홍길동";
+		mobile = "01012345678";
+		email = "orderer@goti.com";
+	}
+
+	@Test
+	void 구매자정보_생성_성공() {
+		OrdererEntity orderer = OrdererEntity.create(order, name, mobile, email);
+
+		assertThat(orderer.getOrder()).isEqualTo(order);
+		assertThat(orderer.getName()).isEqualTo(name);
+		assertThat(orderer.getMobile()).isEqualTo(mobile);
+		assertThat(orderer.getEmail()).isEqualTo(email);
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	@ValueSource(strings = {" ", "   "})
+	void 구매자정보_생성_실패_이름_빈값(String invalidName) {
+		assertThatThrownBy(
+			() -> OrdererEntity.create(order, invalidName, mobile, email)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("구매자 이름은 비어 있을 수 없습니다.");
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	@ValueSource(strings = {" ", "   "})
+	void 구매자정보_생성_실패_연락처_빈값(String invalidMobile) {
+		assertThatThrownBy(
+			() -> OrdererEntity.create(order, name, invalidMobile, email)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("구매자 연락처는 비어 있을 수 없습니다.");
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	@ValueSource(strings = {" ", "   "})
+	void 구매자정보_생성_실패_이메일_빈값(String invalidEmail) {
+		assertThatThrownBy(
+			() -> OrdererEntity.create(order, name, mobile, invalidEmail)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("구매자 이메일은 비어 있을 수 없습니다.");
+	}
+}

--- a/core/src/test/java/pricing/TicketPriceEntityTest.java
+++ b/core/src/test/java/pricing/TicketPriceEntityTest.java
@@ -1,0 +1,139 @@
+package pricing;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.goti.constants.TicketPricingDayType;
+import com.goti.constants.TicketPricingMatchType;
+import com.goti.constants.TicketType;
+import com.goti.domain.entity.pricing.TicketPriceEntity;
+import com.goti.domain.entity.pricing.TicketPricingPolicyEntity;
+import com.goti.domain.entity.seat.SeatGradeEntity;
+import com.goti.exception.FieldValidationException;
+
+@ActiveProfiles("test")
+class TicketPriceEntityTest {
+
+	private SeatGradeEntity grade;
+	private TicketPricingPolicyEntity policy;
+	private UUID createdBy;
+
+	@BeforeEach
+	void setup() {
+		grade = SeatGradeEntity.create(UUID.randomUUID(), "VIP", "#FFAA00");
+		policy = TicketPricingPolicyEntity.create(
+			UUID.randomUUID(),
+			LocalDate.of(2026, 3, 1),
+			LocalDate.of(2026, 10, 31),
+			UUID.randomUUID()
+		);
+		createdBy = UUID.randomUUID();
+	}
+
+	@Test
+	void 티켓요금_생성_성공() {
+		TicketPriceEntity ticketPrice = TicketPriceEntity.create(
+			grade,
+			policy,
+			TicketType.ADULT,
+			TicketPricingDayType.WEEKDAY,
+			TicketPricingMatchType.REGULAR,
+			15000,
+			createdBy
+		);
+
+		assertThat(ticketPrice.getGrade()).isEqualTo(grade);
+		assertThat(ticketPrice.getPolicy()).isEqualTo(policy);
+		assertThat(ticketPrice.getTicketType()).isEqualTo(TicketType.ADULT);
+		assertThat(ticketPrice.getDayType()).isEqualTo(TicketPricingDayType.WEEKDAY);
+		assertThat(ticketPrice.getMatchType()).isEqualTo(TicketPricingMatchType.REGULAR);
+		assertThat(ticketPrice.getPrice()).isEqualTo(15000);
+		assertThat(ticketPrice.getCreatedBy()).isEqualTo(createdBy);
+	}
+
+	@Test
+	void 티켓요금_생성_실패_권종_null() {
+		assertThatThrownBy(
+			() -> TicketPriceEntity.create(
+				grade,
+				policy,
+				null,
+				TicketPricingDayType.WEEKDAY,
+				TicketPricingMatchType.REGULAR,
+				15000,
+				createdBy
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("권종은 필수입니다.");
+	}
+
+	@Test
+	void 티켓요금_생성_실패_요일유형_null() {
+		assertThatThrownBy(
+			() -> TicketPriceEntity.create(
+				grade,
+				policy,
+				TicketType.ADULT,
+				null,
+				TicketPricingMatchType.REGULAR,
+				15000,
+				createdBy
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("요일 유형은 필수입니다.");
+	}
+
+	@Test
+	void 티켓요금_생성_실패_매치유형_null() {
+		assertThatThrownBy(
+			() -> TicketPriceEntity.create(
+				grade,
+				policy,
+				TicketType.ADULT,
+				TicketPricingDayType.WEEKDAY,
+				null,
+				15000,
+				createdBy
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("매치 유형은 필수입니다.");
+	}
+
+	@Test
+	void 티켓요금_생성_실패_가격_음수() {
+		assertThatThrownBy(
+			() -> TicketPriceEntity.create(
+				grade,
+				policy,
+				TicketType.ADULT,
+				TicketPricingDayType.WEEKDAY,
+				TicketPricingMatchType.REGULAR,
+				-1,
+				createdBy
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("가격은 0 이상이어야 합니다.");
+	}
+
+	@Test
+	void 티켓요금_생성_실패_생성자_null() {
+		assertThatThrownBy(
+			() -> TicketPriceEntity.create(
+				grade,
+				policy,
+				TicketType.ADULT,
+				TicketPricingDayType.WEEKDAY,
+				TicketPricingMatchType.REGULAR,
+				15000,
+				null
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("생성자 ID는 필수입니다.");
+	}
+}

--- a/core/src/test/java/pricing/TicketPriceEntityTest.java
+++ b/core/src/test/java/pricing/TicketPriceEntityTest.java
@@ -20,9 +20,8 @@ import com.goti.exception.FieldValidationException;
 @ActiveProfiles("test")
 class TicketPriceEntityTest {
 
-	private SeatGradeEntity grade;
-	private TicketPricingPolicyEntity policy;
-	private UUID createdBy;
+	SeatGradeEntity grade;
+	TicketPricingPolicyEntity policy;
 
 	@BeforeEach
 	void setup() {
@@ -30,10 +29,8 @@ class TicketPriceEntityTest {
 		policy = TicketPricingPolicyEntity.create(
 			UUID.randomUUID(),
 			LocalDate.of(2026, 3, 1),
-			LocalDate.of(2026, 10, 31),
-			UUID.randomUUID()
+			LocalDate.of(2026, 10, 31)
 		);
-		createdBy = UUID.randomUUID();
 	}
 
 	@Test
@@ -44,8 +41,7 @@ class TicketPriceEntityTest {
 			TicketType.ADULT,
 			TicketPricingDayType.WEEKDAY,
 			TicketPricingMatchType.REGULAR,
-			15000,
-			createdBy
+			15000
 		);
 
 		assertThat(ticketPrice.getGrade()).isEqualTo(grade);
@@ -54,7 +50,6 @@ class TicketPriceEntityTest {
 		assertThat(ticketPrice.getDayType()).isEqualTo(TicketPricingDayType.WEEKDAY);
 		assertThat(ticketPrice.getMatchType()).isEqualTo(TicketPricingMatchType.REGULAR);
 		assertThat(ticketPrice.getPrice()).isEqualTo(15000);
-		assertThat(ticketPrice.getCreatedBy()).isEqualTo(createdBy);
 	}
 
 	@Test
@@ -66,8 +61,7 @@ class TicketPriceEntityTest {
 				null,
 				TicketPricingDayType.WEEKDAY,
 				TicketPricingMatchType.REGULAR,
-				15000,
-				createdBy
+				15000
 			)
 		).isInstanceOf(FieldValidationException.class)
 			.hasMessageContaining("권종은 필수입니다.");
@@ -82,8 +76,7 @@ class TicketPriceEntityTest {
 				TicketType.ADULT,
 				null,
 				TicketPricingMatchType.REGULAR,
-				15000,
-				createdBy
+				15000
 			)
 		).isInstanceOf(FieldValidationException.class)
 			.hasMessageContaining("요일 유형은 필수입니다.");
@@ -98,8 +91,7 @@ class TicketPriceEntityTest {
 				TicketType.ADULT,
 				TicketPricingDayType.WEEKDAY,
 				null,
-				15000,
-				createdBy
+				15000
 			)
 		).isInstanceOf(FieldValidationException.class)
 			.hasMessageContaining("매치 유형은 필수입니다.");
@@ -114,26 +106,9 @@ class TicketPriceEntityTest {
 				TicketType.ADULT,
 				TicketPricingDayType.WEEKDAY,
 				TicketPricingMatchType.REGULAR,
-				-1,
-				createdBy
+				-1
 			)
 		).isInstanceOf(FieldValidationException.class)
 			.hasMessageContaining("가격은 0 이상이어야 합니다.");
-	}
-
-	@Test
-	void 티켓요금_생성_실패_생성자_null() {
-		assertThatThrownBy(
-			() -> TicketPriceEntity.create(
-				grade,
-				policy,
-				TicketType.ADULT,
-				TicketPricingDayType.WEEKDAY,
-				TicketPricingMatchType.REGULAR,
-				15000,
-				null
-			)
-		).isInstanceOf(FieldValidationException.class)
-			.hasMessageContaining("생성자 ID는 필수입니다.");
 	}
 }

--- a/core/src/test/java/pricing/TicketPricingPolicyEntityTest.java
+++ b/core/src/test/java/pricing/TicketPricingPolicyEntityTest.java
@@ -15,17 +15,15 @@ import com.goti.exception.FieldValidationException;
 @ActiveProfiles("test")
 class TicketPricingPolicyEntityTest {
 
-	private UUID teamId;
-	private LocalDate policyStartAt;
-	private LocalDate policyEndAt;
-	private UUID createdBy;
+	UUID teamId;
+	LocalDate policyStartAt;
+	LocalDate policyEndAt;
 
 	@BeforeEach
 	void setup() {
 		teamId = UUID.randomUUID();
 		policyStartAt = LocalDate.of(2026, 3, 1);
 		policyEndAt = LocalDate.of(2026, 10, 31);
-		createdBy = UUID.randomUUID();
 	}
 
 	@Test
@@ -33,22 +31,20 @@ class TicketPricingPolicyEntityTest {
 		TicketPricingPolicyEntity policy = TicketPricingPolicyEntity.create(
 			teamId,
 			policyStartAt,
-			policyEndAt,
-			createdBy
+			policyEndAt
 		);
 
 		assertThat(policy.getTeamId()).isEqualTo(teamId);
 		assertThat(policy.getPolicyStartAt()).isEqualTo(policyStartAt);
 		assertThat(policy.getPolicyEndAt()).isEqualTo(policyEndAt);
 		assertThat(policy.isActive()).isTrue();
-		assertThat(policy.getCreatedBy()).isEqualTo(createdBy);
 	}
 
 
 	@Test
 	void 가격정책_생성_실패_팀ID_null() {
 		assertThatThrownBy(
-			() -> TicketPricingPolicyEntity.create(null, policyStartAt, policyEndAt, createdBy)
+			() -> TicketPricingPolicyEntity.create(null, policyStartAt, policyEndAt)
 		).isInstanceOf(FieldValidationException.class)
 			.hasMessageContaining("팀 ID는 필수입니다.");
 	}
@@ -56,7 +52,7 @@ class TicketPricingPolicyEntityTest {
 	@Test
 	void 가격정책_생성_실패_시작일_null() {
 		assertThatThrownBy(
-			() -> TicketPricingPolicyEntity.create(teamId, null, policyEndAt, createdBy)
+			() -> TicketPricingPolicyEntity.create(teamId, null, policyEndAt)
 		).isInstanceOf(FieldValidationException.class)
 			.hasMessageContaining("정책 시작일은 필수입니다.");
 	}
@@ -64,7 +60,7 @@ class TicketPricingPolicyEntityTest {
 	@Test
 	void 가격정책_생성_실패_종료일_null() {
 		assertThatThrownBy(
-			() -> TicketPricingPolicyEntity.create(teamId, policyStartAt, null, createdBy)
+			() -> TicketPricingPolicyEntity.create(teamId, policyStartAt, null)
 		).isInstanceOf(FieldValidationException.class)
 			.hasMessageContaining("정책 종료일은 필수입니다.");
 	}
@@ -75,18 +71,9 @@ class TicketPricingPolicyEntityTest {
 			() -> TicketPricingPolicyEntity.create(
 				teamId,
 				policyStartAt,
-				policyStartAt.minusDays(1),
-				createdBy
+				policyStartAt.minusDays(1)
 			)
 		).isInstanceOf(FieldValidationException.class)
 			.hasMessageContaining("정책 종료일은 시작일보다 빠를 수 없습니다.");
-	}
-
-	@Test
-	void 가격정책_생성_실패_생성자_null() {
-		assertThatThrownBy(
-			() -> TicketPricingPolicyEntity.create(teamId, policyStartAt, policyEndAt, null)
-		).isInstanceOf(FieldValidationException.class)
-			.hasMessageContaining("생성자 ID는 필수입니다.");
 	}
 }

--- a/core/src/test/java/pricing/TicketPricingPolicyEntityTest.java
+++ b/core/src/test/java/pricing/TicketPricingPolicyEntityTest.java
@@ -1,0 +1,92 @@
+package pricing;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.goti.domain.entity.pricing.TicketPricingPolicyEntity;
+import com.goti.exception.FieldValidationException;
+
+@ActiveProfiles("test")
+class TicketPricingPolicyEntityTest {
+
+	private UUID teamId;
+	private LocalDate policyStartAt;
+	private LocalDate policyEndAt;
+	private UUID createdBy;
+
+	@BeforeEach
+	void setup() {
+		teamId = UUID.randomUUID();
+		policyStartAt = LocalDate.of(2026, 3, 1);
+		policyEndAt = LocalDate.of(2026, 10, 31);
+		createdBy = UUID.randomUUID();
+	}
+
+	@Test
+	void 가격정책_생성_성공() {
+		TicketPricingPolicyEntity policy = TicketPricingPolicyEntity.create(
+			teamId,
+			policyStartAt,
+			policyEndAt,
+			createdBy
+		);
+
+		assertThat(policy.getTeamId()).isEqualTo(teamId);
+		assertThat(policy.getPolicyStartAt()).isEqualTo(policyStartAt);
+		assertThat(policy.getPolicyEndAt()).isEqualTo(policyEndAt);
+		assertThat(policy.isActive()).isTrue();
+		assertThat(policy.getCreatedBy()).isEqualTo(createdBy);
+	}
+
+
+	@Test
+	void 가격정책_생성_실패_팀ID_null() {
+		assertThatThrownBy(
+			() -> TicketPricingPolicyEntity.create(null, policyStartAt, policyEndAt, createdBy)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("팀 ID는 필수입니다.");
+	}
+
+	@Test
+	void 가격정책_생성_실패_시작일_null() {
+		assertThatThrownBy(
+			() -> TicketPricingPolicyEntity.create(teamId, null, policyEndAt, createdBy)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("정책 시작일은 필수입니다.");
+	}
+
+	@Test
+	void 가격정책_생성_실패_종료일_null() {
+		assertThatThrownBy(
+			() -> TicketPricingPolicyEntity.create(teamId, policyStartAt, null, createdBy)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("정책 종료일은 필수입니다.");
+	}
+
+	@Test
+	void 가격정책_생성_실패_종료일이_시작일보다_빠름() {
+		assertThatThrownBy(
+			() -> TicketPricingPolicyEntity.create(
+				teamId,
+				policyStartAt,
+				policyStartAt.minusDays(1),
+				createdBy
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("정책 종료일은 시작일보다 빠를 수 없습니다.");
+	}
+
+	@Test
+	void 가격정책_생성_실패_생성자_null() {
+		assertThatThrownBy(
+			() -> TicketPricingPolicyEntity.create(teamId, policyStartAt, policyEndAt, null)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("생성자 ID는 필수입니다.");
+	}
+}

--- a/core/src/test/java/stadium/BaseballTeamEntityTest.java
+++ b/core/src/test/java/stadium/BaseballTeamEntityTest.java
@@ -1,0 +1,401 @@
+package stadium;
+
+import com.goti.constants.TeamCode;
+import com.goti.domain.entity.team.BaseballTeamEntity;
+
+import com.goti.exception.FieldValidationException;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+@ActiveProfiles("test")
+public class BaseballTeamEntityTest {
+
+	BaseballTeamEntity baseballTeam;
+
+	@Test
+	void 구단_생성_성공() {
+		baseballTeam = BaseballTeamEntity.create(
+			TeamCode.SS,
+			"삼성라이온즈",
+			"Samsung Lions",
+			"삼성",
+			"대구",
+			1982,
+			"대구광역시 수성구 야구전설로 1",
+			"42250",
+			"https://www.samsunglions.com/",
+			"홍길동",
+			"삼성그룹",
+			"이재용",
+			"이종열",
+			"박진만",
+			"https://image.url/logo.png"
+		);
+		assertNotNull(baseballTeam);
+		log.info("baseballTeam teamName :: {}", baseballTeam.getTeamName());
+	}
+
+	@Test
+	void 구단_생성_실패_teamCode_null() {
+		assertThatThrownBy(
+			() -> BaseballTeamEntity.create(
+				null,
+				"삼성라이온즈",
+				"Samsung Lions",
+				"삼성",
+				"대구",
+				1982,
+				"대구광역시 수성구 야구전설로 1",
+				"42250",
+				"https://www.samsunglions.com/",
+				"홍길동",
+				"삼성그룹",
+				"이재용",
+				"이종열",
+				"박진만",
+				"https://image.url/logo.png"
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("BaseballTeamEntity:Field-teamCode invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 구단(팀)코드는 비어있을 수 없습니다.", ex.getMessage());
+			}
+		);
+	}
+
+	@NullAndEmptySource
+	@ParameterizedTest
+	void 구단_생성_실패_teamName_null_또는_공백(String teamName) {
+		assertThatThrownBy(
+			() -> BaseballTeamEntity.create(
+				TeamCode.SS,
+				teamName,
+				"Samsung Lions",
+				"삼성",
+				"대구",
+				1982,
+				"대구광역시 수성구 야구전설로 1",
+				"42250",
+				"https://www.samsunglions.com/",
+				"홍길동",
+				"삼성그룹",
+				"이재용",
+				"이종열",
+				"박진만",
+				"https://image.url/logo.png"
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("BaseballTeamEntity:Field-teamName invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 구단(팀)명은 비어있을 수 없습니다.", ex.getMessage());
+			}
+		);
+	}
+
+	@NullAndEmptySource
+	@ParameterizedTest
+	void 구단_생성_실패_teamNameEn_null_또는_공백(String teamNameEn) {
+		assertThatThrownBy(
+			() -> BaseballTeamEntity.create(
+				TeamCode.SS,
+				"삼성라이온즈",
+				teamNameEn,
+				"삼성",
+				"대구",
+				1982,
+				"대구광역시 수성구 야구전설로 1",
+				"42250",
+				"https://www.samsunglions.com/",
+				"홍길동",
+				"삼성그룹",
+				"이재용",
+				"이종열",
+				"박진만",
+				"https://image.url/logo.png"
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("BaseballTeamEntity:Field-teamNameEn invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 구단(팀) 영문명은 비어있을 수 없습니다.", ex.getMessage());
+			}
+		);
+	}
+
+	@NullAndEmptySource
+	@ParameterizedTest
+	void 구단_생성_실패_sponsor_null_또는_공백(String sponsor) {
+		assertThatThrownBy(
+			() -> BaseballTeamEntity.create(
+				TeamCode.SS,
+				"삼성라이온즈",
+				"Samsung Lions",
+				sponsor,
+				"대구",
+				1982,
+				"대구광역시 수성구 야구전설로 1",
+				"42250",
+				"https://www.samsunglions.com/",
+				"홍길동",
+				"삼성그룹",
+				"이재용",
+				"이종열",
+				"박진만",
+				"https://image.url/logo.png"
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("BaseballTeamEntity:Field-sponsor invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 스폰서는 비어있을 수 없습니다.", ex.getMessage());
+			}
+		);
+	}
+
+	@NullAndEmptySource
+	@ParameterizedTest
+	void 구단_생성_실패_homeGround_null_또는_공백(String homeGround) {
+		assertThatThrownBy(
+			() -> BaseballTeamEntity.create(
+				TeamCode.SS,
+				"삼성라이온즈",
+				"Samsung Lions",
+				"삼성",
+				homeGround,
+				1982,
+				"대구광역시 수성구 야구전설로 1",
+				"42250",
+				"https://www.samsunglions.com/",
+				"홍길동",
+				"삼성그룹",
+				"이재용",
+				"이종열",
+				"박진만",
+				"https://image.url/logo.png"
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("BaseballTeamEntity:Field-homeGround invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 연고지는 비어있을 수 없습니다.", ex.getMessage());
+			}
+		);
+	}
+
+	@ParameterizedTest
+	@NullSource
+	@MethodSource("invalidYears")
+	void 구단_생성_실패_foundedYear_유효하지_않음(Integer foundedYear) {
+		assertThatThrownBy(() ->
+			BaseballTeamEntity.create(
+				TeamCode.SS,
+				"삼성라이온즈",
+				"Samsung Lions",
+				"삼성",
+				"대구",
+				null,
+				"대구광역시 수성구 야구전설로 1",
+				"42250",
+				"https://www.samsunglions.com/",
+				"홍길동",
+				"삼성그룹",
+				"이재용",
+				"이종열",
+				"박진만",
+				"https://image.url/logo.png"
+			)
+		).isInstanceOfSatisfying(FieldValidationException.class, ex -> {
+			log.info("BaseballTeamEntity:Field-foundedYear invalid ErrorMessage : {}", ex.getMessage());
+			assertEquals("도메인 필드 오류 : 창단년도는 비어있거나 현재연도와 같거나 미래일 수 없습니다.", ex.getMessage());
+		});
+	}
+
+	@NullAndEmptySource
+	@ParameterizedTest
+	void 구단_생성_실패_officeAddress_null_또는_공백(String officeAddress) {
+		assertThatThrownBy(
+			() -> BaseballTeamEntity.create(
+				TeamCode.SS,
+				"삼성라이온즈",
+				"Samsung Lions",
+				"삼성",
+				"대구",
+				1982,
+				officeAddress,
+				"42250",
+				"https://www.samsunglions.com/",
+				"홍길동",
+				"삼성그룹",
+				"이재용",
+				"이종열",
+				"박진만",
+				"https://image.url/logo.png"
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("BaseballTeamEntity:Field-officeAddress invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 구단 사무실 도로명주소는 비어있을 수 없습니다.", ex.getMessage());
+			}
+		);
+	}
+
+	@NullAndEmptySource
+	@ParameterizedTest
+	void 구단_생성_실패_zipCode_null_또는_공백(String zipCode) {
+		assertThatThrownBy(
+			() -> BaseballTeamEntity.create(
+				TeamCode.SS,
+				"삼성라이온즈",
+				"Samsung Lions",
+				"삼성",
+				"대구",
+				1982,
+				"대구광역시 수성구 야구전설로 1",
+				zipCode,
+				"https://www.samsunglions.com/",
+				"홍길동",
+				"삼성그룹",
+				"이재용",
+				"이종열",
+				"박진만",
+				"https://image.url/logo.png"
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("BaseballTeamEntity:Field-zipCode invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 구단 사무실 우편주소는 비어있을 수 없습니다.", ex.getMessage());
+			}
+		);
+	}
+
+	@NullAndEmptySource
+	@ParameterizedTest
+	void 구단_생성_실패_siteAddress_null_또는_공백(String siteAddress) {
+		assertThatThrownBy(
+			() -> BaseballTeamEntity.create(
+				TeamCode.SS,
+				"삼성라이온즈",
+				"Samsung Lions",
+				"삼성",
+				"대구",
+				1982,
+				"대구광역시 수성구 야구전설로 1",
+				"42250",
+				siteAddress,
+				"이재용",
+				"삼성그룹",
+				"홍길동",
+				"이종열",
+				"박진만",
+				"https://image.url/logo.png"
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("BaseballTeamEntity:Field-siteAddress invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 구단 사이트 주소는 비어있을 수 없습니다.", ex.getMessage());
+			}
+		);
+	}
+
+	@NullAndEmptySource
+	@ParameterizedTest
+	void 구단_생성_실패_owner_null_또는_공백(String owner) {
+		assertThatThrownBy(
+			() -> BaseballTeamEntity.create(
+				TeamCode.SS,
+				"삼성라이온즈",
+				"Samsung Lions",
+				"삼성",
+				"대구",
+				1982,
+				"대구광역시 수성구 야구전설로 1",
+				"42250",
+				"https://www.samsunglions.com/",
+				owner,
+				"삼성그룹",
+				"홍길동",
+				"이종열",
+				"박진만",
+				"https://image.url/logo.png"
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("BaseballTeamEntity:Field-owner invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 구단주명은 비어있을 수 없습니다.", ex.getMessage());
+			}
+		);
+	}
+
+	@NullAndEmptySource
+	@ParameterizedTest
+	void 구단_생성_실패_generalManager_null_또는_공백(String generalManager) {
+		assertThatThrownBy(
+			() -> BaseballTeamEntity.create(
+				TeamCode.SS,
+				"삼성라이온즈",
+				"Samsung Lions",
+				"삼성",
+				"대구",
+				1982,
+				"대구광역시 수성구 야구전설로 1",
+				"42250",
+				"https://www.samsunglions.com/",
+				"이재용",
+				generalManager,
+				"홍길동",
+				"이종열",
+				"박진만",
+				"https://image.url/logo.png"
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("BaseballTeamEntity:Field-generalManager invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 단장명은 비어있을 수 없습니다.", ex.getMessage());
+			}
+		);
+	}
+
+	@NullAndEmptySource
+	@ParameterizedTest
+	void 구단_생성_실패_director_null_또는_공백(String director) {
+		assertThatThrownBy(
+			() -> BaseballTeamEntity.create(
+				TeamCode.SS,
+				"삼성라이온즈",
+				"Samsung Lions",
+				"삼성",
+				"대구",
+				1982,
+				"대구광역시 수성구 야구전설로 1",
+				"42250",
+				"https://www.samsunglions.com/",
+				"홍길동",
+				"삼성그룹",
+				director,
+				"이종열",
+				"박진만",
+				"https://image.url/logo.png"
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("BaseballTeamEntity:Field-director invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 감독명은 비어있을 수 없습니다.", ex.getMessage());
+			}
+		);
+	}
+
+	static Stream<Integer> invalidYears() {
+		return Stream.of(LocalDate.now().getYear() + 1);
+	}
+}

--- a/stadium/build.gradle
+++ b/stadium/build.gradle
@@ -22,4 +22,5 @@ dependencies {
     implementation project(':core')
     implementation project(':common')
     implementation project(':integration')
+    implementation project(':user')
 }

--- a/stadium/src/main/java/com/goti/controller/BaseballTeamController.java
+++ b/stadium/src/main/java/com/goti/controller/BaseballTeamController.java
@@ -1,0 +1,14 @@
+package com.goti.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "BaseballTeam", description = "야구구단(팀) 관련 API")
+@RestController
+@RequestMapping("/api/v1/baseball-teams")
+@RequiredArgsConstructor
+public class BaseballTeamController {
+}

--- a/stadium/src/main/java/com/goti/controller/StadiumController.java
+++ b/stadium/src/main/java/com/goti/controller/StadiumController.java
@@ -1,0 +1,51 @@
+package com.goti.controller;
+
+import com.goti.dto.request.StadiumCreateRequest;
+import com.goti.dto.response.StadiumCreateResponse;
+import com.goti.global.api.ApiSuccessResponse;
+import com.goti.service.domain.stadium.StadiumService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.goti.global.api.ApiSuccessResponse.wrap;
+
+@Tag(name = "Stadium", description = "야구구장 관련 API")
+@RestController
+@RequestMapping("/api/v1/stadiums")
+@RequiredArgsConstructor
+public class StadiumController {
+	
+	private final StadiumService stadiumService;
+
+	@Operation(
+		summary = "야구 구장 생성",
+		description = "야구 구장 생성 API"
+	)
+	@PostMapping
+	public ResponseEntity<ApiSuccessResponse<StadiumCreateResponse>> create(
+		@RequestBody @Valid StadiumCreateRequest request
+	) {
+		return wrap(
+			stadiumService.create(
+				request.stadiumName(),
+				request.location(),
+				request.city(),
+				request.district(),
+				request.roadAddress(),
+				request.latitude(),
+				request.longitude(),
+				request.totalSeats(),
+				request.seatMapConfig()
+			)
+		);
+	}
+}

--- a/stadium/src/main/java/com/goti/dto/request/BaseballTeamCreateRequest.java
+++ b/stadium/src/main/java/com/goti/dto/request/BaseballTeamCreateRequest.java
@@ -1,0 +1,74 @@
+package com.goti.dto.request;
+
+import com.goti.config.validator.PastYear;
+import com.goti.constants.TeamCode;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record BaseballTeamCreateRequest(
+
+	@Schema(description = "구단코드", example = "SS")
+	@NotNull(message = "구단(팀) 코드는 필수 항목입니다.")
+	TeamCode teamCode,
+
+	@Schema(description = "구단명", example = "삼성라이온즈")
+	@NotBlank(message = "구단(팀)이름은 필수 항목입니다.")
+	String teamName,
+
+	@Schema(description = "구단명(영문)", example = "Samsung Lions")
+	@NotBlank(message = "구단(팀)이름은(영문) 필수 항목입니다.")
+	String teamNameEn,
+
+	@Schema(description = "스폰서", example = "삼성")
+	@NotBlank(message = "구단(팀)의 스폰서는 필수 항목입니다.")
+	String sponsor,
+
+	@Schema(description = "연고지", example = "대구")
+	@NotBlank(message = "구단(팀) 연고지는 필수 항목입니다.")
+	String homeGround,
+
+	@Schema(description = "창단년도", example = "1995")
+	@PastYear(yearName = "창단년도")
+	@NotNull(message = "구단(팀) 창단년도는 필수 항목입니다.")
+	Integer foundedYear,
+
+	@Schema(description = "도로명주소", example = "대구광역시 수성구 야구전설로 1")
+	@NotBlank(message = "구단(팀) 사무실 도로명 주소는 필수 항목입니다.")
+	String officeAddress,
+
+	@Schema(description = "구단 사무실 우편주소", example = "42250")
+	@NotBlank(message = "구단(팀) 사무실 우편주소는 필수 항목입니다.")
+	String zipCode,
+
+	@Schema(description = "구단 사이트 주소", example = "https://www.samsunglions.com/")
+	@NotBlank(message = "구단(팀) 사이트 주소는 필수 항목입니다.")
+	String siteAddress,
+
+	@Schema(description = "구단주", example = "홍길동")
+	@NotBlank(message = "구단주명은 필수 항목입니다.")
+	String owner,
+
+	@Schema(description = "구단주 대행", example = "홍길동")
+	String ownerAgency,
+
+	@Schema(description = "대표이사", example = "홍길동")
+	String ceo,
+
+	@Schema(description = "단장", example = "홍길동")
+	@NotBlank(message = "구단(팀)의 단장명은 필수 항목입니다.")
+	String generalManager,
+
+	@Schema(description = "감독", example = "홍길동")
+	@NotBlank(message = "구단(팀)의 감독명은 필수 항목입니다.")
+	String director,
+
+
+	@Schema(
+		description = "구단 로고 이미지 URL",
+		example = "https://image.goti.com/logos/samsung_lions.png"
+	)
+	String logoUrl
+) {
+}

--- a/stadium/src/main/java/com/goti/dto/response/BaseballTeamCreateResponse.java
+++ b/stadium/src/main/java/com/goti/dto/response/BaseballTeamCreateResponse.java
@@ -1,0 +1,29 @@
+package com.goti.dto.response;
+
+import com.goti.constants.TeamCode;
+
+import java.util.UUID;
+
+public record BaseballTeamCreateResponse(
+	UUID teamId,
+	TeamCode teamCode,
+	String teamName,
+	String teamNameEn,
+	String homeGround,
+	String owner,
+	String director
+) {
+	public static BaseballTeamCreateResponse from(
+		UUID teamId,
+		TeamCode teamCode,
+		String teamName,
+		String teamNameEn,
+		String homeGround,
+		String owner,
+		String director
+	) {
+		return new BaseballTeamCreateResponse(
+			teamId, teamCode, teamName, teamNameEn, homeGround, owner, director
+		);
+	}
+}

--- a/stadium/src/main/java/com/goti/repository/BaseballTeamRepository.java
+++ b/stadium/src/main/java/com/goti/repository/BaseballTeamRepository.java
@@ -1,0 +1,12 @@
+package com.goti.repository;
+
+import com.goti.domain.entity.team.BaseballTeamEntity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface BaseballTeamRepository extends JpaRepository<BaseballTeamEntity, UUID> {
+}

--- a/stadium/src/main/java/com/goti/service/domain/baseballteam/BaseballTeamService.java
+++ b/stadium/src/main/java/com/goti/service/domain/baseballteam/BaseballTeamService.java
@@ -1,0 +1,25 @@
+package com.goti.service.domain.baseballteam;
+
+import com.goti.constants.TeamCode;
+import com.goti.dto.response.BaseballTeamCreateResponse;
+
+public interface BaseballTeamService {
+
+	BaseballTeamCreateResponse create(
+		TeamCode teamCode,
+		String teamName,
+		String teamNameEn,
+		String sponsor,
+		String homeGround,
+		Integer foundedYear,
+		String officeAddress,
+		String zipCode,
+		String siteAddress,
+		String owner,
+		String ownerAgency,
+		String ceo,
+		String generalManager,
+		String director,
+		String logoUrl
+	);
+}

--- a/stadium/src/main/java/com/goti/service/domain/baseballteam/BaseballTeamServiceImpl.java
+++ b/stadium/src/main/java/com/goti/service/domain/baseballteam/BaseballTeamServiceImpl.java
@@ -1,0 +1,56 @@
+package com.goti.service.domain.baseballteam;
+
+import com.goti.constants.TeamCode;
+import com.goti.domain.entity.team.BaseballTeamEntity;
+import com.goti.dto.response.BaseballTeamCreateResponse;
+
+import com.goti.repository.BaseballTeamRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BaseballTeamServiceImpl implements BaseballTeamService {
+
+	private final BaseballTeamRepository baseballTeamRepository;
+
+	@Override
+	@Transactional
+	public BaseballTeamCreateResponse create(
+		TeamCode teamCode,
+		String teamName,
+		String teamNameEn,
+		String sponsor,
+		String homeGround,
+		Integer foundedYear,
+		String officeAddress,
+		String zipCode,
+		String siteAddress,
+		String owner,
+		String ownerAgency,
+		String ceo,
+		String generalManager,
+		String director,
+		String logoUrl
+	) {
+		BaseballTeamEntity baseballTeam = BaseballTeamEntity.create(
+			teamCode, teamName, teamNameEn, sponsor, homeGround, foundedYear, officeAddress,
+			zipCode, siteAddress, owner, ownerAgency, ceo, generalManager, director, logoUrl
+		);
+		baseballTeamRepository.save(baseballTeam);
+
+		return BaseballTeamCreateResponse.from(
+			baseballTeam.getId(),
+			baseballTeam.getTeamCode(),
+			baseballTeam.getTeamName(),
+			baseballTeam.getTeamNameEn(),
+			baseballTeam.getHomeGround(),
+			baseballTeam.getOwner(),
+			baseballTeam.getDirector()
+		);
+	}
+}
+

--- a/stadium/src/test/java/com/goti/api/StadiumCreateApiTest.java
+++ b/stadium/src/test/java/com/goti/api/StadiumCreateApiTest.java
@@ -1,0 +1,77 @@
+package com.goti.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goti.GotiStadiumApplication;
+import com.goti.config.jwt.JwtAuthenticationFilter;
+import com.goti.config.security.SecurityConfig;
+import com.goti.dto.request.StadiumCreateRequest;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+@SpringBootTest(classes = GotiStadiumApplication.class)
+@Transactional
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DisplayName("야구 구장 생성 - POST /api/v1/stadiums")
+public class StadiumCreateApiTest {
+
+	@Autowired
+	public MockMvc mockMvc;
+
+	@Autowired
+	public ObjectMapper objectMapper;
+
+	static final String STADIUM_NAME = "대구삼성라이온즈파크";
+	static final String ROAD_ADDRESS = "대구 수성구 야구전설로 1 대구삼성라이온즈파크";
+
+	@Test
+	void 야구구장_생성_성공__200_OK() throws Exception {
+		Map<String, Object> seatMapConfig = Map.of("sections", "test");
+		StadiumCreateRequest request = new StadiumCreateRequest(
+			STADIUM_NAME,
+			"대구",
+			"대구광역시",
+			"수성구",
+			ROAD_ADDRESS,
+			BigDecimal.valueOf(35.84),
+			BigDecimal.valueOf(128.68),
+			24000,
+			seatMapConfig
+		);
+
+		mockMvc.perform(
+			post("/api/v1/stadiums")
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request))
+		)
+			.andDo(print())
+			.andExpectAll(
+				status().isOk(),
+				jsonPath("$.code").value("ok"),
+				jsonPath("$.message").value("성공"),
+				jsonPath("$.data").exists(),
+				jsonPath("$.data.stadiumId").exists(),
+				jsonPath("$.data.stadiumName").value(STADIUM_NAME),
+				jsonPath("$.data.roadAddress").value(ROAD_ADDRESS)
+			);
+	}
+}

--- a/stadium/src/test/java/com/goti/service/domain/baseballteam/BaseballTeamServiceTest.java
+++ b/stadium/src/test/java/com/goti/service/domain/baseballteam/BaseballTeamServiceTest.java
@@ -1,0 +1,78 @@
+package com.goti.service.domain.baseballteam;
+
+import com.goti.GotiStadiumApplication;
+
+import com.goti.constants.TeamCode;
+import com.goti.dto.request.BaseballTeamCreateRequest;
+import com.goti.dto.response.BaseballTeamCreateResponse;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@Slf4j
+@Transactional
+@SpringBootTest(classes = GotiStadiumApplication.class)
+@ActiveProfiles("test")
+public class BaseballTeamServiceTest {
+
+	@Autowired
+	BaseballTeamService baseballTeamService;
+
+	BaseballTeamCreateRequest baseballTeamCreateRequest;
+
+	@BeforeEach
+	void setup() {
+		baseballTeamCreateRequest = new BaseballTeamCreateRequest(
+			TeamCode.SS,
+			"삼성라이온즈",
+			"Samsung Lions",
+			"삼성",
+			"대구",
+			1982,
+			"대구광역시 수성구 야구전설로 1",
+			"42250",
+			"https://www.samsunglions.com/",
+			"홍길동",
+			"삼성그룹",
+			"이재용",
+			"이종열",
+			"박진만",
+			"https://image.url/logo.png"
+		);
+	}
+
+	@Test
+	void 야구구단_생성_성공() {
+		BaseballTeamCreateResponse response = baseballTeamService.create(
+			baseballTeamCreateRequest.teamCode(),
+			baseballTeamCreateRequest.teamName(),
+			baseballTeamCreateRequest.teamNameEn(),
+			baseballTeamCreateRequest.sponsor(),
+			baseballTeamCreateRequest.homeGround(),
+			baseballTeamCreateRequest.foundedYear(),
+			baseballTeamCreateRequest.officeAddress(),
+			baseballTeamCreateRequest.zipCode(),
+			baseballTeamCreateRequest.siteAddress(),
+			baseballTeamCreateRequest.owner(),
+			baseballTeamCreateRequest.generalManager(),
+			baseballTeamCreateRequest.director(),
+			baseballTeamCreateRequest.ownerAgency(),
+			baseballTeamCreateRequest.ceo(),
+			baseballTeamCreateRequest.logoUrl()
+		);
+
+		assertNotNull(response.teamId());
+		log.info("response teamId :: {}", response.teamId());
+		log.info("response teamName :: {}", response.teamName());
+
+	}
+
+}

--- a/ticketing/src/main/java/com/goti/game/dto/response/GameResponse.java
+++ b/ticketing/src/main/java/com/goti/game/dto/response/GameResponse.java
@@ -4,7 +4,7 @@ import com.goti.constants.GameResult;
 import com.goti.constants.GameStatus;
 import com.goti.constants.LeagueType;
 import com.goti.domain.entity.game.GameScheduleEntity;
-import com.goti.domain.entity.game.BaseballGameStatusEntity;
+import com.goti.domain.entity.game.GameStatusEntity;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -37,7 +37,7 @@ public record GameResponse(
 	@Schema(description = "경기 결과", example = "PENDING")
 	GameResult gameResult
 ) {
-	public static GameResponse from(GameScheduleEntity game, BaseballGameStatusEntity status) {
+	public static GameResponse from(GameScheduleEntity game, GameStatusEntity status) {
 		return new GameResponse(
 			game.getId(),
 			game.getHomeTeamId(),

--- a/ticketing/src/main/java/com/goti/game/repository/BaseballGameStatusRepository.java
+++ b/ticketing/src/main/java/com/goti/game/repository/BaseballGameStatusRepository.java
@@ -1,6 +1,6 @@
 package com.goti.game.repository;
 
-import com.goti.domain.entity.game.BaseballGameStatusEntity;
+import com.goti.domain.entity.game.GameStatusEntity;
 
 import com.goti.domain.entity.game.GameScheduleEntity;
 
@@ -11,6 +11,6 @@ import java.util.UUID;
 import java.util.Optional;
 
 @Repository
-public interface BaseballGameStatusRepository extends JpaRepository<BaseballGameStatusEntity, UUID> {
-	Optional<BaseballGameStatusEntity> findByGameSchedule(GameScheduleEntity gameSchedule);
+public interface BaseballGameStatusRepository extends JpaRepository<GameStatusEntity, UUID> {
+	Optional<GameStatusEntity> findByGameSchedule(GameScheduleEntity gameSchedule);
 }

--- a/ticketing/src/main/java/com/goti/game/repository/GameStatusRepository.java
+++ b/ticketing/src/main/java/com/goti/game/repository/GameStatusRepository.java
@@ -11,6 +11,6 @@ import java.util.UUID;
 import java.util.Optional;
 
 @Repository
-public interface BaseballGameStatusRepository extends JpaRepository<GameStatusEntity, UUID> {
+public interface GameStatusRepository extends JpaRepository<GameStatusEntity, UUID> {
 	Optional<GameStatusEntity> findByGameSchedule(GameScheduleEntity gameSchedule);
 }

--- a/ticketing/src/main/java/com/goti/game/service/GameScheduleService.java
+++ b/ticketing/src/main/java/com/goti/game/service/GameScheduleService.java
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.goti.constants.messages.ErrorCode;
 import com.goti.domain.entity.game.GameScheduleEntity;
 import com.goti.game.dto.response.GameResponse;
-import com.goti.game.repository.BaseballGameStatusRepository;
+import com.goti.game.repository.GameStatusRepository;
 import com.goti.game.service.command.CreateGameCommand;
 import com.goti.global.validation.Preconditions;
 
@@ -25,7 +25,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class GameScheduleService {
 	private final GameScheduleRepository gameScheduleRepository;
-	private final BaseballGameStatusRepository baseballGameStatusRepository;
+	private final GameStatusRepository gameStatusRepository;
 
 	@Transactional
 	public GameResponse create(CreateGameCommand cmd) {
@@ -48,7 +48,7 @@ public class GameScheduleService {
 		GameScheduleEntity savedGame = gameScheduleRepository.save(game);
 
 		GameStatusEntity gameStatus = GameStatusEntity.create(savedGame);
-		baseballGameStatusRepository.save(gameStatus);
+		gameStatusRepository.save(gameStatus);
 
 		return GameResponse.from(savedGame, gameStatus);
 	}
@@ -56,7 +56,7 @@ public class GameScheduleService {
 	@Transactional(readOnly = true)
 	public Page<GameResponse> getGames(Pageable pageable) {
 		return gameScheduleRepository.findAll(pageable)
-			.map(gameSchedule -> baseballGameStatusRepository.findByGameSchedule(gameSchedule)
+			.map(gameSchedule -> gameStatusRepository.findByGameSchedule(gameSchedule)
 				.map(status -> GameResponse.from(gameSchedule, status))
 				.orElseThrow(() -> new CustomException(ErrorCode.GAME_NOT_FOUND)));
 	}
@@ -66,7 +66,7 @@ public class GameScheduleService {
 		GameScheduleEntity gameSchedule = gameScheduleRepository.findById(gameScheduleId)
 			.orElseThrow(() -> new CustomException(ErrorCode.GAME_NOT_FOUND));
 
-		GameStatusEntity status = baseballGameStatusRepository
+		GameStatusEntity status = gameStatusRepository
 			.findByGameSchedule(gameSchedule)
 			.orElseThrow(() -> new CustomException(ErrorCode.GAME_NOT_FOUND));
 

--- a/ticketing/src/main/java/com/goti/game/service/GameScheduleService.java
+++ b/ticketing/src/main/java/com/goti/game/service/GameScheduleService.java
@@ -1,5 +1,6 @@
 package com.goti.game.service;
 
+import com.goti.domain.entity.game.GameStatusEntity;
 import com.goti.exception.CustomException;
 
 import com.goti.game.repository.GameScheduleRepository;
@@ -11,7 +12,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.goti.constants.messages.ErrorCode;
 import com.goti.domain.entity.game.GameScheduleEntity;
-import com.goti.domain.entity.game.BaseballGameStatusEntity;
 import com.goti.game.dto.response.GameResponse;
 import com.goti.game.repository.BaseballGameStatusRepository;
 import com.goti.game.service.command.CreateGameCommand;
@@ -47,7 +47,7 @@ public class GameScheduleService {
 		);
 		GameScheduleEntity savedGame = gameScheduleRepository.save(game);
 
-		BaseballGameStatusEntity gameStatus = BaseballGameStatusEntity.init(savedGame);
+		GameStatusEntity gameStatus = GameStatusEntity.create(savedGame);
 		baseballGameStatusRepository.save(gameStatus);
 
 		return GameResponse.from(savedGame, gameStatus);
@@ -66,7 +66,7 @@ public class GameScheduleService {
 		GameScheduleEntity gameSchedule = gameScheduleRepository.findById(gameScheduleId)
 			.orElseThrow(() -> new CustomException(ErrorCode.GAME_NOT_FOUND));
 
-		BaseballGameStatusEntity status = baseballGameStatusRepository
+		GameStatusEntity status = baseballGameStatusRepository
 			.findByGameSchedule(gameSchedule)
 			.orElseThrow(() -> new CustomException(ErrorCode.GAME_NOT_FOUND));
 

--- a/ticketing/src/main/java/com/goti/pricing/controller/TicketPricingPolicyController.java
+++ b/ticketing/src/main/java/com/goti/pricing/controller/TicketPricingPolicyController.java
@@ -1,0 +1,57 @@
+package com.goti.pricing.controller;
+
+import static com.goti.global.api.ApiSuccessResponse.*;
+
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.goti.global.api.ApiSuccessResponse;
+import com.goti.pricing.dto.request.TicketPricingPolicyCreateRequest;
+import com.goti.pricing.dto.response.TicketPricingPolicyCreateResponse;
+import com.goti.pricing.service.domain.TicketPricingPolicyService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Ticket Pricing Policy", description = "가격 정책 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/teams/{teamId}/ticket-pricing-policies")
+public class TicketPricingPolicyController {
+	private final TicketPricingPolicyService ticketPricingPolicyService;
+
+	@Operation(
+		summary = "가격 정책 생성",
+		description = "관리자가 가격 정책과 티켓 가격 상세를 함께 생성하는 API"
+	)
+	@PostMapping
+	public ResponseEntity<ApiSuccessResponse<TicketPricingPolicyCreateResponse>> create(
+		@PathVariable UUID teamId,
+		@Valid @RequestBody TicketPricingPolicyCreateRequest request
+	) {
+		// TODO: 추후 관리자 인증 도입 후 관리자만 생성 가능하도록 처리
+		TicketPricingPolicyCreateResponse response = ticketPricingPolicyService.create(
+			teamId,
+			request.policyStartAt(),
+			request.policyEndAt(),
+			request.prices().stream()
+				.map(price -> new TicketPricingPolicyService.TicketPriceCreateParam(
+					price.gradeId(),
+					price.ticketType(),
+					price.dayType(),
+					price.matchType(),
+					price.price()
+				))
+				.toList()
+		);
+		return wrap(response);
+	}
+}

--- a/ticketing/src/main/java/com/goti/pricing/dto/request/TicketPricingPolicyCreateRequest.java
+++ b/ticketing/src/main/java/com/goti/pricing/dto/request/TicketPricingPolicyCreateRequest.java
@@ -1,0 +1,54 @@
+package com.goti.pricing.dto.request;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import com.goti.constants.TicketPricingDayType;
+import com.goti.constants.TicketPricingMatchType;
+import com.goti.constants.TicketType;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+public record TicketPricingPolicyCreateRequest(
+	@Schema(description = "정책 시작일", example = "2026-03-01")
+	@NotNull(message = "정책 시작일은 필수입니다.")
+	@JsonFormat(pattern = "yyyy-MM-dd")
+	LocalDate policyStartAt,
+
+	@Schema(description = "정책 종료일", example = "2026-10-31")
+	@NotNull(message = "정책 종료일은 필수입니다.")
+	@JsonFormat(pattern = "yyyy-MM-dd")
+	LocalDate policyEndAt,
+
+	@Schema(description = "가격 정책 상세 목록")
+	@NotEmpty(message = "가격 정책 상세 목록은 비어 있을 수 없습니다.")
+	List<@Valid TicketPriceCreateRequest> prices
+) {
+	public record TicketPriceCreateRequest(
+		@Schema(description = "좌석 등급 ID", example = "22222222-2222-2222-2222-222222222222")
+		@NotNull(message = "좌석 등급 ID는 필수입니다.")
+		UUID gradeId,
+
+		@Schema(description = "권종", example = "ADULT")
+		@NotNull(message = "권종은 필수입니다.")
+		TicketType ticketType,
+
+		@Schema(description = "요일 유형", example = "WEEKDAY")
+		@NotNull(message = "요일 유형은 필수입니다.")
+		TicketPricingDayType dayType,
+
+		@Schema(description = "매치 유형", example = "REGULAR")
+		@NotNull(message = "매치 유형은 필수입니다.")
+		TicketPricingMatchType matchType,
+
+		@Schema(description = "가격", example = "15000")
+		@NotNull(message = "가격은 필수입니다.")
+		Integer price
+	) {
+	}
+}

--- a/ticketing/src/main/java/com/goti/pricing/dto/response/TicketPricingPolicyCreateResponse.java
+++ b/ticketing/src/main/java/com/goti/pricing/dto/response/TicketPricingPolicyCreateResponse.java
@@ -1,0 +1,80 @@
+package com.goti.pricing.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import com.goti.constants.TicketPricingDayType;
+import com.goti.constants.TicketPricingMatchType;
+import com.goti.constants.TicketType;
+import com.goti.domain.entity.pricing.TicketPriceEntity;
+import com.goti.domain.entity.pricing.TicketPricingPolicyEntity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TicketPricingPolicyCreateResponse(
+	@Schema(description = "가격 정책 ID", example = "22222222-2222-2222-2222-222222222222")
+	UUID policyId,
+
+	@Schema(description = "팀 ID", example = "11111111-1111-1111-1111-111111111111")
+	UUID teamId,
+
+	@Schema(description = "정책 시작일", example = "2026-03-01")
+	LocalDate policyStartAt,
+
+	@Schema(description = "정책 종료일", example = "2026-10-31")
+	LocalDate policyEndAt,
+
+	@Schema(description = "활성 여부", example = "true")
+	boolean isActive,
+
+	@Schema(description = "가격 정책 상세 목록")
+	List<TicketPriceResponse> prices
+) {
+	public static TicketPricingPolicyCreateResponse from(
+		TicketPricingPolicyEntity policy,
+		List<TicketPriceEntity> prices
+	) {
+		return new TicketPricingPolicyCreateResponse(
+			policy.getId(),
+			policy.getTeamId(),
+			policy.getPolicyStartAt(),
+			policy.getPolicyEndAt(),
+			policy.isActive(),
+			prices.stream()
+				.map(TicketPriceResponse::from)
+				.toList()
+		);
+	}
+
+	public record TicketPriceResponse(
+		@Schema(description = "티켓 가격 ID", example = "33333333-3333-3333-3333-333333333333")
+		UUID priceId,
+
+		@Schema(description = "좌석 등급 ID", example = "22222222-2222-2222-2222-222222222222")
+		UUID gradeId,
+
+		@Schema(description = "권종", example = "ADULT")
+		TicketType ticketType,
+
+		@Schema(description = "요일 유형", example = "WEEKDAY")
+		TicketPricingDayType dayType,
+
+		@Schema(description = "매치 유형", example = "REGULAR")
+		TicketPricingMatchType matchType,
+
+		@Schema(description = "가격", example = "15000")
+		Integer price
+	) {
+		public static TicketPriceResponse from(TicketPriceEntity ticketPrice) {
+			return new TicketPriceResponse(
+				ticketPrice.getId(),
+				ticketPrice.getGrade().getId(),
+				ticketPrice.getTicketType(),
+				ticketPrice.getDayType(),
+				ticketPrice.getMatchType(),
+				ticketPrice.getPrice()
+			);
+		}
+	}
+}

--- a/ticketing/src/main/java/com/goti/pricing/repository/TicketPriceRepository.java
+++ b/ticketing/src/main/java/com/goti/pricing/repository/TicketPriceRepository.java
@@ -1,0 +1,12 @@
+package com.goti.pricing.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.goti.domain.entity.pricing.TicketPriceEntity;
+
+@Repository
+public interface TicketPriceRepository extends JpaRepository<TicketPriceEntity, UUID> {
+}

--- a/ticketing/src/main/java/com/goti/pricing/repository/TicketPricingPolicyRepository.java
+++ b/ticketing/src/main/java/com/goti/pricing/repository/TicketPricingPolicyRepository.java
@@ -1,0 +1,12 @@
+package com.goti.pricing.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.goti.domain.entity.pricing.TicketPricingPolicyEntity;
+
+@Repository
+public interface TicketPricingPolicyRepository extends JpaRepository<TicketPricingPolicyEntity, UUID> {
+}

--- a/ticketing/src/main/java/com/goti/pricing/service/domain/TicketPricingPolicyService.java
+++ b/ticketing/src/main/java/com/goti/pricing/service/domain/TicketPricingPolicyService.java
@@ -1,0 +1,28 @@
+package com.goti.pricing.service.domain;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import com.goti.constants.TicketPricingDayType;
+import com.goti.constants.TicketPricingMatchType;
+import com.goti.constants.TicketType;
+import com.goti.pricing.dto.response.TicketPricingPolicyCreateResponse;
+
+public interface TicketPricingPolicyService {
+	TicketPricingPolicyCreateResponse create(
+		UUID teamId,
+		LocalDate policyStartAt,
+		LocalDate policyEndAt,
+		List<TicketPriceCreateParam> prices
+	);
+
+	record TicketPriceCreateParam(
+		UUID gradeId,
+		TicketType ticketType,
+		TicketPricingDayType dayType,
+		TicketPricingMatchType matchType,
+		Integer price
+	) {
+	}
+}

--- a/ticketing/src/main/java/com/goti/pricing/service/domain/TicketPricingPolicyServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/pricing/service/domain/TicketPricingPolicyServiceImpl.java
@@ -1,0 +1,111 @@
+package com.goti.pricing.service.domain;
+
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goti.constants.TicketPricingDayType;
+import com.goti.constants.TicketPricingMatchType;
+import com.goti.constants.messages.ErrorCode;
+import com.goti.domain.entity.pricing.TicketPriceEntity;
+import com.goti.domain.entity.pricing.TicketPricingPolicyEntity;
+import com.goti.domain.entity.seat.SeatGradeEntity;
+import com.goti.global.validation.Preconditions;
+import com.goti.pricing.dto.response.TicketPricingPolicyCreateResponse;
+import com.goti.pricing.repository.TicketPriceRepository;
+import com.goti.pricing.repository.TicketPricingPolicyRepository;
+import com.goti.seat.repository.SeatGradeRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TicketPricingPolicyServiceImpl implements TicketPricingPolicyService {
+	private final TicketPricingPolicyRepository ticketPricingPolicyRepository;
+	private final TicketPriceRepository ticketPriceRepository;
+	private final SeatGradeRepository seatGradeRepository;
+
+	@Override
+	@Transactional
+	public TicketPricingPolicyCreateResponse create(
+		UUID teamId,
+		LocalDate policyStartAt,
+		LocalDate policyEndAt,
+		List<TicketPriceCreateParam> ticketPriceRequest
+	) {
+		TicketPricingPolicyEntity policy = TicketPricingPolicyEntity.create(
+			teamId,
+			policyStartAt,
+			policyEndAt
+		);
+
+		ticketPricingPolicyRepository.save(policy);
+
+		Map<UUID, SeatGradeEntity> gradesById = getGrades(ticketPriceRequest);
+		validateDuplicateticketPrice(ticketPriceRequest);
+
+		List<TicketPriceEntity> ticketPrices = ticketPriceRequest.stream()
+			.map(price -> TicketPriceEntity.create(
+				gradesById.get(price.gradeId()),
+				policy,
+				price.ticketType(),
+				price.dayType(),
+				price.matchType(),
+				price.price()
+			))
+			.toList();
+
+		ticketPriceRepository.saveAll(ticketPrices);
+		return TicketPricingPolicyCreateResponse.from(policy, ticketPrices);
+	}
+
+	private Map<UUID, SeatGradeEntity> getGrades(List<TicketPriceCreateParam> ticketPriceRequest) {
+		List<UUID> gradeIds = ticketPriceRequest.stream()
+			.map(TicketPriceCreateParam::gradeId)
+			.distinct()
+			.toList();
+
+		List<SeatGradeEntity> grades = seatGradeRepository.findAllById(gradeIds);
+		Preconditions.validate(
+			grades.size() == gradeIds.size(),
+			ErrorCode.SEAT_GRADE_NOT_FOUND
+		);
+
+		return grades.stream()
+			.collect(Collectors.toMap(SeatGradeEntity::getId, Function.identity()));
+	}
+
+	private void validateDuplicateticketPrice(
+		List<TicketPriceCreateParam> ticketPriceRequest
+	) {
+		Set<TicketPriceCondition> uniqueConditions = new HashSet<>();
+
+		for (TicketPriceCreateParam price : ticketPriceRequest) {
+			Preconditions.validate(
+				uniqueConditions.add(
+					new TicketPriceCondition(
+						price.gradeId(),
+						price.dayType(),
+						price.matchType()
+					)
+				),
+				ErrorCode.TICKET_PRICE_CONDITION_ALREADY_EXISTS
+			);
+		}
+	}
+
+	private record TicketPriceCondition(
+		UUID gradeId,
+		TicketPricingDayType dayType,
+		TicketPricingMatchType matchType
+	) {
+	}
+}

--- a/ticketing/src/main/java/com/goti/seat/controller/GameSeatStatusController.java
+++ b/ticketing/src/main/java/com/goti/seat/controller/GameSeatStatusController.java
@@ -1,0 +1,41 @@
+package com.goti.seat.controller;
+
+import static com.goti.global.api.ApiSuccessResponse.*;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.goti.global.api.ApiSuccessResponse;
+import com.goti.seat.dto.response.GameSeatStatusResponse;
+import com.goti.seat.service.domain.SeatStatusService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Game Seat Status", description = "경기별 좌석 상태 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/games")
+public class GameSeatStatusController {
+	private final SeatStatusService seatStatusService;
+
+	@Operation(
+		summary = "경기별 좌석 상태 조회",
+		description = "특정 경기의 특정 구역 좌석 상태 목록 조회 API"
+	)
+	@GetMapping("/{gameId}/sections/{sectionId}/seat-statuses")
+	public ResponseEntity<ApiSuccessResponse<List<GameSeatStatusResponse>>> list(
+		@PathVariable UUID gameId,
+		@PathVariable UUID sectionId
+	) {
+		return wrap(seatStatusService.get(gameId, sectionId));
+	}
+}

--- a/ticketing/src/main/java/com/goti/seat/dto/response/GameSeatStatusResponse.java
+++ b/ticketing/src/main/java/com/goti/seat/dto/response/GameSeatStatusResponse.java
@@ -1,0 +1,23 @@
+package com.goti.seat.dto.response;
+
+import java.util.UUID;
+
+import com.goti.constants.SeatStatus;
+import com.goti.domain.entity.seat.SeatStatusEntity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record GameSeatStatusResponse(
+	@Schema(description = "좌석 ID", example = "44444444-4444-4444-4444-444444444444")
+	UUID seatId,
+
+	@Schema(description = "좌석 상태", example = "AVAILABLE")
+	SeatStatus status
+) {
+	public static GameSeatStatusResponse from(SeatStatusEntity seatStatus) {
+		return new GameSeatStatusResponse(
+			seatStatus.getSeat().getId(),
+			seatStatus.getStatus()
+		);
+	}
+}

--- a/ticketing/src/main/java/com/goti/seat/repository/SeatStatusRepository.java
+++ b/ticketing/src/main/java/com/goti/seat/repository/SeatStatusRepository.java
@@ -1,13 +1,32 @@
 package com.goti.seat.repository;
 
-import com.goti.domain.entity.seat.SeatStatusEntity;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.goti.domain.entity.game.GameScheduleEntity;
+
+import com.goti.domain.entity.seat.SeatEntity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.goti.domain.entity.seat.SeatStatusEntity;
+
 @Repository
 public interface SeatStatusRepository extends JpaRepository<SeatStatusEntity, UUID> {
-	Optional<SeatStatusEntity> findByGame_IdAndSeat_Id(UUID gameId, UUID seatId);
+
+	@Query("""
+		SELECT ss
+			FROM SeatStatusEntity ss
+		WHERE ss.game.id = :gameId
+  		AND ss.seat.seatSection.id = :sectionId
+	""")
+	List<SeatStatusEntity> findSeatStatuses(
+		@Param("gameId") UUID gameId,
+		@Param("sectionId") UUID sectionId
+	);
+	Optional<SeatStatusEntity> findByGameAndSeat(GameScheduleEntity game, SeatEntity seat);
 }

--- a/ticketing/src/main/java/com/goti/seat/service/application/SeatHoldExpiryTransactionalService.java
+++ b/ticketing/src/main/java/com/goti/seat/service/application/SeatHoldExpiryTransactionalService.java
@@ -28,10 +28,10 @@ public class SeatHoldExpiryTransactionalService {
 		SeatHoldEntity seatHold = seatHoldRepository.findById(holdId)
 			.orElseThrow(() -> new CustomException(ErrorCode.SEAT_HOLD_NOT_FOUND));
 
-		UUID gameId = seatHold.getGameSchedule().getId();
-		UUID seatId = seatHold.getSeat().getId();
-
-		SeatStatusEntity seatStatus = seatStatusRepository.findByGame_IdAndSeat_Id(gameId, seatId)
+		SeatStatusEntity seatStatus = seatStatusRepository.findByGameAndSeat(
+			seatHold.getGameSchedule(),
+			seatHold.getSeat()
+		)
 			.orElseThrow(() -> new CustomException(ErrorCode.SEAT_STATUS_NOT_FOUND));
 
 		seatHoldExpiryService.expire(seatStatus, seatHold, now);

--- a/ticketing/src/main/java/com/goti/seat/service/application/SeatHoldTransactionalService.java
+++ b/ticketing/src/main/java/com/goti/seat/service/application/SeatHoldTransactionalService.java
@@ -10,9 +10,11 @@ import com.goti.constants.messages.ErrorCode;
 import com.goti.domain.entity.seat.SeatHoldEntity;
 import com.goti.domain.entity.seat.SeatStatusEntity;
 import com.goti.exception.CustomException;
+import com.goti.game.repository.GameScheduleRepository;
 import com.goti.global.validation.Preconditions;
 import com.goti.seat.config.properties.SeatHoldProperties;
 import com.goti.seat.repository.SeatHoldRepository;
+import com.goti.seat.repository.SeatRepository;
 import com.goti.seat.repository.SeatStatusRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -20,13 +22,18 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class SeatHoldTransactionalService {
+	private final GameScheduleRepository gameScheduleRepository;
+	private final SeatRepository seatRepository;
 	private final SeatStatusRepository seatStatusRepository;
 	private final SeatHoldRepository seatHoldRepository;
 	private final SeatHoldProperties seatHoldProperties;
 
 	@Transactional
 	public UUID hold(UUID gameId, UUID seatId, UUID userId, String queueTokenJti) {
-		SeatStatusEntity seatStatus = seatStatusRepository.findByGame_IdAndSeat_Id(gameId, seatId)
+		SeatStatusEntity seatStatus = seatStatusRepository.findByGameAndSeat(
+				gameScheduleRepository.getReferenceById(gameId),
+				seatRepository.getReferenceById(seatId)
+			)
 			.orElseThrow(() -> new CustomException(ErrorCode.SEAT_STATUS_NOT_FOUND));
 
 		seatStatus.hold();
@@ -54,9 +61,9 @@ public class SeatHoldTransactionalService {
 			ErrorCode.AUTH_PERMISSION_DENIED
 		);
 
-		SeatStatusEntity seatStatus = seatStatusRepository.findByGame_IdAndSeat_Id(
-			seatHold.getGameSchedule().getId(),
-			seatHold.getSeat().getId()
+		SeatStatusEntity seatStatus = seatStatusRepository.findByGameAndSeat(
+			seatHold.getGameSchedule(),
+			seatHold.getSeat()
 		).orElseThrow(() -> new CustomException(ErrorCode.SEAT_STATUS_NOT_FOUND));
 
 		seatStatus.release();

--- a/ticketing/src/main/java/com/goti/seat/service/domain/SeatStatusService.java
+++ b/ticketing/src/main/java/com/goti/seat/service/domain/SeatStatusService.java
@@ -1,0 +1,10 @@
+package com.goti.seat.service.domain;
+
+import java.util.List;
+import java.util.UUID;
+
+import com.goti.seat.dto.response.GameSeatStatusResponse;
+
+public interface SeatStatusService {
+	List<GameSeatStatusResponse> get(UUID gameId, UUID sectionId);
+}

--- a/ticketing/src/main/java/com/goti/seat/service/domain/SeatStatusServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/seat/service/domain/SeatStatusServiceImpl.java
@@ -1,0 +1,29 @@
+package com.goti.seat.service.domain;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goti.seat.dto.response.GameSeatStatusResponse;
+import com.goti.seat.repository.SeatStatusRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SeatStatusServiceImpl implements SeatStatusService {
+	private final SeatStatusRepository seatStatusRepository;
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<GameSeatStatusResponse> get(
+		UUID gameId,
+		UUID sectionId
+	) {
+		return seatStatusRepository.findSeatStatuses(gameId, sectionId).stream()
+			.map(GameSeatStatusResponse::from)
+			.toList();
+	}
+}

--- a/ticketing/src/test/java/com/goti/game/controller/GameScheduleControllerTest.java
+++ b/ticketing/src/test/java/com/goti/game/controller/GameScheduleControllerTest.java
@@ -85,7 +85,7 @@ class GameScheduleControllerTest {
 			GameStatus.SCHEDULED,
 			0,
 			0,
-			GameResult.PENDING
+			GameResult.NONE
 		);
 		given(gameScheduleService.create(any())).willReturn(response);
 
@@ -141,7 +141,7 @@ class GameScheduleControllerTest {
 			GameStatus.SCHEDULED,
 			0,
 			0,
-			GameResult.PENDING
+			GameResult.NONE
 		);
 		Page<GameResponse> page = new PageImpl<>(
 			java.util.List.of(response),
@@ -179,7 +179,7 @@ class GameScheduleControllerTest {
 			GameStatus.SCHEDULED,
 			0,
 			0,
-			GameResult.PENDING
+			GameResult.NONE
 		);
 		given(gameScheduleService.getGame(gameId)).willReturn(response);
 

--- a/ticketing/src/test/java/com/goti/game/service/GameScheduleApplicationServiceTest.java
+++ b/ticketing/src/test/java/com/goti/game/service/GameScheduleApplicationServiceTest.java
@@ -8,6 +8,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.UUID;
 
+import com.goti.domain.entity.game.GameStatusEntity;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,7 +21,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import com.goti.constants.LeagueType;
 import com.goti.constants.messages.ErrorCode;
-import com.goti.domain.entity.game.BaseballGameStatusEntity;
 import com.goti.domain.entity.game.GameScheduleEntity;
 import com.goti.exception.CustomException;
 import com.goti.game.dto.response.GameResponse;
@@ -72,7 +72,7 @@ class GameScheduleApplicationServiceTest {
 		ReflectionTestUtils.setField(savedGame, "id", UUID.randomUUID());
 
 		given(gameScheduleRepository.save(any(GameScheduleEntity.class))).willReturn(savedGame);
-		given(baseballGameStatusRepository.save(any(BaseballGameStatusEntity.class)))
+		given(baseballGameStatusRepository.save(any(GameStatusEntity.class)))
 			.willAnswer(invocation -> invocation.getArgument(0));
 
 		GameResponse response = baseballGameApplicationService.create(createGameCommand);
@@ -83,7 +83,7 @@ class GameScheduleApplicationServiceTest {
 		assertThat(response.stadiumId()).isEqualTo(createGameCommand.stadiumId());
 
 		verify(gameScheduleRepository, times(1)).save(any(GameScheduleEntity.class));
-		verify(baseballGameStatusRepository, times(1)).save(any(BaseballGameStatusEntity.class));
+		verify(baseballGameStatusRepository, times(1)).save(any(GameStatusEntity.class));
 	}
 
 	@Test
@@ -98,6 +98,6 @@ class GameScheduleApplicationServiceTest {
 			.hasMessageContaining(ErrorCode.GAME_ALREADY_EXISTS.getMessage());
 
 		verify(gameScheduleRepository, never()).save(any(GameScheduleEntity.class));
-		verify(baseballGameStatusRepository, never()).save(any(BaseballGameStatusEntity.class));
+		verify(baseballGameStatusRepository, never()).save(any(GameStatusEntity.class));
 	}
 }

--- a/ticketing/src/test/java/com/goti/game/service/GameScheduleApplicationServiceTest.java
+++ b/ticketing/src/test/java/com/goti/game/service/GameScheduleApplicationServiceTest.java
@@ -24,7 +24,7 @@ import com.goti.constants.messages.ErrorCode;
 import com.goti.domain.entity.game.GameScheduleEntity;
 import com.goti.exception.CustomException;
 import com.goti.game.dto.response.GameResponse;
-import com.goti.game.repository.BaseballGameStatusRepository;
+import com.goti.game.repository.GameStatusRepository;
 import com.goti.game.repository.GameScheduleRepository;
 import com.goti.game.service.command.CreateGameCommand;
 
@@ -36,7 +36,7 @@ class GameScheduleApplicationServiceTest {
 	private GameScheduleRepository gameScheduleRepository;
 
 	@Mock
-	private BaseballGameStatusRepository baseballGameStatusRepository;
+	private GameStatusRepository gameStatusRepository;
 
 	@InjectMocks
 	private GameScheduleService baseballGameApplicationService;
@@ -72,7 +72,7 @@ class GameScheduleApplicationServiceTest {
 		ReflectionTestUtils.setField(savedGame, "id", UUID.randomUUID());
 
 		given(gameScheduleRepository.save(any(GameScheduleEntity.class))).willReturn(savedGame);
-		given(baseballGameStatusRepository.save(any(GameStatusEntity.class)))
+		given(gameStatusRepository.save(any(GameStatusEntity.class)))
 			.willAnswer(invocation -> invocation.getArgument(0));
 
 		GameResponse response = baseballGameApplicationService.create(createGameCommand);
@@ -83,7 +83,7 @@ class GameScheduleApplicationServiceTest {
 		assertThat(response.stadiumId()).isEqualTo(createGameCommand.stadiumId());
 
 		verify(gameScheduleRepository, times(1)).save(any(GameScheduleEntity.class));
-		verify(baseballGameStatusRepository, times(1)).save(any(GameStatusEntity.class));
+		verify(gameStatusRepository, times(1)).save(any(GameStatusEntity.class));
 	}
 
 	@Test
@@ -98,6 +98,6 @@ class GameScheduleApplicationServiceTest {
 			.hasMessageContaining(ErrorCode.GAME_ALREADY_EXISTS.getMessage());
 
 		verify(gameScheduleRepository, never()).save(any(GameScheduleEntity.class));
-		verify(baseballGameStatusRepository, never()).save(any(GameStatusEntity.class));
+		verify(gameStatusRepository, never()).save(any(GameStatusEntity.class));
 	}
 }

--- a/user/src/main/java/com/goti/config/security/SecurityConfig.java
+++ b/user/src/main/java/com/goti/config/security/SecurityConfig.java
@@ -31,6 +31,7 @@ public class SecurityConfig {
 
 	public static final String[] PERMIT_PUBLIC_PATH = {
 		"/api/v1/auth/**",
+		"/api/v1/stadiums/**",
 		"/actuator/**",
 		"/swagger-ui/**",
 		"/v3/api-docs/**",
@@ -63,8 +64,8 @@ public class SecurityConfig {
 					.accessDeniedHandler(accessDeniedHandler)
 			).authorizeHttpRequests(
 				auth -> auth
-					.requestMatchers(PERMIT_MEMBER_PATH).hasRole("MEMBER")
 					.requestMatchers(PERMIT_PUBLIC_PATH).permitAll()
+					.requestMatchers(PERMIT_MEMBER_PATH).hasRole("MEMBER")
 					.anyRequest().authenticated()
 			).addFilterBefore(
 				jwtAuthenticationFilter,


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#138 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
야구 게임 상태 (BaseballGameStatusEntity) 엔티티명 수정 및 생성 로직 개선
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- 야구게임 status 엔티티 네이밍 수정 (BaseballGameStatusEntity -> GameStatusEntity) 및 도메인 validate 검증메소드 추가
- GameStatusEntity 생성 static factory : init -> create 변경 및 생성 시 인자 변경 (GameStatus, GameResult 제거),
- 위 내용으로 인한 참조 파일들 변경
<br/>