### PR TITLE
[BUG] OTel 메트릭 exporter 명시적 활성화 (#174)

### DIFF
--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -61,6 +61,8 @@ otel:
       endpoint: ${OTEL_EXPORTER_ENDPOINT:http://localhost:4318}
   sdk:
     disabled: ${OTEL_SDK_DISABLED:true}
+  metrics:
+    exporter: otlp
 
 logging:
   pattern:


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #174 
<br/>

## 🔎 개요
Kind K8s 환경에서 OTel 메트릭이 Prometheus에 전송되지 않는 문제 수정.
docker-compose는 표준 OTel 환경변수로 자동 활성화되지만, Kind는 커스텀
환경변수를 사용하여 metrics exporter가 기본값 `none`으로 유지되는 것이 원인.

<br/>


## 📋 작업 내용
- `application.yml`에 `otel.metrics.exporter: otlp` 추가
- 환경변수 방식에 관계없이 SDK 활성화 시 메트릭 OTLP 전송 보장
- 로컬(`OTEL_SDK_DISABLED=true`)에서는 영향 없음

<br/>