### PR TITLE
[FEAT] 테스트 유저 생성 API (#215)

### DIFF
--- a/user/src/main/java/com/goti/user/config/security/TestSecurityConfig.java
+++ b/user/src/main/java/com/goti/user/config/security/TestSecurityConfig.java
@@ -1,0 +1,29 @@
+package com.goti.user.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Profile("!prod")
+@Configuration
+public class TestSecurityConfig {
+
+	@Bean
+	@Order(Ordered.HIGHEST_PRECEDENCE)
+	public SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+		http.securityMatcher("/api/v1/test/**")
+			.csrf(AbstractHttpConfigurer::disable)
+			.sessionManagement(session ->
+				session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+			)
+			.authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+
+		return http.build();
+	}
+}

--- a/user/src/main/java/com/goti/user/controller/TestUserController.java
+++ b/user/src/main/java/com/goti/user/controller/TestUserController.java
@@ -1,0 +1,71 @@
+package com.goti.user.controller;
+
+import static com.goti.global.api.ApiSuccessResponse.*;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.goti.global.api.ApiSuccessResponse;
+import com.goti.user.dto.request.BulkCreateTestUserRequest;
+import com.goti.user.dto.request.CreateTestUserRequest;
+import com.goti.user.dto.request.TestLoginRequest;
+import com.goti.user.dto.response.BulkTestUserResponse;
+import com.goti.user.dto.response.TestUserResponse;
+import com.goti.user.dto.response.TokenResponse;
+import com.goti.user.service.test.TestUserService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Profile("!prod")
+@Tag(name = "Test User", description = "테스트 유저 생성/로그인 API (non-prod only)")
+@RestController
+@RequestMapping("/api/v1/test/users")
+@RequiredArgsConstructor
+public class TestUserController {
+
+	private final TestUserService testUserService;
+
+	@Operation(
+		summary = "테스트 유저 단건 생성",
+		description = "OAuth/SMS 인증 없이 테스트 유저를 생성하고 JWT 토큰을 발급합니다. "
+			+ "동일 mobile이 이미 존재하면 기존 유저의 새 토큰을 반환합니다."
+	)
+	@PostMapping
+	public ResponseEntity<ApiSuccessResponse<TestUserResponse>> createUser(
+		@RequestBody @Valid CreateTestUserRequest request
+	) {
+		return wrap(testUserService.createUser(request));
+	}
+
+	@Operation(
+		summary = "테스트 유저 대량 생성",
+		description = "K6 부하 테스트용 유저를 대량 생성합니다. "
+			+ "mobile: 000{startIndex:08d} ~ 000{startIndex+count-1:08d}, "
+			+ "이미 존재하는 유저는 skip합니다."
+	)
+	@PostMapping("/bulk")
+	public ResponseEntity<ApiSuccessResponse<BulkTestUserResponse>> bulkCreateUsers(
+		@RequestBody @Valid BulkCreateTestUserRequest request
+	) {
+		return wrap(testUserService.bulkCreateUsers(request));
+	}
+
+	@Operation(
+		summary = "테스트 유저 로그인",
+		description = "mobile 번호로 테스트 유저의 JWT 토큰을 발급합니다. "
+			+ "K6 시나리오에서 bulk 생성 후 개별 토큰 발급에 사용합니다."
+	)
+	@PostMapping("/login")
+	public ResponseEntity<ApiSuccessResponse<TokenResponse>> login(
+		@RequestBody @Valid TestLoginRequest request
+	) {
+		return wrap(testUserService.login(request));
+	}
+}

--- a/user/src/main/java/com/goti/user/dto/request/BulkCreateTestUserRequest.java
+++ b/user/src/main/java/com/goti/user/dto/request/BulkCreateTestUserRequest.java
@@ -1,5 +1,6 @@
 package com.goti.user.dto.request;
 
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -13,7 +14,16 @@ public record BulkCreateTestUserRequest(
 
 	@NotNull(message = "시작 인덱스는 필수 항목입니다.")
 	@Min(value = 1, message = "시작 인덱스는 1 이상이어야 합니다.")
-	@Max(value = 99_990_000, message = "시작 인덱스 범위를 초과했습니다.")
 	Integer startIndex
 ) {
+
+	private static final int MAX_MOBILE_INDEX = 100_000_000;
+
+	@AssertTrue(message = "startIndex + count가 100,000,000을 초과할 수 없습니다.")
+	boolean isIndexRangeValid() {
+		if (startIndex == null || count == null) {
+			return true;
+		}
+		return (long) startIndex + count <= MAX_MOBILE_INDEX;
+	}
 }

