### PR TITLE
[FEAT] 야구구단 생성 API 구축 및 API 테스트 코드 추가

### DIFF
--- a/stadium/src/main/java/com/goti/controller/BaseballTeamController.java
+++ b/stadium/src/main/java/com/goti/controller/BaseballTeamController.java
@@ -1,14 +1,37 @@
 package com.goti.controller;
 
+import com.goti.dto.request.BaseballTeamCreateRequest;
+import com.goti.dto.response.BaseballTeamCreateResponse;
+import com.goti.global.api.ApiSuccessResponse;
+import com.goti.service.domain.baseballteam.BaseballTeamService;
+
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static com.goti.global.api.ApiSuccessResponse.wrap;
 
 @Tag(name = "BaseballTeam", description = "야구구단(팀) 관련 API")
 @RestController
 @RequestMapping("/api/v1/baseball-teams")
 @RequiredArgsConstructor
 public class BaseballTeamController {
+
+	private final BaseballTeamService baseballTeamService;
+
+	@PostMapping
+	public ResponseEntity<ApiSuccessResponse<BaseballTeamCreateResponse>> register(
+		@RequestBody @Valid BaseballTeamCreateRequest request
+	) {
+		return wrap(
+			baseballTeamService.create(request.toCommand())
+		);
+	}
+
 }

--- a/stadium/src/main/java/com/goti/dto/request/BaseballTeamCreateRequest.java
+++ b/stadium/src/main/java/com/goti/dto/request/BaseballTeamCreateRequest.java
@@ -3,6 +3,8 @@ package com.goti.dto.request;
 import com.goti.config.validator.PastYear;
 import com.goti.constants.TeamCode;
 
+import com.goti.service.domain.baseballteam.command.BaseballTeamCreateCommand;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -71,4 +73,12 @@ public record BaseballTeamCreateRequest(
 	)
 	String logoUrl
 ) {
+
+	public BaseballTeamCreateCommand toCommand() {
+		return new BaseballTeamCreateCommand(
+			teamCode, teamName, teamNameEn, sponsor, homeGround,
+			foundedYear, officeAddress, zipCode, siteAddress,
+			owner, ownerAgency, ceo, generalManager, director, logoUrl
+		);
+	}
 }

--- a/stadium/src/main/java/com/goti/service/domain/baseballteam/BaseballTeamService.java
+++ b/stadium/src/main/java/com/goti/service/domain/baseballteam/BaseballTeamService.java
@@ -1,30 +1,14 @@
 package com.goti.service.domain.baseballteam;
 
-import com.goti.constants.TeamCode;
 import com.goti.domain.entity.team.BaseballTeamEntity;
 import com.goti.dto.response.BaseballTeamCreateResponse;
+import com.goti.service.domain.baseballteam.command.BaseballTeamCreateCommand;
 
 import java.util.UUID;
 
 public interface BaseballTeamService {
 
-	BaseballTeamCreateResponse create(
-		TeamCode teamCode,
-		String teamName,
-		String teamNameEn,
-		String sponsor,
-		String homeGround,
-		Integer foundedYear,
-		String officeAddress,
-		String zipCode,
-		String siteAddress,
-		String owner,
-		String ownerAgency,
-		String ceo,
-		String generalManager,
-		String director,
-		String logoUrl
-	);
+	BaseballTeamCreateResponse create(BaseballTeamCreateCommand command);
 
 	BaseballTeamEntity getById(UUID teamId);
 }

--- a/stadium/src/main/java/com/goti/service/domain/baseballteam/BaseballTeamServiceImpl.java
+++ b/stadium/src/main/java/com/goti/service/domain/baseballteam/BaseballTeamServiceImpl.java
@@ -1,10 +1,11 @@
 package com.goti.service.domain.baseballteam;
 
-import com.goti.constants.TeamCode;
 import com.goti.domain.entity.team.BaseballTeamEntity;
 import com.goti.dto.response.BaseballTeamCreateResponse;
 
 import com.goti.repository.BaseballTeamRepository;
