### PR TITLE
[CHORE] CD 이미지 태그 형식 변경 — run_number 기반 (#223)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set image tag
         id: image
         run: |
-          IMAGE_TAG="dev-${GITHUB_SHA::7}"
+          IMAGE_TAG="dev-${{ github.run_number }}-${GITHUB_SHA::7}"
           FULL_IMAGE="${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${IMAGE_TAG}"
           echo "tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
           echo "full_image=${FULL_IMAGE}" >> "$GITHUB_OUTPUT"
@@ -119,7 +119,7 @@ jobs:
         run: |
           MODULES="${{ steps.detect.outputs.modules }}"
           SHORT_SHA=${GITHUB_SHA::7}
-          TAG="dev-${SHORT_SHA}"
+          TAG="dev-${{ github.run_number }}-${SHORT_SHA}"
 
           echo "빌드 대상 모듈: $MODULES"
           echo "이미지 태그: $TAG"


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
- #223


<br/>

## 🔎 개요
CD workflow의 Docker 이미지 태그 형식을 `dev-<sha>` → `dev-<run_number>-<sha>`로 변경하여
Goti-k8s Renovate가 이미지 태그의 신/구 순서를 비교하고 자동 업데이트할 수 있도록 수정합니다.

<br/>


## 📋 작업 내용
- `.github/workflows/cd.yml` 모놀리식 빌드 태그에 `github.run_number` 추가
- `.github/workflows/cd.yml` MSA 빌드 태그에 동일하게 `github.run_number` 추가
- 태그 예시: `dev-41af00e` → `dev-42-41af00e`
- Goti-k8s 측 Renovate 설정은 별도 커밋으로 반영 완료 (0c02685)

<br/>