--- a/user/src/main/java/com/goti/user/dto/request/BulkCreateTestUserRequest.java
+++ b/user/src/main/java/com/goti/user/dto/request/BulkCreateTestUserRequest.java
@@ -2,9 +2,18 @@ package com.goti.user.dto.request;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 
 public record BulkCreateTestUserRequest(
-	@Min(1) @Max(100_000) int count,
-	@Min(1) int startIndex
+
+	@NotNull(message = "생성 건수는 필수 항목입니다.")
+	@Min(value = 1, message = "최소 1건 이상이어야 합니다.")
+	@Max(value = 10_000, message = "최대 10,000건까지 가능합니다. 더 필요하면 startIndex를 변경하여 반복 호출하세요.")
+	Integer count,
+
+	@NotNull(message = "시작 인덱스는 필수 항목입니다.")
+	@Min(value = 1, message = "시작 인덱스는 1 이상이어야 합니다.")
+	@Max(value = 99_990_000, message = "시작 인덱스 범위를 초과했습니다.")
+	Integer startIndex
 ) {
 }

--- a/user/src/main/java/com/goti/user/dto/request/BulkCreateTestUserRequest.java
+++ b/user/src/main/java/com/goti/user/dto/request/BulkCreateTestUserRequest.java
@@ -1,0 +1,10 @@
+package com.goti.user.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+public record BulkCreateTestUserRequest(
+	@Min(1) @Max(100_000) int count,
+	@Min(1) int startIndex
+) {
+}

--- a/user/src/main/java/com/goti/user/dto/request/CreateTestUserRequest.java
+++ b/user/src/main/java/com/goti/user/dto/request/CreateTestUserRequest.java
@@ -1,0 +1,17 @@
+package com.goti.user.dto.request;
+
+import java.time.LocalDate;
+
+import com.goti.constants.Gender;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Past;
+
+public record CreateTestUserRequest(
+	@NotBlank String name,
+	@NotBlank String mobile,
+	@NotNull Gender gender,
+	@NotNull @Past LocalDate birthDate
+) {
+}

--- a/user/src/main/java/com/goti/user/dto/request/CreateTestUserRequest.java
+++ b/user/src/main/java/com/goti/user/dto/request/CreateTestUserRequest.java
@@ -2,16 +2,29 @@ package com.goti.user.dto.request;
 
 import java.time.LocalDate;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.goti.constants.Gender;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.Pattern;
 
 public record CreateTestUserRequest(
-	@NotBlank String name,
-	@NotBlank String mobile,
-	@NotNull Gender gender,
-	@NotNull @Past LocalDate birthDate
+
+	@NotBlank(message = "이름은 필수 항목입니다.")
+	String name,
+
+	@NotBlank(message = "휴대전화번호는 필수 항목입니다.")
+	@Pattern(regexp = "^000\\d{8}$", message = "테스트 유저 mobile은 000XXXXXXXX 형식이어야 합니다")
+	String mobile,
+
+	@NotNull(message = "성별은 필수 항목입니다.")
+	Gender gender,
+
+	@NotNull(message = "생년월일은 필수 항목입니다.")
+	@Past(message = "유효하지 않은 생년월일입니다.")
+	@JsonFormat(pattern = "yyyy-MM-dd")
+	LocalDate birthDate
 ) {
 }

--- a/user/src/main/java/com/goti/user/dto/request/TestLoginRequest.java
+++ b/user/src/main/java/com/goti/user/dto/request/TestLoginRequest.java
@@ -1,0 +1,8 @@
+package com.goti.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TestLoginRequest(
+	@NotBlank String mobile
+) {
+}

--- a/user/src/main/java/com/goti/user/dto/request/TestLoginRequest.java
+++ b/user/src/main/java/com/goti/user/dto/request/TestLoginRequest.java
@@ -1,8 +1,12 @@
 package com.goti.user.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 public record TestLoginRequest(
-	@NotBlank String mobile
+
+	@NotBlank(message = "휴대전화번호는 필수 항목입니다.")
+	@Pattern(regexp = "^000\\d{8}$", message = "테스트 유저 mobile은 000XXXXXXXX 형식이어야 합니다")
+	String mobile
 ) {
 }