+
+import com.goti.service.domain.baseballteam.command.BaseballTeamCreateCommand;
 
 import lombok.RequiredArgsConstructor;
 
@@ -21,26 +22,23 @@ public class BaseballTeamServiceImpl implements BaseballTeamService {
 
 	@Override
 	@Transactional
-	public BaseballTeamCreateResponse create(
-		TeamCode teamCode,
-		String teamName,
-		String teamNameEn,
-		String sponsor,
-		String homeGround,
-		Integer foundedYear,
-		String officeAddress,
-		String zipCode,
-		String siteAddress,
-		String owner,
-		String ownerAgency,
-		String ceo,
-		String generalManager,
-		String director,
-		String logoUrl
-	) {
+	public BaseballTeamCreateResponse create(BaseballTeamCreateCommand command) {
 		BaseballTeamEntity baseballTeam = BaseballTeamEntity.create(
-			teamCode, teamName, teamNameEn, sponsor, homeGround, foundedYear, officeAddress,
-			zipCode, siteAddress, owner, ownerAgency, ceo, generalManager, director, logoUrl
+			command.teamCode(),
+			command.teamName(),
+			command.teamNameEn(),
+			command.sponsor(),
+			command.homeGround(),
+			command.foundedYear(),
+			command.officeAddress(),
+			command.zipCode(),
+			command.siteAddress(),
+			command.owner(),
+			command.ownerAgency(),
+			command.ceo(),
+			command.generalManager(),
+			command.director(),
+			command.logoUrl()
 		);
 		baseballTeamRepository.save(baseballTeam);
 

--- a/stadium/src/main/java/com/goti/service/domain/baseballteam/BaseballTeamServiceImpl.java
+++ b/stadium/src/main/java/com/goti/service/domain/baseballteam/BaseballTeamServiceImpl.java
@@ -34,10 +34,10 @@ public class BaseballTeamServiceImpl implements BaseballTeamService {
 			command.zipCode(),
 			command.siteAddress(),
 			command.owner(),
-			command.ownerAgency(),
-			command.ceo(),
 			command.generalManager(),
 			command.director(),
+			command.ownerAgency(),
+			command.ceo(),
 			command.logoUrl()
 		);
 		baseballTeamRepository.save(baseballTeam);

--- a/stadium/src/main/java/com/goti/service/domain/baseballteam/command/BaseballTeamCreateCommand.java
+++ b/stadium/src/main/java/com/goti/service/domain/baseballteam/command/BaseballTeamCreateCommand.java
@@ -1,0 +1,22 @@
+package com.goti.service.domain.baseballteam.command;
+
+import com.goti.constants.TeamCode;
+
+public record BaseballTeamCreateCommand(
+	TeamCode teamCode,
+	String teamName,
+	String teamNameEn,
+	String sponsor,
+	String homeGround,
+	Integer foundedYear,
+	String officeAddress,
+	String zipCode,
+	String siteAddress,
+	String owner,
+	String ownerAgency,
+	String ceo,
+	String generalManager,
+	String director,
+	String logoUrl
+) {
+}

--- a/stadium/src/test/java/com/goti/api/BaseballTeamCreateApiTest.java
+++ b/stadium/src/test/java/com/goti/api/BaseballTeamCreateApiTest.java
@@ -70,7 +70,11 @@ public class BaseballTeamCreateApiTest {
 				jsonPath("$.data").exists(),
 				jsonPath("$.data.teamId").exists(),
 				jsonPath("$.data.teamCode").value(request.teamCode().toString()),
-				jsonPath("$.data.teamName").value(request.teamName())
+				jsonPath("$.data.teamName").value(request.teamName()),
+				jsonPath("$.data.teamNameEn").value(request.teamNameEn()),
+				jsonPath("$.data.homeGround").value(request.homeGround()),
+				jsonPath("$.data.owner").value(request.owner()),
+				jsonPath("$.data.director").value(request.director())
 			);
 	}
 

--- a/stadium/src/test/java/com/goti/api/BaseballTeamCreateApiTest.java
+++ b/stadium/src/test/java/com/goti/api/BaseballTeamCreateApiTest.java
@@ -1,0 +1,77 @@
+package com.goti.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goti.GotiStadiumApplication;
+
+import com.goti.constants.TeamCode;
+import com.goti.dto.request.BaseballTeamCreateRequest;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@SpringBootTest(classes = GotiStadiumApplication.class)
+@Transactional
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DisplayName("야구 구단 생성 - POST /api/v1/baseball-teams")
+public class BaseballTeamCreateApiTest {
+	@Autowired
+	public MockMvc mockMvc;
+
+	@Autowired
+	public ObjectMapper objectMapper;
+
+	@Test
+	void 야구구단_생성_성공__200_ok() throws Exception {
+
+		BaseballTeamCreateRequest request =
+			new BaseballTeamCreateRequest(
+				TeamCode.SS,
+				"삼성라이온즈",
+				"Samsung Lions",
+				"삼성",
+				"대구",
+				1982,
+				"대구광역시 수성구 야구전설로 1",
+				"42250",
+				"https://www.samsunglions.com/",
+				"홍길동",
+				"삼성그룹",
+				"이재용",
+				"이종열",
+				"박진만",
+				"https://image.url/logo.png"
+			);
+
+		mockMvc.perform(
+				post("/api/v1/baseball-teams")
+					.with(csrf())
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request))
+			)
+			.andDo(print())
+			.andExpectAll(
+				status().isOk(),
+				jsonPath("$.code").value("ok"),
+				jsonPath("$.message").value("성공"),
+				jsonPath("$.data").exists(),
+				jsonPath("$.data.teamId").exists(),
+				jsonPath("$.data.teamCode").value(request.teamCode().toString()),
+				jsonPath("$.data.teamName").value(request.teamName())
+			);
+	}
+
+}

