### PR TITLE
[BUG] 에러 핸들러 로그 개선 — 원인 유실 및 불필요한 stacktrace 제거

### DIFF
--- a/common/src/main/java/com/goti/exception/handler/SystemExceptionHandler.java
+++ b/common/src/main/java/com/goti/exception/handler/SystemExceptionHandler.java
@@ -32,7 +32,7 @@ public class SystemExceptionHandler extends BaseExceptionHandler {
 		if (error.isSystemError()) {
 			log.error("[System Error] code={} message={}", error.name(), ex.getMessage(), ex);
 		} else {
-			log.warn("[Business Error] code={} message={}", error.name(), ex.getMessage(), ex);
+			log.warn("[Business Error] code={} message={}", error.name(), ex.getMessage());
 		}
 		return toResponse(ex);
 	}

--- a/integration/src/main/java/com/goti/config/api/RestClientConfig.java
+++ b/integration/src/main/java/com/goti/config/api/RestClientConfig.java
@@ -68,6 +68,8 @@ public class RestClientConfig {
 			body
 		);
 
-		throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+		throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR,
+			new RuntimeException(String.format("외부 API 오류: %s %s → %d",
+				request.getMethod(), request.getURI(), status)));
 	}
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #198 

<br/>

## 🔎 개요
에러 핸들러 로그에서 외부 API 에러 원인이 유실되고, 비즈니스 에러(4xx)에 불필요한 전체 stacktrace가 출력되는 문제 수정

<br/>


## 📋 작업 내용
- `RestClientConfig.handleError()` — 외부 API 에러 시 cause 체이닝으로 method/URI/status 정보를 `CustomException`에 전달
- `SystemExceptionHandler.handleCustomException()` — 비즈니스 에러(4xx)는 stacktrace 없이 메시지만 로깅, 시스템 에러(5xx)만 stacktrace 포함

<br/>