### PR TITLE
[FEAT] 홈 구장 도메인 엔티티 생성 및 도메인 테스트 코드 추가

### DIFF
--- a/core/src/main/java/com/goti/constants/StadiumType.java
+++ b/core/src/main/java/com/goti/constants/StadiumType.java
@@ -1,0 +1,15 @@
+package com.goti.constants;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum StadiumType {
+
+	PRIMARY("제1구장"),
+	SECONDARY("제2구장")
+	;
+
+	private final String description;
+}

--- a/core/src/main/java/com/goti/domain/entity/stadium/HomeStadiumEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/stadium/HomeStadiumEntity.java
@@ -1,0 +1,83 @@
+package com.goti.domain.entity.stadium;
+
+import com.goti.constants.StadiumType;
+import com.goti.domain.base.ModificationTimestampEntity;
+
+import com.goti.domain.entity.team.BaseballTeamEntity;
+
+import com.goti.global.validation.Preconditions;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Entity
+@Table(name = "home_stadiums")
+@NoArgsConstructor(access = PROTECTED)
+public class HomeStadiumEntity extends ModificationTimestampEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "baseball_team_id", nullable = false)
+	private BaseballTeamEntity baseballTeam;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "stadium_id", nullable = false)
+	private StadiumEntity stadium;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private StadiumType type;
+
+	private HomeStadiumEntity(
+		BaseballTeamEntity baseballTeam,
+		StadiumEntity stadium,
+		StadiumType type
+	) {
+		this.baseballTeam = baseballTeam;
+		this.stadium = stadium;
+		this.type = type;
+	}
+
+	public static HomeStadiumEntity create(
+		final BaseballTeamEntity baseballTeam,
+		final StadiumEntity stadium,
+		final StadiumType type
+	) {
+		validate(baseballTeam, stadium, type);
+		return new HomeStadiumEntity(
+			baseballTeam, stadium, type
+		);
+	}
+
+	private static void validate(
+		BaseballTeamEntity baseballTeam,
+		StadiumEntity stadium,
+		StadiumType type
+	) {
+		Preconditions.domainValidate(
+			baseballTeam != null,
+			"야구구단 정보는 비어있을 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			stadium != null,
+			"구장 정보는 비어있을 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			type != null,
+			"구장 타입은 비어있을 수 없습니다."
+		);
+	}
+
+}

