### PR TITLE
[BUG] CD에서 미빌드 MSA 모듈 태그 업데이트 방지 (#231)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,6 +61,8 @@ jobs:
   # MSA 모듈별 ECR 이미지 빌드+push
   msa-image-build:
     runs-on: ubuntu-latest
+    outputs:
+      built-modules: ${{ steps.detect.outputs.modules }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -145,10 +147,10 @@ jobs:
             echo "--- ${MODULE} 빌드 완료: ${IMAGE} ---"
           done
 
-  # ECR 이미지 push 후 Goti-k8s values.yaml 태그 직접 업데이트
+  # 빌드된 MSA 모듈만 Goti-k8s values.yaml 태그 업데이트
   update-k8s-image-tag:
-    needs: [image-build, msa-image-build]
-    if: always() && (needs.image-build.result == 'success' || needs.msa-image-build.result == 'success')
+    needs: [msa-image-build]
+    if: needs.msa-image-build.outputs.built-modules != ''
     runs-on: ubuntu-latest
     steps:
       - name: Update Goti-k8s image tags
@@ -158,11 +160,12 @@ jobs:
           TAG="dev-${{ github.run_number }}-${GITHUB_SHA::7}"
           REPO="Team-Ikujo/Goti-k8s"
           BRANCH="main"
-          MSA_MODULES="user stadium ticketing payment resale"
+          BUILT_MODULES="${{ needs.msa-image-build.outputs.built-modules }}"
 
           echo "이미지 태그: $TAG"
+          echo "빌드된 모듈: $BUILT_MODULES"
 
-          for MODULE in $MSA_MODULES; do
+          for MODULE in $BUILT_MODULES; do
             FILE_PATH="environments/dev/goti-${MODULE}/values.yaml"
 
             # 현재 파일 내용 + SHA 가져오기


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closes #231

<br/>

## 🔎 개요
CD workflow에서 MSA 이미지가 빌드되지 않은 경우에도 Goti-k8s values.yaml 태그를 전체 업데이트하여,
ECR에 존재하지 않는 이미지를 참조하는 문제 수정.
CD run #33에서 `.github/` 변경만으로 전체 MSA Pod ImagePullBackOff 발생.

<br/>


## 📋 작업 내용
- `msa-image-build` job에 `built-modules` output 추가
- `update-k8s-image-tag` job의 `needs`를 `msa-image-build`만으로 변경
- job 실행 조건을 `built-modules != ''`로 변경 — 빌드된 모듈 없으면 스킵
- 태그 업데이트 대상을 하드코딩 전체 → `built-modules` output만 사용


<br/>