--- a/user/src/main/java/com/goti/user/dto/response/BulkTestUserResponse.java
+++ b/user/src/main/java/com/goti/user/dto/response/BulkTestUserResponse.java
@@ -1,0 +1,7 @@
+package com.goti.user.dto.response;
+
+public record BulkTestUserResponse(
+	int createdCount,
+	int skippedCount
+) {
+}

--- a/user/src/main/java/com/goti/user/dto/response/TestUserResponse.java
+++ b/user/src/main/java/com/goti/user/dto/response/TestUserResponse.java
@@ -1,0 +1,11 @@
+package com.goti.user.dto.response;
+
+import java.util.UUID;
+
+public record TestUserResponse(
+	UUID userId,
+	String mobile,
+	String name,
+	String accessToken
+) {
+}

--- a/user/src/main/java/com/goti/user/service/test/TestUserService.java
+++ b/user/src/main/java/com/goti/user/service/test/TestUserService.java
@@ -1,0 +1,105 @@
+package com.goti.user.service.test;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goti.constants.Gender;
+import com.goti.constants.OAuthProvider;
+import com.goti.user.config.jwt.JwtTokenProvider;
+import com.goti.user.constants.UserRole;
+import com.goti.user.domain.entity.user.MemberEntity;
+import com.goti.user.dto.request.BulkCreateTestUserRequest;
+import com.goti.user.dto.request.CreateTestUserRequest;
+import com.goti.user.dto.request.TestLoginRequest;
+import com.goti.user.dto.response.BulkTestUserResponse;
+import com.goti.user.dto.response.TestUserResponse;
+import com.goti.user.dto.response.TokenResponse;
+import com.goti.user.service.domain.user.MemberService;
+import com.goti.user.service.domain.user.SocialProviderService;
+
+import lombok.RequiredArgsConstructor;
+
+@Profile("!prod")
+@Service
+@RequiredArgsConstructor
+public class TestUserService {
+
+	private final MemberService memberService;
+	private final SocialProviderService socialProviderService;
+	private final JwtTokenProvider jwtTokenProvider;
+
+	@Transactional
+	public TestUserResponse createUser(CreateTestUserRequest request) {
+		MemberEntity member = memberService.findByMobile(request.mobile())
+			.orElseGet(() -> createMemberWithSocialProvider(
+				request.name(), request.mobile(), request.gender(), request.birthDate()
+			));
+
+		String accessToken = jwtTokenProvider.create(
+			member.getId(), member.getMobile(), UserRole.MEMBER
+		);
+
+		return new TestUserResponse(
+			member.getId(), member.getMobile(), member.getName(), accessToken
+		);
+	}
+
+	@Transactional
+	public BulkTestUserResponse bulkCreateUsers(BulkCreateTestUserRequest request) {
+		int created = 0;
+		int skipped = 0;
+
+		for (int i = request.startIndex(); i < request.startIndex() + request.count(); i++) {
+			String mobile = String.format("000%08d", i);
+
+			if (memberService.findByMobile(mobile).isPresent()) {
+				skipped++;
+				continue;
+			}
+
+			String name = "test-user-" + i;
+			String email = "test-" + i + "@test.com";
+
+			MemberEntity member = memberService.save(
+				name, mobile, Gender.MALE, LocalDate.of(2000, 1, 1)
+			);
+			socialProviderService.save(
+				member, OAuthProvider.NAVER, "test-" + UUID.randomUUID(), email
+			);
+
+			created++;
+		}
+
+		return new BulkTestUserResponse(created, skipped);
+	}
+
+	@Transactional(readOnly = true)
+	public TokenResponse login(TestLoginRequest request) {
+		MemberEntity member = memberService.findByMobile(request.mobile())
+			.orElseThrow(() -> new IllegalArgumentException(
+				"테스트 유저를 찾을 수 없습니다: mobile=" + request.mobile()
+			));
+
+		String accessToken = jwtTokenProvider.create(
+			member.getId(), member.getMobile(), UserRole.MEMBER
+		);
+
+		return new TokenResponse(accessToken);
+	}
+
+	private MemberEntity createMemberWithSocialProvider(
+		String name, String mobile, Gender gender, LocalDate birthDate
+	) {
+		MemberEntity member = memberService.save(name, mobile, gender, birthDate);
+		socialProviderService.save(
+			member, OAuthProvider.NAVER,
+			"test-" + UUID.randomUUID(),
+			"test-" + mobile + "@test.com"
+		);
+		return member;
+	}
+}