--- a/stadium/src/test/java/com/goti/service/domain/baseballteam/BaseballTeamServiceTest.java
+++ b/stadium/src/test/java/com/goti/service/domain/baseballteam/BaseballTeamServiceTest.java
@@ -51,22 +51,9 @@ public class BaseballTeamServiceTest {
 
 	@Test
 	void 야구구단_생성_성공() {
+
 		BaseballTeamCreateResponse response = baseballTeamService.create(
-			baseballTeamCreateRequest.teamCode(),
-			baseballTeamCreateRequest.teamName(),
-			baseballTeamCreateRequest.teamNameEn(),
-			baseballTeamCreateRequest.sponsor(),
-			baseballTeamCreateRequest.homeGround(),
-			baseballTeamCreateRequest.foundedYear(),
-			baseballTeamCreateRequest.officeAddress(),
-			baseballTeamCreateRequest.zipCode(),
-			baseballTeamCreateRequest.siteAddress(),
-			baseballTeamCreateRequest.owner(),
-			baseballTeamCreateRequest.generalManager(),
-			baseballTeamCreateRequest.director(),
-			baseballTeamCreateRequest.ownerAgency(),
-			baseballTeamCreateRequest.ceo(),
-			baseballTeamCreateRequest.logoUrl()
+			baseballTeamCreateRequest.toCommand()
 		);
 
 		assertNotNull(response.teamId());

--- a/user/src/main/java/com/goti/config/security/SecurityConfig.java
+++ b/user/src/main/java/com/goti/config/security/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
 		"/api/v1/auth/**",
 		"/api/v1/stadiums/**",
 		"/api/v1/games/**",
+		"/api/v1/baseball-teams/**",
 		"/actuator/**",
 		"/swagger-ui/**",
 		"/v3/api-docs/**"


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#160 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
야구구단 생성 API 구축 및 API 테스트 코드 추가
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- 야구구단 생성 API 추가 (Stadium module, BaseballTeamController)
- 야구구단 생성 API 테스트 코드 추가
- SecurityPath 임의 추가 (야구구단 생성 endpoint)
- baseballTeamCreate Command 추가 (해당 로직 Service 의 패키지와 동일) BaseballTeamCreateCommand) 

<br/>