### PR TITLE
[FEAT] 야구게임일정 생성 시 해당 게임 티켓 상태 생성 서비스 로직 추가 및 테스트 

### DIFF
--- a/core/src/main/java/com/goti/constants/TicketingStatus.java
+++ b/core/src/main/java/com/goti/constants/TicketingStatus.java
@@ -6,10 +6,10 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum TicketingStatus {
-	UPCOMING("판매 예정"),
-	OPEN("판매 중"),
-	SOLD_OUT("매진"),
-	CLOSED("판매 마감"),
+	SCHEDULED("판매 예정"),
+	AVAILABLE("구매 가능"),
+	EXHAUSTED("매진"),
+	TERMINATED("판매 종료"),
 	CANCELED("판매 취소"),
 	PAUSED("일시 중단")
 	;

--- a/core/src/main/java/com/goti/domain/entity/game/GameScheduleEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/game/GameScheduleEntity.java
@@ -63,7 +63,8 @@ public class GameScheduleEntity extends ModificationTimestampEntity {
 		LeagueType leagueType
 	) {
 
-		validate(homeTeamId, awayTeamId, stadiumId, startAt, leagueType);
+		validate(homeTeamId, awayTeamId, stadiumId, leagueType);
+		validateStartAt(startAt);
 
 		return new GameScheduleEntity(
 			homeTeamId,
@@ -78,7 +79,6 @@ public class GameScheduleEntity extends ModificationTimestampEntity {
 		UUID homeTeamId,
 		UUID awayTeamId,
 		UUID stadiumId,
-		LocalDateTime startAt,
 		LeagueType leagueType
 	) {
 
@@ -101,15 +101,26 @@ public class GameScheduleEntity extends ModificationTimestampEntity {
 		);
 
 		Preconditions.domainValidate(
-			startAt != null,
-			"경기 시작 시간은 필수입니다."
-		);
-
-		Preconditions.domainValidate(
 			leagueType != null,
 			"경기 타입은 필수입니다."
 		);
 
+	}
 
+	private static void validateStartAt(LocalDateTime startAt) {
+		Preconditions.domainValidate(
+			startAt != null,
+			"경기 시작 시간은 필수입니다."
+		);
+		LocalDateTime now = LocalDateTime.now();
+		Preconditions.domainValidate(
+			startAt.isAfter(now),
+			"과거 시점의 경기 일정은 생성할 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			!startAt.toLocalDate().isEqual(now.toLocalDate()),
+			"경기 당일에는 일정을 등록할 수 없습니다"
+		);
 	}
 }

--- a/core/src/main/java/com/goti/domain/entity/game/GameTicketingStatusEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/game/GameTicketingStatusEntity.java
@@ -43,30 +43,33 @@ public class GameTicketingStatusEntity extends ModificationTimestampEntity {
 	private GameTicketingStatusEntity(
 		GameScheduleEntity gameSchedule,
 		LocalDateTime ticketingOpenedAt,
-		LocalDateTime ticketingEndAt
+		LocalDateTime ticketingEndAt,
+		TicketingStatus status
 	) {
 		this.gameSchedule = gameSchedule;
 		this.ticketingOpenedAt = ticketingOpenedAt;
 		this.ticketingEndAt = ticketingEndAt;
-		this.status = TicketingStatus.UPCOMING;
+		this.status = status;
 	}
 
 	public static GameTicketingStatusEntity create(
 		final GameScheduleEntity gameSchedule,
 		final LocalDateTime ticketingOpenedAt,
-		final LocalDateTime ticketingEndAt
+		final LocalDateTime ticketingEndAt,
+		final TicketingStatus status
 	) {
-		validate(gameSchedule, ticketingOpenedAt, ticketingEndAt);
+		validate(gameSchedule, ticketingOpenedAt, ticketingEndAt, status);
 
 		return new GameTicketingStatusEntity(
-			gameSchedule, ticketingOpenedAt, ticketingEndAt
+			gameSchedule, ticketingOpenedAt, ticketingEndAt, status
 		);
 	}
 
 	private static void validate(
 		GameScheduleEntity gameSchedule,
 		LocalDateTime ticketingOpenedAt,
-		LocalDateTime ticketingEndAt
+		LocalDateTime ticketingEndAt,
+		TicketingStatus status
 	) {
 		LocalDateTime now = LocalDateTime.now();
 		Preconditions.domainValidate(
@@ -90,6 +93,11 @@ public class GameTicketingStatusEntity extends ModificationTimestampEntity {
 				"예매 종료 시점은 시작 시점보다 이후여야 합니다."
 			);
 		}
+
+		Preconditions.domainValidate(
+			status != null,
+			"티켓팅 상태는 비어있을 수 없습니다."
+		);
 	}
 
 }

--- a/core/src/main/java/com/goti/domain/entity/game/GameTicketingStatusEntity.java
+++ b/core/src/main/java/com/goti/domain/entity/game/GameTicketingStatusEntity.java
@@ -78,21 +78,19 @@ public class GameTicketingStatusEntity extends ModificationTimestampEntity {
 		);
 
 		Preconditions.domainValidate(
-			ticketingOpenedAt != null && ticketingOpenedAt.isAfter(now),
-			"예매 시작 시점은 현재보다 미래여야 합니다."
+			ticketingOpenedAt != null,
+			"예매 시작 시점은 비어있을 수 없습니다."
 		);
 
 		Preconditions.domainValidate(
-			ticketingEndAt != null && ticketingEndAt.isAfter(now),
-			"예매 종료 시점은 현재보다 미래여야 합니다."
+			ticketingEndAt != null,
+			"예매 종료 시점은 비어있을 수 없습니다."
 		);
 
-		if (ticketingOpenedAt != null && ticketingEndAt != null) {
-			Preconditions.domainValidate(
-				ticketingEndAt.isAfter(ticketingOpenedAt),
-				"예매 종료 시점은 시작 시점보다 이후여야 합니다."
-			);
-		}
+		Preconditions.domainValidate(
+			ticketingEndAt.isAfter(ticketingOpenedAt),
+			"예매 종료 시점은 시작 시점보다 이후여야 합니다."
+		);
 
 		Preconditions.domainValidate(
 			status != null,

--- a/core/src/test/java/game/GameTicketingStatusEntityTest.java
+++ b/core/src/test/java/game/GameTicketingStatusEntityTest.java
@@ -1,6 +1,7 @@
 package game;
 
 import com.goti.constants.LeagueType;
+import com.goti.constants.TicketingStatus;
 import com.goti.domain.entity.game.GameScheduleEntity;
 
 import com.goti.domain.entity.game.GameTicketingStatusEntity;
@@ -29,6 +30,7 @@ public class GameTicketingStatusEntityTest {
 	static final LeagueType LEAGUE_TYPE = LeagueType.REGULAR;
 	static final LocalDateTime OPENED_AT = LocalDateTime.now().plusDays(3);
 	static final LocalDateTime CLOSED_AT = LocalDateTime.now().plusDays(5);
+	static final TicketingStatus TICKETING_STATUS = TicketingStatus.SCHEDULED;
 
 	@BeforeEach
 	void setup() {
@@ -44,7 +46,7 @@ public class GameTicketingStatusEntityTest {
 	@Test
 	void 게임_티켓팅_상태_생성_성공() {
 		GameTicketingStatusEntity gameTicketingStatus = GameTicketingStatusEntity.create(
-			gameSchedule, OPENED_AT, CLOSED_AT
+			gameSchedule, OPENED_AT, CLOSED_AT, TICKETING_STATUS
 		);
 
 		assertNotNull(gameTicketingStatus);
@@ -55,7 +57,7 @@ public class GameTicketingStatusEntityTest {
 	void 게임_티켓팅_상태_생성_실패_gameSchedule_null() {
 		assertThatThrownBy(
 			() -> GameTicketingStatusEntity.create(
-				null, OPENED_AT, CLOSED_AT
+				null, OPENED_AT, CLOSED_AT, TICKETING_STATUS
 			)
 		).isInstanceOf(FieldValidationException.class)
 			.hasMessageContaining("게임일정 값은 비어있을 수 없습니다.");
@@ -65,7 +67,7 @@ public class GameTicketingStatusEntityTest {
 	void 게임_티켓팅_상태_생성_실패_예매시작_시간_null() {
 		assertThatThrownBy(
 			() -> GameTicketingStatusEntity.create(
-				gameSchedule, null, CLOSED_AT
+				gameSchedule, null, CLOSED_AT, TICKETING_STATUS
 			)
 		).isInstanceOf(FieldValidationException.class)
 			.hasMessageContaining("예매 시작 시점은 현재보다 미래여야 합니다.");
@@ -77,7 +79,7 @@ public class GameTicketingStatusEntityTest {
 
 		assertThatThrownBy(
 			() -> GameTicketingStatusEntity.create(
-				gameSchedule, openedAt , CLOSED_AT
+				gameSchedule, openedAt , CLOSED_AT, TICKETING_STATUS
 			)
 		).isInstanceOf(FieldValidationException.class)
 			.hasMessageContaining("예매 시작 시점은 현재보다 미래여야 합니다.");
@@ -87,7 +89,7 @@ public class GameTicketingStatusEntityTest {
 	void 게임_티켓팅_상태_생성_실패_예매종료_시간_null() {
 		assertThatThrownBy(
 			() -> GameTicketingStatusEntity.create(
-				gameSchedule, OPENED_AT, null
+				gameSchedule, OPENED_AT, null, TICKETING_STATUS
 			)
 		).isInstanceOf(FieldValidationException.class)
 			.hasMessageContaining("예매 종료 시점은 현재보다 미래여야 합니다.");
@@ -99,7 +101,7 @@ public class GameTicketingStatusEntityTest {
 
 		assertThatThrownBy(
 			() -> GameTicketingStatusEntity.create(
-				gameSchedule, OPENED_AT, closeAt
+				gameSchedule, OPENED_AT, closeAt, TICKETING_STATUS
 			)
 		).isInstanceOf(FieldValidationException.class)
 			.hasMessageContaining("예매 종료 시점은 현재보다 미래여야 합니다.");
@@ -112,7 +114,7 @@ public class GameTicketingStatusEntityTest {
 
 		assertThatThrownBy(
 			() -> GameTicketingStatusEntity.create(
-				gameSchedule, openedAt, closeAt
+				gameSchedule, openedAt, closeAt, TICKETING_STATUS
 			)
 		).isInstanceOf(FieldValidationException.class)
 			.hasMessageContaining("예매 종료 시점은 시작 시점보다 이후여야 합니다.");

--- a/core/src/test/java/game/GameTicketingStatusEntityTest.java
+++ b/core/src/test/java/game/GameTicketingStatusEntityTest.java
@@ -28,7 +28,7 @@ public class GameTicketingStatusEntityTest {
 
 	static final LocalDateTime START_AT = LocalDateTime.now().plusDays(3);
 	static final LeagueType LEAGUE_TYPE = LeagueType.REGULAR;
-	static final LocalDateTime OPENED_AT = LocalDateTime.now().plusDays(3);
+	static final LocalDateTime OPENED_AT = LocalDateTime.now().plusDays(1);
 	static final LocalDateTime CLOSED_AT = LocalDateTime.now().plusDays(5);
 	static final TicketingStatus TICKETING_STATUS = TicketingStatus.SCHEDULED;
 
@@ -70,19 +70,7 @@ public class GameTicketingStatusEntityTest {
 				gameSchedule, null, CLOSED_AT, TICKETING_STATUS
 			)
 		).isInstanceOf(FieldValidationException.class)
-			.hasMessageContaining("예매 시작 시점은 현재보다 미래여야 합니다.");
-	}
-
-	@Test
-	void 게임_티켓팅_상태_생성_실패_예매시작_시간_과거() {
-		LocalDateTime openedAt = LocalDateTime.now().minusDays(2);
-
-		assertThatThrownBy(
-			() -> GameTicketingStatusEntity.create(
-				gameSchedule, openedAt , CLOSED_AT, TICKETING_STATUS
-			)
-		).isInstanceOf(FieldValidationException.class)
-			.hasMessageContaining("예매 시작 시점은 현재보다 미래여야 합니다.");
+			.hasMessageContaining("예매 시작 시점은 비어있을 수 없습니다.");
 	}
 
 	@Test
@@ -92,25 +80,13 @@ public class GameTicketingStatusEntityTest {
 				gameSchedule, OPENED_AT, null, TICKETING_STATUS
 			)
 		).isInstanceOf(FieldValidationException.class)
-			.hasMessageContaining("예매 종료 시점은 현재보다 미래여야 합니다.");
-	}
-
-	@Test
-	void 게임_티켓팅_상태_생성_실패_예매종료_시간_과거() {
-		LocalDateTime closeAt = LocalDateTime.now().minusDays(2);
-
-		assertThatThrownBy(
-			() -> GameTicketingStatusEntity.create(
-				gameSchedule, OPENED_AT, closeAt, TICKETING_STATUS
-			)
-		).isInstanceOf(FieldValidationException.class)
-			.hasMessageContaining("예매 종료 시점은 현재보다 미래여야 합니다.");
+			.hasMessageContaining("예매 종료 시점은 비어있을 수 없습니다.");
 	}
 
 	@Test
 	void 게임_티켓팅_상태_생성_실패_예매시작시간_예매종료시간_이후() {
 		LocalDateTime openedAt = LocalDateTime.now().plusDays(3);
-		LocalDateTime closeAt = LocalDateTime.now().plusDays(1);
+		LocalDateTime closeAt = LocalDateTime.now().minusDays(1);
 
 		assertThatThrownBy(
 			() -> GameTicketingStatusEntity.create(

--- a/ticketing/src/main/java/com/goti/game/controller/GameController.java
+++ b/ticketing/src/main/java/com/goti/game/controller/GameController.java
@@ -2,7 +2,7 @@ package com.goti.game.controller;
 
 import com.goti.game.dto.request.GameCreateRequest;
 import com.goti.game.dto.response.GameCreateResponse;
-import com.goti.game.service.application.GameOperationService;
+import com.goti.game.service.application.GameManagementService;
 
 import com.goti.global.api.ApiSuccessResponse;
 
@@ -25,7 +25,7 @@ import static com.goti.global.api.ApiSuccessResponse.wrap;
 @RequestMapping("/api/v1/games")
 public class GameController {
 
-	private final GameOperationService gameOperationService;
+	private final GameManagementService gameManagementService;
 
 	@Operation(
 		summary = "야구 경기 등록",
@@ -36,7 +36,7 @@ public class GameController {
 		@RequestBody @Valid GameCreateRequest request
 	) {
 		return wrap(
-			gameOperationService.register(
+			gameManagementService.register(
 				request.homeTeamId(),
 				request.awayTeamId(),
 				request.stadiumId(),

--- a/ticketing/src/main/java/com/goti/game/dto/response/GameCreateResponse.java
+++ b/ticketing/src/main/java/com/goti/game/dto/response/GameCreateResponse.java
@@ -1,7 +1,10 @@
 package com.goti.game.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.goti.constants.GameStatus;
 import com.goti.constants.LeagueType;
+
+import com.goti.constants.TicketingStatus;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -11,16 +14,16 @@ import java.util.UUID;
 @Schema(description = "경기 등록 응답")
 public record GameCreateResponse(
 
-	@Schema(description = "경기 ID", example = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+	@Schema(description = "경기 ID", example = "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d")
 	UUID gameId,
 
-	@Schema(description = "홈팀 ID", example = "11111111-1111-1111-1111-111111111111")
+	@Schema(description = "홈팀 ID", example = "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d")
 	UUID homeTeamId,
 
-	@Schema(description = "원정팀 ID", example = "22222222-2222-2222-2222-222222222222")
+	@Schema(description = "원정팀 ID", example = "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d")
 	UUID awayTeamId,
 
-	@Schema(description = "구장 ID", example = "33333333-3333-3333-3333-333333333333")
+	@Schema(description = "구장 ID", example = "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d")
 	UUID stadiumId,
 
 	@Schema(
@@ -34,7 +37,24 @@ public record GameCreateResponse(
 	LeagueType leagueType,
 
 	@Schema(description = "경기 상태", example = "SCHEDULED")
-	GameStatus gameStatus
+	GameStatus gameStatus,
+
+	@Schema(
+		description = "게임 예매 오픈 일시 (yyyy-MM-dd HH:mm)",
+		example = "2026-08-20 11:00"
+	)
+	@JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+	LocalDateTime ticketingOpenedAt,
+
+	@Schema(
+		description = "게임 예매 마감 일시 (yyyy-MM-dd HH:mm)",
+		example = "2026-08-26 19:00"
+	)
+	@JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+	LocalDateTime ticketingEndAt,
+
+	@Schema(description = "게임 예매 상태", example = "SCHEDULED")
+	TicketingStatus ticketingStatus
 
 ) {
 	public static GameCreateResponse from(
@@ -44,10 +64,22 @@ public record GameCreateResponse(
 		UUID stadiumId,
 		LocalDateTime startAt,
 		LeagueType leagueType,
-		GameStatus gameStatus
+		GameStatus gameStatus,
+		LocalDateTime ticketingOpenedAt,
+		LocalDateTime ticketingEndAt,
+		TicketingStatus ticketingStatus
 	) {
 		return new GameCreateResponse(
-			gameId, homeTeamId, awayTeamId, stadiumId, startAt, leagueType, gameStatus
+			gameId,
+			homeTeamId,
+			awayTeamId,
+			stadiumId,
+			startAt,
+			leagueType,
+			gameStatus,
+			ticketingOpenedAt,
+			ticketingEndAt,
+			ticketingStatus
 		);
 	}
 }

--- a/ticketing/src/main/java/com/goti/game/repository/GameTicketingStatusRepository.java
+++ b/ticketing/src/main/java/com/goti/game/repository/GameTicketingStatusRepository.java
@@ -1,0 +1,12 @@
+package com.goti.game.repository;
+
+import com.goti.domain.entity.game.GameTicketingStatusEntity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface GameTicketingStatusRepository extends JpaRepository<GameTicketingStatusEntity, UUID> {
+}

--- a/ticketing/src/main/java/com/goti/game/service/application/GameManagementService.java
+++ b/ticketing/src/main/java/com/goti/game/service/application/GameManagementService.java
@@ -15,6 +15,7 @@ import com.goti.service.domain.stadium.StadiumService;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -28,6 +29,7 @@ public class GameManagementService {
 	private final BaseballTeamService baseballTeamService;
 	private final StadiumService stadiumService;
 
+	@Transactional
 	public GameCreateResponse register(
 		UUID homeTeamId,
 		UUID awayTeamId,

--- a/ticketing/src/main/java/com/goti/game/service/application/GameManagementService.java
+++ b/ticketing/src/main/java/com/goti/game/service/application/GameManagementService.java
@@ -21,7 +21,7 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
-public class GameOperationService {
+public class GameManagementService {
 
 	private final GameScheduleService gameScheduleService;
 	private final GameStatusService gameStatusService;

--- a/ticketing/src/main/java/com/goti/game/service/application/GameManagementService.java
+++ b/ticketing/src/main/java/com/goti/game/service/application/GameManagementService.java
@@ -3,11 +3,13 @@ package com.goti.game.service.application;
 import com.goti.constants.LeagueType;
 import com.goti.domain.entity.game.GameScheduleEntity;
 import com.goti.domain.entity.game.GameStatusEntity;
+import com.goti.domain.entity.game.GameTicketingStatusEntity;
 import com.goti.game.dto.response.GameCreateResponse;
 import com.goti.game.service.domain.GameScheduleService;
 
 import com.goti.game.service.domain.GameStatusService;
 
+import com.goti.game.service.domain.GameTicketingStatusService;
 import com.goti.service.domain.baseballteam.BaseballTeamService;
 
 import com.goti.service.domain.stadium.StadiumService;
@@ -26,6 +28,7 @@ public class GameManagementService {
 
 	private final GameScheduleService gameScheduleService;
 	private final GameStatusService gameStatusService;
+	private final GameTicketingStatusService gameTicketingStatusService;
 	private final BaseballTeamService baseballTeamService;
 	private final StadiumService stadiumService;
 
@@ -48,6 +51,9 @@ public class GameManagementService {
 
 		GameStatusEntity gameStatus = gameStatusService.create(gameSchedule);
 
+		GameTicketingStatusEntity gameTicketingStatus =
+			gameTicketingStatusService.create(gameSchedule);
+
 		return GameCreateResponse.from(
 			gameSchedule.getId(),
 			gameSchedule.getHomeTeamId(),
@@ -55,7 +61,10 @@ public class GameManagementService {
 			gameSchedule.getStadiumId(),
 			gameSchedule.getStartAt(),
 			gameSchedule.getLeagueType(),
-			gameStatus.getGameStatus()
+			gameStatus.getGameStatus(),
+			gameTicketingStatus.getTicketingOpenedAt(),
+			gameTicketingStatus.getTicketingEndAt(),
+			gameTicketingStatus.getStatus()
 		);
 	}
 

--- a/ticketing/src/main/java/com/goti/game/service/domain/GameTicketingStatusService.java
+++ b/ticketing/src/main/java/com/goti/game/service/domain/GameTicketingStatusService.java
@@ -1,0 +1,9 @@
+package com.goti.game.service.domain;
+
+import com.goti.domain.entity.game.GameScheduleEntity;
+import com.goti.domain.entity.game.GameTicketingStatusEntity;
+
+public interface GameTicketingStatusService {
+
+	GameTicketingStatusEntity create(GameScheduleEntity gameSchedule);
+}

--- a/ticketing/src/main/java/com/goti/game/service/domain/GameTicketingStatusServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/game/service/domain/GameTicketingStatusServiceImpl.java
@@ -1,0 +1,53 @@
+package com.goti.game.service.domain;
+
+import com.goti.constants.TicketingStatus;
+import com.goti.domain.entity.game.GameScheduleEntity;
+import com.goti.domain.entity.game.GameTicketingStatusEntity;
+
+import com.goti.game.repository.GameTicketingStatusRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class GameTicketingStatusServiceImpl implements GameTicketingStatusService {
+
+	private final GameTicketingStatusRepository gameTicketingStatusRepository;
+
+	@Override
+	@Transactional
+	public GameTicketingStatusEntity create(GameScheduleEntity gameSchedule) {
+		LocalDateTime gameStartAt = gameSchedule.getStartAt();
+		LocalDateTime now = LocalDateTime.now();
+
+		LocalDateTime openedAt = calculateOpenedAt(gameStartAt, now);
+		LocalDateTime endAt = gameStartAt.plusHours(1);
+		TicketingStatus status = TicketingStatus.SCHEDULED;
+		if (openedAt.isBefore(now) || openedAt.isEqual(now))
+			status = TicketingStatus.AVAILABLE;
+
+		GameTicketingStatusEntity gameTicketingStatus = GameTicketingStatusEntity.create(
+			gameSchedule, openedAt, endAt, status
+		);
+		return gameTicketingStatusRepository.save(gameTicketingStatus);
+	}
+
+	private LocalDateTime calculateOpenedAt(LocalDateTime gameStartAt, LocalDateTime now) {
+		LocalDateTime standardOpenAt = gameStartAt.minusDays(7)
+			.withHour(11)
+			.withMinute(0)
+			.withSecond(0)
+			.withNano(0);
+
+		if (standardOpenAt.isBefore(now)) {
+			standardOpenAt = now.toLocalDate().atTime(11, 0);
+		}
+
+		return standardOpenAt;
+	}
+}

--- a/ticketing/src/main/java/com/goti/game/service/domain/GameTicketingStatusServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/game/service/domain/GameTicketingStatusServiceImpl.java
@@ -45,7 +45,7 @@ public class GameTicketingStatusServiceImpl implements GameTicketingStatusServic
 			.withNano(0);
 
 		if (standardOpenAt.isBefore(now)) {
-			standardOpenAt = now.toLocalDate().atTime(11, 0);
+			standardOpenAt = now.toLocalDate().atTime(11, 0, 0, 0);
 		}
 
 		return standardOpenAt;

--- a/ticketing/src/main/java/com/goti/game/service/domain/GameTicketingStatusServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/game/service/domain/GameTicketingStatusServiceImpl.java
@@ -26,7 +26,7 @@ public class GameTicketingStatusServiceImpl implements GameTicketingStatusServic
 		LocalDateTime now = LocalDateTime.now();
 
 		LocalDateTime openedAt = calculateOpenedAt(gameStartAt, now);
-		LocalDateTime endAt = gameStartAt.plusHours(1);
+		LocalDateTime endAt = gameStartAt.plusHours(1).withSecond(0).withNano(0);
 		TicketingStatus status = TicketingStatus.SCHEDULED;
 		if (openedAt.isBefore(now) || openedAt.isEqual(now))
 			status = TicketingStatus.AVAILABLE;

--- a/ticketing/src/test/java/com/goti/game/api/game/GameRegistrationTest.java
+++ b/ticketing/src/test/java/com/goti/game/api/game/GameRegistrationTest.java
@@ -7,6 +7,7 @@ import com.goti.config.jwt.JwtAuthenticationFilter;
 import com.goti.config.security.SecurityConfig;
 import com.goti.constants.LeagueType;
 import com.goti.constants.TeamCode;
+import com.goti.constants.TicketingStatus;
 import com.goti.domain.entity.stadium.StadiumEntity;
 
 import com.goti.domain.entity.team.BaseballTeamEntity;
@@ -33,6 +34,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 
@@ -67,8 +69,11 @@ public class GameRegistrationTest {
 	BaseballTeamEntity awayTeam;
 	StadiumEntity stadium;
 
-	static final LocalDateTime START_AT = LocalDateTime.now().plusDays(3);
+	static final LocalDateTime START_AT =
+		LocalDateTime.now().plusDays(3).withMinute(30).withSecond(0).withNano(0);
 	static final LeagueType LEAGUE_TYPE = LeagueType.REGULAR;
+	static final LocalDateTime now = LocalDateTime.now();
+	static final int TICKETING_START_HOUR = 11;
 
 	@BeforeEach
 	void setup() {
@@ -90,6 +95,11 @@ public class GameRegistrationTest {
 			LEAGUE_TYPE
 		);
 
+		String expectedTicketingOpenedAt = LocalDateTime.of(
+			now.getYear(), now.getMonth(), now.getDayOfMonth(), TICKETING_START_HOUR, 0,0,0
+		).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+
+		String expectedTicketingEndAt = START_AT.plusHours(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
 
 		MvcResult result = mockMvc.perform(
 				post("/api/v1/games")
@@ -106,7 +116,11 @@ public class GameRegistrationTest {
 				jsonPath("$.data.gameId").exists(),
 				jsonPath("$.data.homeTeamId").value(homeTeam.getId().toString()),
 				jsonPath("$.data.awayTeamId").value(awayTeam.getId().toString()),
-				jsonPath("$.data.stadiumId").value(stadium.getId().toString())
+				jsonPath("$.data.stadiumId").value(stadium.getId().toString()),
+				jsonPath("$.data.ticketingOpenedAt").value(expectedTicketingOpenedAt),
+				jsonPath("$.data.ticketingEndAt").value(expectedTicketingEndAt),
+				jsonPath("$.data.ticketingStatus").value(TicketingStatus.AVAILABLE.name())
+
 			).andReturn();
 
 		String responseJson = result.getResponse().getContentAsString();

--- a/ticketing/src/test/java/com/goti/game/api/game/GameRegistrationTest.java
+++ b/ticketing/src/test/java/com/goti/game/api/game/GameRegistrationTest.java
@@ -69,11 +69,11 @@ public class GameRegistrationTest {
 	BaseballTeamEntity awayTeam;
 	StadiumEntity stadium;
 
-	static final LocalDateTime START_AT =
+	private static final LocalDateTime START_AT =
 		LocalDateTime.now().plusDays(3).withMinute(30).withSecond(0).withNano(0);
-	static final LeagueType LEAGUE_TYPE = LeagueType.REGULAR;
-	static final LocalDateTime now = LocalDateTime.now();
-	static final int TICKETING_START_HOUR = 11;
+	private static final LeagueType LEAGUE_TYPE = LeagueType.REGULAR;
+	private static final LocalDateTime now = LocalDateTime.now();
+	private static final int TICKETING_START_HOUR = 11;
 
 	@BeforeEach
 	void setup() {
@@ -95,11 +95,17 @@ public class GameRegistrationTest {
 			LEAGUE_TYPE
 		);
 
-		String expectedTicketingOpenedAt = LocalDateTime.of(
-			now.getYear(), now.getMonth(), now.getDayOfMonth(), TICKETING_START_HOUR, 0,0,0
-		).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+		LocalDateTime executionTime = LocalDateTime.now();
 
-		String expectedTicketingEndAt = START_AT.plusHours(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+		LocalDateTime expectedOpenTime = executionTime.toLocalDate().atTime(TICKETING_START_HOUR, 0);
+		String formattedOpenedAt = expectedOpenTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+
+		String formattedEndAt = START_AT.plusHours(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+
+		TicketingStatus expectedStatus = TicketingStatus.SCHEDULED;
+		if (expectedOpenTime.isBefore(executionTime) || expectedOpenTime.isEqual(executionTime)) {
+			expectedStatus = TicketingStatus.AVAILABLE;
+		}
 
 		MvcResult result = mockMvc.perform(
 				post("/api/v1/games")
@@ -117,9 +123,9 @@ public class GameRegistrationTest {
 				jsonPath("$.data.homeTeamId").value(homeTeam.getId().toString()),
 				jsonPath("$.data.awayTeamId").value(awayTeam.getId().toString()),
 				jsonPath("$.data.stadiumId").value(stadium.getId().toString()),
-				jsonPath("$.data.ticketingOpenedAt").value(expectedTicketingOpenedAt),
-				jsonPath("$.data.ticketingEndAt").value(expectedTicketingEndAt),
-				jsonPath("$.data.ticketingStatus").value(TicketingStatus.AVAILABLE.name())
+				jsonPath("$.data.ticketingOpenedAt").value(formattedOpenedAt),
+				jsonPath("$.data.ticketingEndAt").value(formattedEndAt),
+				jsonPath("$.data.ticketingStatus").value(expectedStatus.name())
 
 			).andReturn();
 

--- a/ticketing/src/test/java/com/goti/game/service/GameManagementServiceTest.java
+++ b/ticketing/src/test/java/com/goti/game/service/GameManagementServiceTest.java
@@ -73,10 +73,19 @@ public class GameManagementServiceTest {
 			LEAGUE_TYPE
 		);
 
+		LocalDateTime executionTime = LocalDateTime.now();
+
+		LocalDateTime expectedOpenAt = executionTime.toLocalDate().atTime(11, 0);
+
+		TicketingStatus expectedStatus = TicketingStatus.SCHEDULED;
+		if (expectedOpenAt.isBefore(executionTime) || expectedOpenAt.isEqual(executionTime)) {
+			expectedStatus = TicketingStatus.AVAILABLE;
+		}
+
 		assertNotNull(response.gameId());
 		assertNotNull(response.ticketingOpenedAt());
 		assertNotNull(response.ticketingEndAt());
-		assertEquals(TicketingStatus.AVAILABLE, response.ticketingStatus());
+		assertEquals(expectedStatus, response.ticketingStatus());
 		log.info("response gameId : {}", response.gameId());
 		log.info("response ticketingStatus :: {}", response.ticketingStatus());
 		log.info("response ticketingOpenedAt :: {}", response.ticketingOpenedAt());

--- a/ticketing/src/test/java/com/goti/game/service/GameManagementServiceTest.java
+++ b/ticketing/src/test/java/com/goti/game/service/GameManagementServiceTest.java
@@ -7,7 +7,7 @@ import com.goti.constants.TeamCode;
 import com.goti.domain.entity.stadium.StadiumEntity;
 import com.goti.domain.entity.team.BaseballTeamEntity;
 import com.goti.game.dto.response.GameCreateResponse;
-import com.goti.game.service.application.GameOperationService;
+import com.goti.game.service.application.GameManagementService;
 
 import com.goti.repository.BaseballTeamRepository;
 
@@ -34,10 +34,10 @@ import static org.junit.jupiter.api.Assertions.*;
 @Transactional
 @SpringBootTest(classes = GotiTicketingApplication.class)
 @ActiveProfiles("test")
-public class GameOperationServiceTest {
+public class GameManagementServiceTest {
 
 	@Autowired
-	GameOperationService gameOperationService;
+	GameManagementService gameManagementService;
 
 	@Autowired
 	BaseballTeamRepository baseballTeamRepository;
@@ -63,7 +63,7 @@ public class GameOperationServiceTest {
 	@Test
 	@DisplayName("method: create() - 경기 생성 성공")
 	void 경기_생성_성공() {
-		GameCreateResponse response = gameOperationService.register(
+		GameCreateResponse response = gameManagementService.register(
 			homeTeam.getId(),
 			awayTeam.getId(),
 			stadium.getId(),

--- a/ticketing/src/test/java/com/goti/game/service/GameManagementServiceTest.java
+++ b/ticketing/src/test/java/com/goti/game/service/GameManagementServiceTest.java
@@ -4,6 +4,7 @@ import com.goti.GotiTicketingApplication;
 
 import com.goti.constants.LeagueType;
 import com.goti.constants.TeamCode;
+import com.goti.constants.TicketingStatus;
 import com.goti.domain.entity.stadium.StadiumEntity;
 import com.goti.domain.entity.team.BaseballTeamEntity;
 import com.goti.game.dto.response.GameCreateResponse;
@@ -49,7 +50,8 @@ public class GameManagementServiceTest {
 	BaseballTeamEntity awayTeam;
 	StadiumEntity stadium;
 
-	static final LocalDateTime START_AT = LocalDateTime.now().plusDays(3);
+	static final LocalDateTime START_AT =
+		LocalDateTime.now().plusDays(3).withHour(18).withMinute(30).withSecond(0).withNano(0);
 
 	static final LeagueType LEAGUE_TYPE = LeagueType.REGULAR;
 
@@ -72,7 +74,13 @@ public class GameManagementServiceTest {
 		);
 
 		assertNotNull(response.gameId());
+		assertNotNull(response.ticketingOpenedAt());
+		assertNotNull(response.ticketingEndAt());
+		assertEquals(TicketingStatus.AVAILABLE, response.ticketingStatus());
 		log.info("response gameId : {}", response.gameId());
+		log.info("response ticketingStatus :: {}", response.ticketingStatus());
+		log.info("response ticketingOpenedAt :: {}", response.ticketingOpenedAt());
+		log.info("response ticketingEndAt :: {}", response.ticketingEndAt());
 	}
 
 	void saveHomeTeam() {


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#187 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
게임 일정 생성 시 해당 게임에 대한 게임 예매 상태 및 티켓 상태 (GameTicketingStatusEntity) 생성 로직 적용
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- 야구 게임 일정 생성 및 관리 Service 명 변경 (GameOperationService -> GameManagementService)
- 게임 등록 시 게임 시작 시각(LocalDateTime startAt) validate 로직 추가 (In GameScheduleEntity: validateStartAt() )
  - 게임 등록 시 validate 추가
    - 당일 및 과거 시점 생성 불가 (도메인단위에서 체크)
- TicketingStatus(Enum) 값 상태들 변경,
- GameTicketingStatusEntity 생성 시 TicketingStatus 값 고정생성 -> 인자로 받아서 처리 (기존 판매예정 값 고정 값 생성 -> 받아서 처리)
- 게임 예매상태(GameTicketingStatus) 생성 서비스 생성 및 로직 생성 (GameTicketingStatusService)
- 게임 일정 생성 후 응답 데이터 필드 추가 (GameCreateResponse: 티켓팅 오픈 및 마감 일시, 티켓상태 -> ticketingOpenedAt, ticketingEndAt, ticketingStatus)
- 게임 일정 생성 시 -> 게임 예매 상태 데이터 일괄 생성 로직 추가,
- 게임 예매 상태 (GameTicketingStatusEntity) validate 수정 (ticketingOpenedAt, ticketingEndAt 비교 로직)
- 게임 예매 상태 -> 예매 마감 일시(ticketingEndAt), second, nano 0 으로 고정(년 월 일 시 분 까지 정의, ex: 2026-03-14 18:30)
- 게임 일정 생성 API 테스트 코드 수정 (게임 예매 상태 (ticketingOpenedAt, ticketingEndAt, TicketStatus 추가 및 날짜 비교 연산 로직 추가)
<br/>