--- a/user/src/main/java/com/goti/user/service/test/TestUserService.java
+++ b/user/src/main/java/com/goti/user/service/test/TestUserService.java
@@ -1,7 +1,6 @@
 package com.goti.user.service.test;
 
 import java.time.LocalDate;
-import java.util.UUID;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -9,6 +8,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.goti.constants.Gender;
 import com.goti.constants.OAuthProvider;
+import com.goti.constants.messages.ErrorCode;
+import com.goti.exception.CustomException;
 import com.goti.user.config.jwt.JwtTokenProvider;
 import com.goti.user.constants.UserRole;
 import com.goti.user.domain.entity.user.MemberEntity;
@@ -48,6 +49,14 @@ public class TestUserService {
 		);
 	}
 
+	/**
+	 * 테스트 유저 대량 생성.
+	 * @Max(10_000)으로 단일 요청 상한을 제한하여 트랜잭션 부담을 완화.
+	 * 10,000건 이상 필요 시 startIndex를 변경하여 반복 호출 (K6 setup에서 처리).
+	 *
+	 * <p>성능 참고: 건당 findByMobile SELECT가 발생하나, 테스트 데이터 세팅 용도이므로
+	 * 배치 IN 쿼리 최적화는 적용하지 않음. 10,000건 기준 수 초 내 완료.</p>
+	 */
 	@Transactional
 	public BulkTestUserResponse bulkCreateUsers(BulkCreateTestUserRequest request) {
 		int created = 0;
@@ -61,16 +70,9 @@ public class TestUserService {
 				continue;
 			}
 
-			String name = "test-user-" + i;
-			String email = "test-" + i + "@test.com";
-
-			MemberEntity member = memberService.save(
-				name, mobile, Gender.MALE, LocalDate.of(2000, 1, 1)
+			createMemberWithSocialProvider(
+				"test-user-" + i, mobile, Gender.MALE, LocalDate.of(2000, 1, 1)
 			);
-			socialProviderService.save(
-				member, OAuthProvider.NAVER, "test-" + UUID.randomUUID(), email
-			);
-
 			created++;
 		}
 
@@ -80,9 +82,7 @@ public class TestUserService {
 	@Transactional(readOnly = true)
 	public TokenResponse login(TestLoginRequest request) {
 		MemberEntity member = memberService.findByMobile(request.mobile())
-			.orElseThrow(() -> new IllegalArgumentException(
-				"테스트 유저를 찾을 수 없습니다: mobile=" + request.mobile()
-			));
+			.orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
 		String accessToken = jwtTokenProvider.create(
 			member.getId(), member.getMobile(), UserRole.MEMBER
@@ -95,9 +95,10 @@ public class TestUserService {
 		String name, String mobile, Gender gender, LocalDate birthDate
 	) {
 		MemberEntity member = memberService.save(name, mobile, gender, birthDate);
+		// 테스트 더미 SocialProvider — providerId는 mobile 기반 고정값 (SecureRandom 불필요)
 		socialProviderService.save(
 			member, OAuthProvider.NAVER,
-			"test-" + UUID.randomUUID(),
+			"test-provider-" + mobile,
 			"test-" + mobile + "@test.com"
 		);
 		return member;


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #215
- 
<br/>

## 🔎 개요
OAuth2 소셜 로그인 + SMS 인증을 우회하여 테스트 유저를 생성하는 전용 API.
Swagger/Postman API 테스트, K6 부하 테스트 등 인증 플로우 없이 유저가 필요한 모든 테스트 시나리오에 사용.

<br/>

## 📋 작업 내용
- `POST /api/v1/test/users` — 단건 생성 (JWT 토큰 즉시 발급, 기존 유저 시 토큰만 재발급)
- `POST /api/v1/test/users/bulk` — 대량 생성 (최대 10,000건, mobile: 000XXXXXXXX)
- `POST /api/v1/test/users/login` — mobile 기반 토큰 재발급
- `@Profile("!prod")` Controller/Service + 별도 `TestSecurityConfig`로 운영 환경 완전 차단
- mobile `@Pattern("^000\\d{8}$")` 강제로 실제 번호 충돌 방지
- DTO validation message, @JsonFormat 등 기존 컨벤션 준수
- 
<br/>