### PR TITLE
[BUG] 모놀리식 실행 시 MSA Application 빈 중복 스캔 수정 (#202)

### DIFF
--- a/api/src/main/java/com/goti/GotiApplication.java
+++ b/api/src/main/java/com/goti/GotiApplication.java
@@ -3,10 +3,31 @@ package com.goti;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+import com.goti.payment.GotiPaymentApplication;
+import com.goti.resale.GotiResaleApplication;
+import com.goti.stadium.GotiStadiumApplication;
+import com.goti.ticketing.GotiTicketingApplication;
+import com.goti.user.GotiUserApplication;
+
 @ConfigurationPropertiesScan
-@SpringBootApplication(scanBasePackages = "com.goti")
+@SpringBootApplication
+@ComponentScan(
+	basePackages = "com.goti",
+	excludeFilters = @ComponentScan.Filter(
+		type = FilterType.ASSIGNABLE_TYPE,
+		classes = {
+			GotiUserApplication.class,
+			GotiStadiumApplication.class,
+			GotiTicketingApplication.class,
+			GotiPaymentApplication.class,
+			GotiResaleApplication.class
+		}
+	)
+)
 @EnableScheduling
 public class GotiApplication {
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #202

## 🔎 개요
MSA 패키지 재구조화(#197) 머지 후 모놀리식(api) 실행 시
`BeanDefinitionOverrideException` 발생하는 버그 수정

## 📋 작업 내용
- `GotiApplication`에 `@ComponentScan(excludeFilters)` 추가
- 5개 MSA Application 클래스(`GotiUserApplication`, `GotiStadiumApplication`,
`GotiTicketingApplication`, `GotiPaymentApplication`, `GotiResaleApplication`)를
모놀리식 컴포넌트 스캔에서 제외
- 모놀리식 실행 시 JPA Repository 빈 중복 등록 방지