--- a/core/src/main/java/com/goti/domain/entity/team/BaseballTeamEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/team/BaseballTeamEntity.java
@@ -120,10 +120,10 @@ public class BaseballTeamEntity extends ModificationTimestampEntity {
 		String zipCode,
 		String siteAddress,
 		String owner,
-		String generalManager,
-		String director,
 		String ownerAgency,
 		String ceo,
+		String generalManager,
+		String director,
 		String logoUrl
 	) {
 

--- a/core/src/test/java/stadium/BaseballTeamEntityTest.java
+++ b/core/src/test/java/stadium/BaseballTeamEntityTest.java
@@ -324,7 +324,7 @@ public class BaseballTeamEntityTest {
 				"https://www.samsunglions.com/",
 				owner,
 				"삼성그룹",
-				"홍길동",
+				"이재용",
 				"이종열",
 				"박진만",
 				"https://image.url/logo.png"
@@ -352,9 +352,9 @@ public class BaseballTeamEntityTest {
 				"42250",
 				"https://www.samsunglions.com/",
 				"이재용",
-				generalManager,
+				"삼성그룹",
 				"홍길동",
-				"이종열",
+				generalManager,
 				"박진만",
 				"https://image.url/logo.png"
 			)
@@ -382,9 +382,9 @@ public class BaseballTeamEntityTest {
 				"https://www.samsunglions.com/",
 				"홍길동",
 				"삼성그룹",
-				director,
-				"이종열",
 				"박진만",
+				"이종열",
+				director,
 				"https://image.url/logo.png"
 			)
 		).isInstanceOfSatisfying(

--- a/core/src/test/java/stadium/HomeStadiumEntityTest.java
+++ b/core/src/test/java/stadium/HomeStadiumEntityTest.java
@@ -1,0 +1,116 @@
+package stadium;
+
+import com.goti.constants.StadiumType;
+import com.goti.constants.TeamCode;
+import com.goti.domain.entity.resale.EscrowAccountEntity;
+import com.goti.domain.entity.stadium.HomeStadiumEntity;
+import com.goti.domain.entity.stadium.StadiumEntity;
+import com.goti.domain.entity.team.BaseballTeamEntity;
+
+import com.goti.exception.FieldValidationException;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+@ActiveProfiles("test")
+public class HomeStadiumEntityTest {
+
+	BaseballTeamEntity baseballTeam;
+	StadiumEntity stadium;
+
+	@BeforeEach
+	void setup() {
+		createBaseballTeam();
+		createStadium();
+	}
+
+	@Test
+	void 홈구장_생성_성공() {
+		HomeStadiumEntity homeStadium = HomeStadiumEntity.create(
+			baseballTeam, stadium, StadiumType.PRIMARY
+		);
+		assertNotNull(homeStadium);
+		assertEquals(baseballTeam, homeStadium.getBaseballTeam());
+		assertEquals(stadium, homeStadium.getStadium());
+		assertEquals(StadiumType.PRIMARY, homeStadium.getType());
+	}
+
+	@Test
+	void 홈구장_생성_실패_baseballTeam_null() {
+		assertThatThrownBy(
+			() -> HomeStadiumEntity.create(
+					null, stadium, StadiumType.PRIMARY
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("도메인 필드 오류 : 야구구단 정보는 비어있을 수 없습니다.");
+	}
+
+	@Test
+	void 홈구장_생성_실패_stadium_null() {
+		assertThatThrownBy(
+			() -> HomeStadiumEntity.create(
+				baseballTeam,null, StadiumType.PRIMARY
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("도메인 필드 오류 : 구장 정보는 비어있을 수 없습니다.");
+	}
+
+	@Test
+	void 홈구장_생성_실패_type_null() {
+		assertThatThrownBy(
+			() -> HomeStadiumEntity.create(
+				baseballTeam, stadium, null
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("도메인 필드 오류 : 구장 타입은 비어있을 수 없습니다.");
+	}
+
+
+	private void createStadium() {
+		stadium = StadiumEntity.create(
+			"대구 삼성 라이온즈 파크",
+			"대구",
+			"대구광역시",
+			"수성구",
+			"대구광역시 수성구 야구전설로 1",
+			new BigDecimal("35.84112000"),
+			new BigDecimal("128.68152000"),
+			24000,
+			Map.of(
+				"shape", "octagon",
+				"openedYear", 2016,
+				"turf", "natural"
+			)
+		);
+	}
+
+	private void createBaseballTeam() {
+		baseballTeam = BaseballTeamEntity.create(
+			TeamCode.SS,
+			"삼성라이온즈",
+			"Samsung Lions",
+			"삼성",
+			"대구",
+			1982,
+			"대구광역시 수성구 야구전설로 1",
+			"42250",
+			"https://www.samsunglions.com/",
+			"홍길동",
+			"삼성그룹",
+			"이재용",
+			"이종열",
+			"박진만",
+			"https://image.url/logo.png"
+		);
+	}
+}

--- a/stadium/src/main/java/com/goti/service/domain/baseballteam/BaseballTeamServiceImpl.java
+++ b/stadium/src/main/java/com/goti/service/domain/baseballteam/BaseballTeamServiceImpl.java
@@ -34,10 +34,10 @@ public class BaseballTeamServiceImpl implements BaseballTeamService {
 			command.zipCode(),
 			command.siteAddress(),
 			command.owner(),
-			command.generalManager(),
-			command.director(),
 			command.ownerAgency(),
 			command.ceo(),
+			command.generalManager(),
+			command.director(),
 			command.logoUrl()
 		);
 		baseballTeamRepository.save(baseballTeam);


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#166 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
홈 장 도메인 엔티티 생성 및 도메인 테스트 코드 추가
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- 홈구장 (HomeStadiumEntity) 엔티티 설계 및 구축
- 홈구장 엔티티 도메인 테스트 코드 추가
- StadiumType (Enum) 생성 및 추가 (제1구장, 제2구장) -> 추후 3구장까지 추가시 수정예정 (3구장은 거의 안쓴다고해도 무방)
<br/>