### PR TITLE
[CHORE] CD 이미지 태그 업데이트 방식 전환 — Renovate → GitHub API 직접 업데이트 (#226)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -145,16 +145,55 @@ jobs:
             echo "--- ${MODULE} 빌드 완료: ${IMAGE} ---"
           done
 
-  # ECR 이미지 push 후 Goti-k8s Renovate 즉시 트리거
-  trigger-renovate:
+  # ECR 이미지 push 후 Goti-k8s values.yaml 태그 직접 업데이트
+  update-k8s-image-tag:
     needs: [image-build, msa-image-build]
     if: always() && (needs.image-build.result == 'success' || needs.msa-image-build.result == 'success')
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger Goti-k8s Renovate
-        run: |
-          gh api repos/Team-Ikujo/Goti-k8s/dispatches \
-            -f event_type=image-pushed \
-            -f 'client_payload[sha]=${{ github.sha }}'
+      - name: Update Goti-k8s image tags
         env:
           GH_TOKEN: ${{ secrets.GOTI_K8S_DISPATCH_TOKEN }}
+        run: |
+          TAG="dev-${{ github.run_number }}-${GITHUB_SHA::7}"
+          REPO="Team-Ikujo/Goti-k8s"
+          BRANCH="main"
+          MSA_MODULES="user stadium ticketing payment resale"
+
+          echo "이미지 태그: $TAG"
+
+          for MODULE in $MSA_MODULES; do
+            FILE_PATH="environments/dev/goti-${MODULE}/values.yaml"
+
+            # 현재 파일 내용 + SHA 가져오기
+            RESPONSE=$(gh api "repos/${REPO}/contents/${FILE_PATH}?ref=${BRANCH}" 2>/dev/null) || {
+              echo "⚠️ ${FILE_PATH} 조회 실패 — 스킵"
+              continue
+            }
+
+            FILE_SHA=$(echo "$RESPONSE" | jq -r '.sha')
+            CONTENT_B64=$(echo "$RESPONSE" | jq -r '.content')
+            CURRENT=$(echo "$CONTENT_B64" | base64 -d)
+
+            # 현재 태그 확인
+            CURRENT_TAG=$(echo "$CURRENT" | grep -oP 'tag:\s*"\K[^"]+')
+            if [ "$CURRENT_TAG" = "$TAG" ]; then
+              echo "✓ goti-${MODULE}: 이미 최신 ($TAG)"
+              continue
+            fi
+
+            # 태그 교체
+            UPDATED=$(echo "$CURRENT" | sed "s|tag: \"${CURRENT_TAG}\"|tag: \"${TAG}\"|")
+            NEW_B64=$(echo "$UPDATED" | base64 -w 0)
+
+            # 커밋
+            gh api "repos/${REPO}/contents/${FILE_PATH}" \
+              -X PUT \
+              -f message="[CHORE] goti-${MODULE} 이미지 태그 업데이트: ${TAG}" \
+              -f content="${NEW_B64}" \
+              -f sha="${FILE_SHA}" \
+              -f branch="${BRANCH}" \
+              --silent
+
+            echo "✓ goti-${MODULE}: ${CURRENT_TAG} → ${TAG}"
+          done


### PR DESCRIPTION
본문:
## #️⃣ 관련 이슈
- #226

<br/>

## 🔎 개요
CD 파이프라인에서 ECR 이미지 빌드 후 Goti-k8s values.yaml 태그 업데이트 방식을 Renovate 트리거에서 GitHub API 직접 업데이트로 전환합니다.
Renovate + ECR private registry 인증 문제 미해결로 인한 대안입니다.

<br/>

## 📋 작업 내용
- `trigger-renovate` job 제거
- `update-k8s-image-tag` job 추가
  - GitHub API로 Goti-k8s의 MSA 5개 모듈(user, stadium, ticketing, payment, resale) values.yaml의 image tag를 직접 수정 커밋
  - 이미 최신 태그인 모듈은 스킵
  - 모듈별 개별 커밋 → ArgoCD 자동 감지 → 배포

  <br/>