### PR TITLE
[FEAT] MSA 모듈별 Docker 이미지 빌드/배포 파이프라인 구축 (#204)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -144,3 +144,90 @@ jobs:
             --instance-id "$INSTANCE_ID" \
             --query "StandardOutputContent" --output text
           exit 1
+
+  # MSA 모듈별 ECR 이미지 빌드+push (deploy job과 병렬 실행)
+  msa-image-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ap-northeast-2
+
+      - name: Login to Amazon ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Detect changed modules
+        id: detect
+        run: |
+          MSA_MODULES="user stadium ticketing payment resale"
+          SHARED_MODULES="common integration core"
+
+          CHANGED=$(git diff --name-only HEAD~1 HEAD | grep -oP '^[^/]+' | sort -u)
+          echo "변경된 디렉토리: $CHANGED"
+
+          # common/integration/core 변경 시 전체 MSA 모듈 빌드
+          BUILD_ALL=false
+          for shared in $SHARED_MODULES; do
+            if echo "$CHANGED" | grep -qx "$shared"; then
+              BUILD_ALL=true
+              echo "공유 모듈 $shared 변경 감지 — 전체 MSA 모듈 빌드"
+              break
+            fi
+          done
+
+          if [ "$BUILD_ALL" = true ]; then
+            echo "modules=$MSA_MODULES" >> "$GITHUB_OUTPUT"
+          else
+            TARGETS=""
+            for module in $MSA_MODULES; do
+              if echo "$CHANGED" | grep -qx "$module"; then
+                TARGETS="$TARGETS $module"
+              fi
+            done
+            TARGETS=$(echo "$TARGETS" | xargs)
+            echo "modules=$TARGETS" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx
+        if: steps.detect.outputs.modules != ''
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push MSA images
+        if: steps.detect.outputs.modules != ''
+        env:
+          ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+        run: |
+          MODULES="${{ steps.detect.outputs.modules }}"
+          SHORT_SHA=${GITHUB_SHA::7}
+          TAG="dev-${SHORT_SHA}"
+
+          echo "빌드 대상 모듈: $MODULES"
+          echo "이미지 태그: $TAG"
+
+          for MODULE in $MODULES; do
+            REPO="goti-${MODULE}"
+            IMAGE="${ECR_REGISTRY}/${REPO}:${TAG}"
+
+            # 이미 존재하는 이미지 스킵 (모놀리식 deploy job과 동일 패턴)
+            if aws ecr describe-images --repository-name "${REPO}" --image-ids imageTag="${TAG}" > /dev/null 2>&1; then
+              echo "--- ${MODULE}: 이미지 ${TAG} 이미 존재 — 스킵 ---"
+              continue
+            fi
+
+            echo "--- ${MODULE} 빌드 시작 ---"
+            docker buildx build \
+              --build-arg MODULE="${MODULE}" \
+              --cache-from type=gha,scope="${MODULE}" \
+              --cache-to type=gha,mode=max,scope="${MODULE}" \
+              --tag "${IMAGE}" \
+              --push \
+              .
+            echo "--- ${MODULE} 빌드 완료: ${IMAGE} ---"
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,54 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Docker build verification
+      - name: Docker build verification (monolith)
         run: DOCKER_BUILDKIT=1 docker build -t goti-server:ci-test .
+
+      - name: Detect changed MSA modules
+        id: detect
+        run: |
+          MSA_MODULES="user stadium ticketing payment resale"
+          SHARED_MODULES="common integration core"
+
+          CHANGED=$(git diff --name-only origin/develop...HEAD | grep -oP '^[^/]+' | sort -u)
+          echo "변경된 디렉토리: $CHANGED"
+
+          BUILD_ALL=false
+          for shared in $SHARED_MODULES; do
+            if echo "$CHANGED" | grep -qx "$shared"; then
+              BUILD_ALL=true
+              echo "공유 모듈 $shared 변경 감지 — 전체 MSA 모듈 빌드 검증"
+              break
+            fi
+          done
+
+          if [ "$BUILD_ALL" = true ]; then
+            echo "modules=$MSA_MODULES" >> "$GITHUB_OUTPUT"
+          else
+            TARGETS=""
+            for module in $MSA_MODULES; do
+              if echo "$CHANGED" | grep -qx "$module"; then
+                TARGETS="$TARGETS $module"
+              fi
+            done
+            TARGETS=$(echo "$TARGETS" | xargs)
+            echo "modules=$TARGETS" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Docker build verification (MSA modules)
+        if: steps.detect.outputs.modules != ''
+        run: |
+          MODULES="${{ steps.detect.outputs.modules }}"
+          echo "MSA 빌드 검증 대상: $MODULES"
+
+          for MODULE in $MODULES; do
+            echo "--- ${MODULE} 빌드 검증 ---"
+            DOCKER_BUILDKIT=1 docker build \
+              --build-arg MODULE="${MODULE}" \
+              -t "goti-${MODULE}:ci-test" \
+              .
+            echo "--- ${MODULE} 빌드 검증 완료 ---"
+          done

--- a/payment/src/test/resources/application-test.yml
+++ b/payment/src/test/resources/application-test.yml
@@ -1,0 +1,33 @@
+server:
+  port: 8080
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        hbm2ddl.create_namespaces: true
+  datasource:
+    url: ${DATASOURCE_URL:jdbc:postgresql://localhost:5432/goti}
+    username: ${DATASOURCE_USERNAME:goti}
+    password: ${DATASOURCE_PASSWORD:goti1234}
+    driver-class-name: org.postgresql.Driver
+    hikari:
+      idle-timeout: 5000
+      max-lifetime: 420000
+      connection-timeout: 5000
+      validation-timeout: 3000
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+  config:
+    import:
+      - application-integration.yml
+      - optional:file:.env.test[.properties]
+
+jwt:
+  secret: ${JWT_SECRET_KEY:test-jwt-secret-key-min-32-characters-long}
+  access-valid-time: ${JWT_ACCESS_TIME:3600000}
+  refresh-valid-time: ${JWT_REFRESH_TIME:604800000}
+  registration-valid-time: ${JWT_REGISTRATION_TIME:300000}

--- a/resale/src/test/resources/application-test.yml
+++ b/resale/src/test/resources/application-test.yml
@@ -1,0 +1,33 @@
+server:
+  port: 8080
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        hbm2ddl.create_namespaces: true
+  datasource:
+    url: ${DATASOURCE_URL:jdbc:postgresql://localhost:5432/goti}
+    username: ${DATASOURCE_USERNAME:goti}
+    password: ${DATASOURCE_PASSWORD:goti1234}
+    driver-class-name: org.postgresql.Driver
+    hikari:
+      idle-timeout: 5000
+      max-lifetime: 420000
+      connection-timeout: 5000
+      validation-timeout: 3000
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+  config:
+    import:
+      - application-integration.yml
+      - optional:file:.env.test[.properties]
+
+jwt:
+  secret: ${JWT_SECRET_KEY:test-jwt-secret-key-min-32-characters-long}
+  access-valid-time: ${JWT_ACCESS_TIME:3600000}
+  refresh-valid-time: ${JWT_REFRESH_TIME:604800000}
+  registration-valid-time: ${JWT_REGISTRATION_TIME:300000}


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #204 

<br/>

## 🔎 개요
MSA 패키지를 위한 CICD 구축
CI에서 모듈별 Docker 빌드 검증 + CD에서 ECR push 파이프라인을 추가

<br/>


## 📋 작업 내용
### CI (`ci.yml`)
- PR 시 변경된 MSA 모듈의 Docker 빌드 검증 추가 (push 없이, `--build-arg MODULE=xxx`)
- common/integration/core 변경 시 전체 5개 모듈 빌드 검증

### CD (`cd.yml`)
- `msa-image-build` job 추가 — 기존 deploy job과 병렬 실행
- 변경된 MSA 모듈만 ECR 이미지 빌드+push (`dev-{SHA::7}` 태그)
- 이미 존재하는 이미지 스킵 (기존 모놀리식 패턴 동일)
- GHA 캐시 적용 (모듈별 scope 분리)

### 테스트 설정
- `payment/src/test/resources/application-test.yml` 신규 생성
- `resale/src/test/resources/application-test.yml` 신규 생성


<br/>