### PR TITLE
[REFACTOR] 좌석 구역 조회 시 응답 데이터에 잔여석 추가

### DIFF
--- a/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderPaymentConfirmService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderPaymentConfirmService.java
@@ -1,5 +1,6 @@
 package com.goti.ticketing.order.service.application;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -8,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.goti.constants.OrderStatus;
 import com.goti.constants.messages.ErrorCode;
+import com.goti.ticketing.constants.SeatHoldStatus;
 import com.goti.ticketing.domain.entity.order.OrderEntity;
 import com.goti.ticketing.domain.entity.order.OrderItemEntity;
 import com.goti.exception.CustomException;
@@ -15,6 +17,7 @@ import com.goti.global.validation.Preconditions;
 import com.goti.ticketing.order.dto.response.OrderPaymentConfirmResponse;
 import com.goti.ticketing.order.repository.OrderItemRepository;
 import com.goti.ticketing.order.repository.OrderRepository;
+import com.goti.ticketing.seat.repository.SeatHoldRepository;
 import com.goti.ticketing.seat.repository.SeatStatusRepository;
 import com.goti.ticketing.ticket.dto.response.TicketResponse;
 import com.goti.ticketing.ticket.service.application.TicketCreateService;
@@ -28,6 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 public class OrderPaymentConfirmService {
 	private final OrderRepository orderRepository;
 	private final OrderItemRepository orderItemRepository;
+	private final SeatHoldRepository seatHoldRepository;
 	private final SeatStatusRepository seatStatusRepository;
 	private final TicketCreateService ticketCreateService;
 
@@ -58,6 +62,8 @@ public class OrderPaymentConfirmService {
 
 		List<OrderItemEntity> orderItems = orderItemRepository.findOrderItemsByOrderId(orderId);
 		for (OrderItemEntity orderItem : orderItems) {
+			validateActiveHold(order, orderItem);
+
 			seatStatusRepository.findByGameAndSeat(order.getGameSchedule(), orderItem.getSeat())
 				.orElseThrow(() -> new CustomException(ErrorCode.SEAT_STATUS_NOT_FOUND))
 				.sell();
@@ -70,6 +76,23 @@ public class OrderPaymentConfirmService {
 			order.getId(),
 			order.getOrderStatus(),
 			tickets.size()
+		);
+	}
+
+	private void validateActiveHold(OrderEntity order, OrderItemEntity orderItem) {
+		boolean activeHoldExists = seatHoldRepository
+			.findLatestActiveHold(
+				order.getGameSchedule(),
+				orderItem.getSeat(),
+				order.getMemberId(),
+				SeatHoldStatus.HOLDING
+			)
+			.filter(seatHold -> seatHold.getExpiredAt().isAfter(LocalDateTime.now()))
+			.isPresent();
+
+		Preconditions.validate(
+			activeHoldExists,
+			ErrorCode.SEAT_HOLD_EXPIRED
 		);
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderPaymentConfirmService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderPaymentConfirmService.java
@@ -15,6 +15,7 @@ import com.goti.global.validation.Preconditions;
 import com.goti.ticketing.order.dto.response.OrderPaymentConfirmResponse;
 import com.goti.ticketing.order.repository.OrderItemRepository;
 import com.goti.ticketing.order.repository.OrderRepository;
+import com.goti.ticketing.seat.repository.SeatStatusRepository;
 import com.goti.ticketing.ticket.dto.response.TicketResponse;
 import com.goti.ticketing.ticket.service.application.TicketCreateService;
 
@@ -27,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 public class OrderPaymentConfirmService {
 	private final OrderRepository orderRepository;
 	private final OrderItemRepository orderItemRepository;
+	private final SeatStatusRepository seatStatusRepository;
 	private final TicketCreateService ticketCreateService;
 
 	@Transactional
@@ -56,6 +58,9 @@ public class OrderPaymentConfirmService {
 
 		List<OrderItemEntity> orderItems = orderItemRepository.findOrderItemsByOrderId(orderId);
 		for (OrderItemEntity orderItem : orderItems) {
+			seatStatusRepository.findByGameAndSeat(order.getGameSchedule(), orderItem.getSeat())
+				.orElseThrow(() -> new CustomException(ErrorCode.SEAT_STATUS_NOT_FOUND))
+				.sell();
 			orderItem.pay();
 		}
 

--- a/ticketing/src/main/java/com/goti/ticketing/seat/controller/StadiumSeatController.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/controller/StadiumSeatController.java
@@ -56,7 +56,7 @@ public class StadiumSeatController {
 		summary = "좌석 등급 조회",
 		description = "구장별 좌석 등급 조회 API"
 	)
-	@GetMapping("/{stadiumId}/seat-grades")
+	@GetMapping("/stadiums/{stadiumId}/seat-grades")
 	public ResponseEntity<ApiSuccessResponse<List<SeatGradeResponse>>> getSeatGrades(
 		@AuthenticationPrincipal(expression = "id") UUID userId,
 		@PathVariable UUID stadiumId

--- a/ticketing/src/main/java/com/goti/ticketing/seat/controller/StadiumSeatController.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/controller/StadiumSeatController.java
@@ -5,6 +5,8 @@ import static com.goti.global.api.ApiSuccessResponse.*;
 import java.util.List;
 import java.util.UUID;
 
+import com.goti.ticketing.seat.dto.response.SeatSectionRegisterResponse;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,7 +20,7 @@ import com.goti.global.api.ApiSuccessResponse;
 import com.goti.ticketing.seat.dto.request.CreateSeatGradeRequest;
 import com.goti.ticketing.seat.dto.request.CreateSeatSectionRequest;
 import com.goti.ticketing.seat.dto.response.SeatGradeResponse;
-import com.goti.ticketing.seat.dto.response.SeatSectionResponse;
+import com.goti.ticketing.seat.dto.response.SeatSectionSearchResponse;
 import com.goti.ticketing.seat.service.domain.SeatGradeService;
 import com.goti.ticketing.seat.service.domain.SeatSectionService;
 
@@ -69,11 +71,11 @@ public class StadiumSeatController {
 		description = "좌석 등급에 속한 좌석 구역 생성 API"
 	)
 	@PostMapping("/seat-sections")
-	public ResponseEntity<ApiSuccessResponse<SeatSectionResponse>> createSection(
+	public ResponseEntity<ApiSuccessResponse<SeatSectionRegisterResponse>> createSection(
 		@Valid @RequestBody CreateSeatSectionRequest request
 	) {
 		// TODO: 관리자용 API 분리 예정
-		SeatSectionResponse response = seatSectionService.create(
+		SeatSectionRegisterResponse response = seatSectionService.create(
 			request.gradeId(),
 			request.stadiumId(),
 			request.sectionCode(),
@@ -87,7 +89,7 @@ public class StadiumSeatController {
 		description = "구장별 좌석 구역 목록 조회 API"
 	)
 	@GetMapping("/stadiums/{stadiumId}/games/{gameId}/seat-sections")
-	public ResponseEntity<ApiSuccessResponse<List<SeatSectionResponse>>> getSeatSections(
+	public ResponseEntity<ApiSuccessResponse<List<SeatSectionSearchResponse>>> getSeatSections(
 		@AuthenticationPrincipal(expression = "id") UUID userId,
 		@PathVariable UUID stadiumId,
 		@PathVariable UUID gameId

--- a/ticketing/src/main/java/com/goti/ticketing/seat/controller/StadiumSeatController.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/controller/StadiumSeatController.java
@@ -86,11 +86,12 @@ public class StadiumSeatController {
 		summary = "좌석 구역 조회",
 		description = "구장별 좌석 구역 목록 조회 API"
 	)
-	@GetMapping("/{stadiumId}/seat-sections")
+	@GetMapping("/stadiums/{stadiumId}/games/{gameId}/seat-sections")
 	public ResponseEntity<ApiSuccessResponse<List<SeatSectionResponse>>> getSeatSections(
 		@AuthenticationPrincipal(expression = "id") UUID userId,
-		@PathVariable UUID stadiumId
+		@PathVariable UUID stadiumId,
+		@PathVariable UUID gameId
 	) {
-		return wrap(seatSectionService.get(stadiumId, userId));
+		return wrap(seatSectionService.get(stadiumId, userId, gameId));
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/controller/StadiumSeatController.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/controller/StadiumSeatController.java
@@ -5,10 +5,6 @@ import static com.goti.global.api.ApiSuccessResponse.*;
 import java.util.List;
 import java.util.UUID;
 
-import com.goti.ticketing.seat.dto.request.CreateSeatSectionRequest;
-import com.goti.ticketing.seat.dto.response.SeatSectionResponse;
-import com.goti.ticketing.seat.service.domain.SeatSectionService;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,8 +16,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.goti.global.api.ApiSuccessResponse;
 import com.goti.ticketing.seat.dto.request.CreateSeatGradeRequest;
+import com.goti.ticketing.seat.dto.request.CreateSeatSectionRequest;
 import com.goti.ticketing.seat.dto.response.SeatGradeResponse;
+import com.goti.ticketing.seat.dto.response.SeatSectionResponse;
 import com.goti.ticketing.seat.service.domain.SeatGradeService;
+import com.goti.ticketing.seat.service.domain.SeatSectionService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/ticketing/src/main/java/com/goti/ticketing/seat/dto/response/SeatSectionRegisterResponse.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/dto/response/SeatSectionRegisterResponse.java
@@ -6,6 +6,7 @@ import com.goti.ticketing.domain.entity.seat.SeatSectionEntity;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "좌석 구역 등록 응답")
 public record SeatSectionRegisterResponse(
 	@Schema(description = "좌석 구역 ID", example = "33333333-3333-3333-3333-333333333333")
 	UUID sectionId,

--- a/ticketing/src/main/java/com/goti/ticketing/seat/dto/response/SeatSectionRegisterResponse.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/dto/response/SeatSectionRegisterResponse.java
@@ -1,0 +1,36 @@
+package com.goti.ticketing.seat.dto.response;
+
+import java.util.UUID;
+
+import com.goti.ticketing.domain.entity.seat.SeatSectionEntity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record SeatSectionRegisterResponse(
+	@Schema(description = "좌석 구역 ID", example = "33333333-3333-3333-3333-333333333333")
+	UUID sectionId,
+
+	@Schema(description = "좌석 등급 ID", example = "11111111-1111-1111-1111-111111111111")
+	UUID gradeId,
+
+	@Schema(description = "구장 ID", example = "22222222-2222-2222-2222-222222222222")
+	UUID stadiumId,
+
+	@Schema(description = "구역 코드", example = "T3-1")
+	String sectionCode,
+
+	@Schema(description = "수용 인원", example = "120")
+	Integer capacity
+) {
+	public static SeatSectionRegisterResponse from(
+		SeatSectionEntity seatSection
+	) {
+		return new SeatSectionRegisterResponse(
+			seatSection.getId(),
+			seatSection.getSeatGrade().getId(),
+			seatSection.getStadiumId(),
+			seatSection.getSectionCode(),
+			seatSection.getCapacity()
+		);
+	}
+}

--- a/ticketing/src/main/java/com/goti/ticketing/seat/dto/response/SeatSectionResponse.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/dto/response/SeatSectionResponse.java
@@ -25,6 +25,10 @@ public record SeatSectionResponse(
 	@Schema(description = "잔여석 수", example = "87")
 	Integer availableSeatCount
 ) {
+	public static SeatSectionResponse from(SeatSectionEntity seatSection) {
+		return from(seatSection, null);
+	}
+
 	public static SeatSectionResponse from(
 		SeatSectionEntity seatSection,
 		Integer availableSeatCount

--- a/ticketing/src/main/java/com/goti/ticketing/seat/dto/response/SeatSectionResponse.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/dto/response/SeatSectionResponse.java
@@ -20,15 +20,22 @@ public record SeatSectionResponse(
 	String sectionCode,
 
 	@Schema(description = "수용 인원", example = "120")
-	Integer capacity
+	Integer capacity,
+
+	@Schema(description = "잔여석 수", example = "87")
+	Integer availableSeatCount
 ) {
-	public static SeatSectionResponse from(SeatSectionEntity seatSection) {
+	public static SeatSectionResponse from(
+		SeatSectionEntity seatSection,
+		Integer availableSeatCount
+	) {
 		return new SeatSectionResponse(
 			seatSection.getId(),
 			seatSection.getSeatGrade().getId(),
 			seatSection.getStadiumId(),
 			seatSection.getSectionCode(),
-			seatSection.getCapacity()
+			seatSection.getCapacity(),
+			availableSeatCount
 		);
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/dto/response/SeatSectionSearchResponse.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/dto/response/SeatSectionSearchResponse.java
@@ -6,6 +6,7 @@ import com.goti.ticketing.domain.entity.seat.SeatSectionEntity;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "좌석 구역 조회 응답")
 public record SeatSectionSearchResponse(
 	@Schema(description = "좌석 구역 ID", example = "33333333-3333-3333-3333-333333333333")
 	UUID sectionId,

--- a/ticketing/src/main/java/com/goti/ticketing/seat/dto/response/SeatSectionSearchResponse.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/dto/response/SeatSectionSearchResponse.java
@@ -6,7 +6,7 @@ import com.goti.ticketing.domain.entity.seat.SeatSectionEntity;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record SeatSectionResponse(
+public record SeatSectionSearchResponse(
 	@Schema(description = "좌석 구역 ID", example = "33333333-3333-3333-3333-333333333333")
 	UUID sectionId,
 
@@ -25,15 +25,11 @@ public record SeatSectionResponse(
 	@Schema(description = "잔여석 수", example = "87")
 	Integer availableSeatCount
 ) {
-	public static SeatSectionResponse from(SeatSectionEntity seatSection) {
-		return from(seatSection, null);
-	}
-
-	public static SeatSectionResponse from(
+	public static SeatSectionSearchResponse from(
 		SeatSectionEntity seatSection,
 		Integer availableSeatCount
 	) {
-		return new SeatSectionResponse(
+		return new SeatSectionSearchResponse(
 			seatSection.getId(),
 			seatSection.getSeatGrade().getId(),
 			seatSection.getStadiumId(),

--- a/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatHoldRepositoryCustom.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatHoldRepositoryCustom.java
@@ -1,10 +1,21 @@
 package com.goti.ticketing.seat.repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
+import com.goti.ticketing.constants.SeatHoldStatus;
+import com.goti.ticketing.domain.entity.game.GameScheduleEntity;
+import com.goti.ticketing.domain.entity.seat.SeatEntity;
 import com.goti.ticketing.domain.entity.seat.SeatHoldEntity;
 
 public interface SeatHoldRepositoryCustom {
 	List<SeatHoldEntity> findAllWithDetailsByIdIn(List<UUID> holdIds);
+
+	Optional<SeatHoldEntity> findLatestActiveHold(
+		GameScheduleEntity gameSchedule,
+		SeatEntity seat,
+		UUID userId,
+		SeatHoldStatus status
+	);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatHoldRepositoryImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatHoldRepositoryImpl.java
@@ -1,11 +1,15 @@
 package com.goti.ticketing.seat.repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.stereotype.Repository;
 
+import com.goti.ticketing.constants.SeatHoldStatus;
+import com.goti.ticketing.domain.entity.game.GameScheduleEntity;
 import com.goti.ticketing.domain.entity.game.QGameScheduleEntity;
+import com.goti.ticketing.domain.entity.seat.SeatEntity;
 import com.goti.ticketing.domain.entity.seat.QSeatEntity;
 import com.goti.ticketing.domain.entity.seat.QSeatGradeEntity;
 import com.goti.ticketing.domain.entity.seat.QSeatHoldEntity;
@@ -36,5 +40,28 @@ public class SeatHoldRepositoryImpl implements SeatHoldRepositoryCustom {
 			.join(seatSection.seatGrade, seatGrade).fetchJoin()
 			.where(seatHold.id.in(holdIds))
 			.fetch();
+	}
+
+	@Override
+	public Optional<SeatHoldEntity> findLatestActiveHold(
+		GameScheduleEntity gameSchedule,
+		SeatEntity seat,
+		UUID userId,
+		SeatHoldStatus status
+	) {
+		QSeatHoldEntity seatHold = QSeatHoldEntity.seatHoldEntity;
+
+		return Optional.ofNullable(
+			queryFactory
+				.selectFrom(seatHold)
+				.where(
+					seatHold.gameSchedule.eq(gameSchedule),
+					seatHold.seat.eq(seat),
+					seatHold.userId.eq(userId),
+					seatHold.status.eq(status)
+				)
+				.orderBy(seatHold.createdAt.desc())
+				.fetchFirst()
+		);
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatStatusRepository.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatStatusRepository.java
@@ -14,9 +14,15 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.goti.ticketing.domain.entity.seat.SeatStatusEntity;
+import com.goti.ticketing.constants.SeatStatus;
 
 @Repository
 public interface SeatStatusRepository extends JpaRepository<SeatStatusEntity, UUID> {
+
+	interface SectionAvailableSeatCountProjection {
+		UUID getSectionId();
+		Long getAvailableSeatCount();
+	}
 
 	@Query("""
 		SELECT ss
@@ -28,5 +34,20 @@ public interface SeatStatusRepository extends JpaRepository<SeatStatusEntity, UU
 		@Param("gameId") UUID gameId,
 		@Param("sectionId") UUID sectionId
 	);
+
 	Optional<SeatStatusEntity> findByGameAndSeat(GameScheduleEntity game, SeatEntity seat);
+
+	@Query("""
+		SELECT ss.seat.seatSection.id AS sectionId, COUNT(ss) AS availableSeatCount
+		FROM SeatStatusEntity ss
+		WHERE ss.game.id = :gameId
+		  AND ss.seat.seatSection.id IN :sectionIds
+		  AND ss.status = :status
+		GROUP BY ss.seat.seatSection.id
+	""")
+	List<SectionAvailableSeatCountProjection> countByGameIdAndSectionIdsAndStatus(
+		@Param("gameId") UUID gameId,
+		@Param("sectionIds") List<UUID> sectionIds,
+		@Param("status") SeatStatus status
+	);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatStatusRepository.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatStatusRepository.java
@@ -45,7 +45,7 @@ public interface SeatStatusRepository extends JpaRepository<SeatStatusEntity, UU
 		  AND ss.status = :status
 		GROUP BY ss.seat.seatSection.id
 	""")
-	List<SectionAvailableSeatCountProjection> countByGameIdAndSectionIdsAndStatus(
+	List<SectionAvailableSeatCountProjection> countSectionAvailableSeats(
 		@Param("gameId") UUID gameId,
 		@Param("sectionIds") List<UUID> sectionIds,
 		@Param("status") SeatStatus status

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatSectionService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatSectionService.java
@@ -8,5 +8,5 @@ import com.goti.ticketing.seat.dto.response.SeatSectionResponse;
 public interface SeatSectionService {
 	SeatSectionResponse create(UUID gradeId, UUID stadiumId, String sectionCode, Integer capacity);
 
-	List<SeatSectionResponse> get(UUID stadiumId, UUID userId);
+	List<SeatSectionResponse> get(UUID stadiumId, UUID userId, UUID gameId);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatSectionService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatSectionService.java
@@ -3,10 +3,11 @@ package com.goti.ticketing.seat.service.domain;
 import java.util.List;
 import java.util.UUID;
 
-import com.goti.ticketing.seat.dto.response.SeatSectionResponse;
+import com.goti.ticketing.seat.dto.response.SeatSectionRegisterResponse;
+import com.goti.ticketing.seat.dto.response.SeatSectionSearchResponse;
 
 public interface SeatSectionService {
-	SeatSectionResponse create(UUID gradeId, UUID stadiumId, String sectionCode, Integer capacity);
+	SeatSectionRegisterResponse create(UUID gradeId, UUID stadiumId, String sectionCode, Integer capacity);
 
-	List<SeatSectionResponse> get(UUID stadiumId, UUID userId, UUID gameId);
+	List<SeatSectionSearchResponse> get(UUID stadiumId, UUID userId, UUID gameId);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatSectionServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatSectionServiceImpl.java
@@ -1,12 +1,15 @@
 package com.goti.ticketing.seat.service.domain;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.goti.constants.messages.ErrorCode;
+import com.goti.ticketing.constants.SeatStatus;
 import com.goti.ticketing.domain.entity.seat.SeatGradeEntity;
 import com.goti.ticketing.domain.entity.seat.SeatSectionEntity;
 import com.goti.exception.CustomException;
@@ -14,6 +17,7 @@ import com.goti.global.validation.Preconditions;
 import com.goti.ticketing.seat.dto.response.SeatSectionResponse;
 import com.goti.ticketing.seat.repository.SeatGradeRepository;
 import com.goti.ticketing.seat.repository.SeatSectionRepository;
+import com.goti.ticketing.seat.repository.SeatStatusRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -22,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 public class SeatSectionServiceImpl implements SeatSectionService {
 	private final SeatGradeRepository seatGradeRepository;
 	private final SeatSectionRepository seatSectionRepository;
+	private final SeatStatusRepository seatStatusRepository;
 
 	@Override
 	@Transactional
@@ -52,14 +57,31 @@ public class SeatSectionServiceImpl implements SeatSectionService {
 
 	@Override
 	@Transactional(readOnly = true)
-	public List<SeatSectionResponse> get(UUID stadiumId, UUID userId) {
+	public List<SeatSectionResponse> get(UUID stadiumId, UUID userId, UUID gameId) {
 		Preconditions.validate(
 			userId != null,
 			ErrorCode.AUTH_INVALID
 		);
 
-		return seatSectionRepository.findAllByStadiumId(stadiumId).stream()
-			.map(SeatSectionResponse::from)
+		List<SeatSectionEntity> seatSections = seatSectionRepository.findAllByStadiumId(stadiumId);
+
+		List<UUID> sectionIds = seatSections.stream()
+			.map(SeatSectionEntity::getId)
+			.toList();
+
+		Map<UUID, Integer> availableSeatCounts = seatStatusRepository
+			.countByGameIdAndSectionIdsAndStatus(gameId, sectionIds, SeatStatus.AVAILABLE)
+			.stream()
+			.collect(Collectors.toMap(
+				SeatStatusRepository.SectionAvailableSeatCountProjection::getSectionId,
+				count -> Math.toIntExact(count.getAvailableSeatCount())
+			));
+
+		return seatSections.stream()
+			.map(section -> SeatSectionResponse.from(
+				section,
+				availableSeatCounts.getOrDefault(section.getId(), 0)
+			))
 			.toList();
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatSectionServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatSectionServiceImpl.java
@@ -72,7 +72,7 @@ public class SeatSectionServiceImpl implements SeatSectionService {
 			.toList();
 
 		Map<UUID, Integer> availableSeatCounts = seatStatusRepository
-			.countByGameIdAndSectionIdsAndStatus(gameId, sectionIds, SeatStatus.AVAILABLE)
+			.countSectionAvailableSeats(gameId, sectionIds, SeatStatus.AVAILABLE)
 			.stream()
 			.collect(Collectors.toMap(
 				SeatStatusRepository.SectionAvailableSeatCountProjection::getSectionId,

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatSectionServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatSectionServiceImpl.java
@@ -5,6 +5,8 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import com.goti.ticketing.seat.dto.response.SeatSectionRegisterResponse;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,7 +16,7 @@ import com.goti.ticketing.domain.entity.seat.SeatGradeEntity;
 import com.goti.ticketing.domain.entity.seat.SeatSectionEntity;
 import com.goti.exception.CustomException;
 import com.goti.global.validation.Preconditions;
-import com.goti.ticketing.seat.dto.response.SeatSectionResponse;
+import com.goti.ticketing.seat.dto.response.SeatSectionSearchResponse;
 import com.goti.ticketing.seat.repository.SeatGradeRepository;
 import com.goti.ticketing.seat.repository.SeatSectionRepository;
 import com.goti.ticketing.seat.repository.SeatStatusRepository;
@@ -30,7 +32,7 @@ public class SeatSectionServiceImpl implements SeatSectionService {
 
 	@Override
 	@Transactional
-	public SeatSectionResponse create(
+	public SeatSectionRegisterResponse create(
 		UUID gradeId,
 		UUID stadiumId,
 		String sectionCode,
@@ -52,12 +54,12 @@ public class SeatSectionServiceImpl implements SeatSectionService {
 		SeatSectionEntity seatSection = SeatSectionEntity.create(seatGrade, stadiumId, sectionCode, capacity);
 		seatSectionRepository.save(seatSection);
 
-		return SeatSectionResponse.from(seatSection);
+		return SeatSectionRegisterResponse.from(seatSection);
 	}
 
 	@Override
 	@Transactional(readOnly = true)
-	public List<SeatSectionResponse> get(UUID stadiumId, UUID userId, UUID gameId) {
+	public List<SeatSectionSearchResponse> get(UUID stadiumId, UUID userId, UUID gameId) {
 		Preconditions.validate(
 			userId != null,
 			ErrorCode.AUTH_INVALID
@@ -78,7 +80,7 @@ public class SeatSectionServiceImpl implements SeatSectionService {
 			));
 
 		return seatSections.stream()
-			.map(section -> SeatSectionResponse.from(
+			.map(section -> SeatSectionSearchResponse.from(
 				section,
 				availableSeatCounts.getOrDefault(section.getId(), 0)
 			))


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#230 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
좌석 구역 조회 시  잔여석도 같이 조회되도록 추가
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
> 결제 완료 시 좌석 상태 SOLD로 변경

> `SeatSectionResponse`에 availableSeatCount 추가
> `SeatSectionServiceImpl` 잔여석 조회 서비스 로직 추가
> 리스트 응답을 N번 조회하지 않고 한 번에 묶어서 가져오기 위해 `SeatStatusRepository`에 SectionAvailableSeatCountProjection 추가
> `StadiumSeatController` 잔여석 조회를 위한 gameId API 경로에 추가

<br/>