### PR TITLE
[FEAT] 미결제 주문 만료 처리 기반 로직 추가

### DIFF
--- a/ticketing/src/main/java/com/goti/ticketing/domain/entity/order/OrderEntity.java
+++ b/ticketing/src/main/java/com/goti/ticketing/domain/entity/order/OrderEntity.java
@@ -103,6 +103,15 @@ public class OrderEntity extends ModificationTimestampEntity {
 		this.confirmedAt = LocalDateTime.now();
 	}
 
+	public void expire() {
+		Preconditions.domainValidate(
+			this.orderStatus == OrderStatus.PENDING,
+			"PENDING 상태에서만 주문 만료 처리가 가능합니다."
+		);
+		this.orderStatus = OrderStatus.CANCELED;
+		this.canceledAt = LocalDateTime.now();
+	}
+
 	private static void validate(
 		String orderNumber,
 		UUID userId,

--- a/ticketing/src/main/java/com/goti/ticketing/domain/entity/order/OrderItemEntity.java
+++ b/ticketing/src/main/java/com/goti/ticketing/domain/entity/order/OrderItemEntity.java
@@ -86,6 +86,14 @@ public class OrderItemEntity extends ModificationTimestampEntity {
 		this.itemStatus = OrderItemStatus.PAID;
 	}
 
+	public void expire() {
+		Preconditions.domainValidate(
+			this.itemStatus == OrderItemStatus.RESERVED,
+			"RESERVED 상태에서만 주문 상세 만료 처리가 가능합니다."
+		);
+		this.itemStatus = OrderItemStatus.CANCELED;
+	}
+
 	private static void validate(
 		TicketType ticketType,
 		Integer ticketPrice

--- a/ticketing/src/main/java/com/goti/ticketing/domain/entity/order/OrderItemEntity.java
+++ b/ticketing/src/main/java/com/goti/ticketing/domain/entity/order/OrderItemEntity.java
@@ -2,12 +2,13 @@ package com.goti.ticketing.domain.entity.order;
 
 import static lombok.AccessLevel.*;
 
+import java.util.UUID;
+
+import com.goti.domain.base.ModificationTimestampEntity;
+import com.goti.global.validation.Preconditions;
 import com.goti.ticketing.constants.OrderItemStatus;
 import com.goti.ticketing.constants.TicketType;
-import com.goti.domain.base.CreationTimestampEntity;
-import com.goti.domain.base.ModificationTimestampEntity;
 import com.goti.ticketing.domain.entity.seat.SeatEntity;
-import com.goti.global.validation.Preconditions;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -51,6 +52,9 @@ public class OrderItemEntity extends ModificationTimestampEntity {
 	@Column(nullable = false)
 	private Integer ticketPrice;
 
+	@Column(nullable = false)
+	private UUID holdId;
+
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
 	private OrderItemStatus itemStatus;
@@ -58,11 +62,13 @@ public class OrderItemEntity extends ModificationTimestampEntity {
 	private OrderItemEntity(
 		OrderEntity order,
 		SeatEntity seat,
+		UUID holdId,
 		TicketType ticketType,
 		Integer ticketPrice
 	) {
 		this.order = order;
 		this.seat = seat;
+		this.holdId = holdId;
 		this.ticketType = ticketType;
 		this.ticketPrice = ticketPrice;
 		this.itemStatus = OrderItemStatus.RESERVED;
@@ -71,11 +77,12 @@ public class OrderItemEntity extends ModificationTimestampEntity {
 	public static OrderItemEntity create(
 		OrderEntity order,
 		SeatEntity seat,
+		UUID holdId,
 		TicketType ticketType,
 		Integer ticketPrice
 	) {
-		validate(ticketType, ticketPrice);
-		return new OrderItemEntity(order, seat, ticketType, ticketPrice);
+		validate(holdId, ticketType, ticketPrice);
+		return new OrderItemEntity(order, seat, holdId, ticketType, ticketPrice);
 	}
 
 	public void pay() {
@@ -95,9 +102,14 @@ public class OrderItemEntity extends ModificationTimestampEntity {
 	}
 
 	private static void validate(
+		UUID holdId,
 		TicketType ticketType,
 		Integer ticketPrice
 	) {
+		Preconditions.domainValidate(
+			holdId != null,
+			"좌석 점유 ID는 필수입니다."
+		);
 		Preconditions.domainValidate(
 			ticketType != null,
 			"권종은 필수입니다."

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderCreateService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderCreateService.java
@@ -154,6 +154,7 @@ public class OrderCreateService {
 			orderItemService.create(
 				order,
 				pricedHold.hold().getSeat(),
+				pricedHold.hold().getId(),
 				TicketType.ADULT,
 				pricedHold.ticketPrice()
 			);

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderExpiryService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderExpiryService.java
@@ -8,9 +8,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.goti.constants.messages.ErrorCode;
 import com.goti.exception.CustomException;
-import com.goti.ticketing.constants.SeatHoldStatus;
 import com.goti.ticketing.domain.entity.order.OrderEntity;
 import com.goti.ticketing.domain.entity.order.OrderItemEntity;
+import com.goti.ticketing.domain.entity.seat.SeatHoldEntity;
 import com.goti.ticketing.order.repository.OrderItemRepository;
 import com.goti.ticketing.order.repository.OrderRepository;
 import com.goti.ticketing.seat.repository.SeatHoldRepository;
@@ -35,17 +35,13 @@ public class OrderExpiryService {
 
 		List<OrderItemEntity> orderItems = orderItemRepository.findOrderItemsByOrderId(orderId);
 		for (OrderItemEntity orderItem : orderItems) {
-			seatHoldRepository.findLatestActiveHold(
-				order.getGameSchedule(),
-				orderItem.getSeat(),
-				order.getMemberId(),
-				SeatHoldStatus.HOLDING
-			).ifPresent(seatHold -> {
-				seatStatusRepository.findByGameAndSeat(order.getGameSchedule(), orderItem.getSeat())
-					.orElseThrow(() -> new CustomException(ErrorCode.SEAT_STATUS_NOT_FOUND))
-					.release();
-				seatHold.release();
-			});
+			SeatHoldEntity seatHold = seatHoldRepository.findById(orderItem.getHoldId())
+				.orElseThrow(() -> new CustomException(ErrorCode.SEAT_HOLD_NOT_FOUND));
+
+			seatStatusRepository.findByGameAndSeat(order.getGameSchedule(), orderItem.getSeat())
+				.orElseThrow(() -> new CustomException(ErrorCode.SEAT_STATUS_NOT_FOUND))
+				.release();
+			seatHold.release();
 
 			orderItem.expire();
 		}

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderExpiryService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderExpiryService.java
@@ -1,44 +1,40 @@
 package com.goti.ticketing.order.service.application;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
-
-import com.goti.global.validation.Preconditions;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.goti.constants.messages.ErrorCode;
-import com.goti.exception.CustomException;
+import com.goti.global.validation.Preconditions;
 import com.goti.ticketing.domain.entity.order.OrderEntity;
 import com.goti.ticketing.domain.entity.order.OrderItemEntity;
 import com.goti.ticketing.domain.entity.seat.SeatHoldEntity;
 import com.goti.ticketing.domain.entity.seat.SeatStatusEntity;
-import com.goti.ticketing.order.repository.OrderItemRepository;
-import com.goti.ticketing.order.repository.OrderRepository;
-import com.goti.ticketing.seat.repository.SeatHoldRepository;
-import com.goti.ticketing.seat.repository.SeatStatusRepository;
+import com.goti.ticketing.order.service.domain.OrderItemService;
+import com.goti.ticketing.order.service.domain.OrderService;
+import com.goti.ticketing.seat.service.domain.SeatHoldExpiryService;
+import com.goti.ticketing.seat.service.domain.SeatStatusService;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class OrderExpiryService {
-	private final OrderRepository orderRepository;
-	private final OrderItemRepository orderItemRepository;
-	private final SeatHoldRepository seatHoldRepository;
-	private final SeatStatusRepository seatStatusRepository;
+	private final OrderService orderService;
+	private final OrderItemService orderItemService;
+	private final SeatHoldExpiryService seatHoldExpiryService;
+	private final SeatStatusService seatStatusService;
 
 	@Transactional
 	public void expire(UUID orderId) {
-		OrderEntity order = orderRepository.findById(orderId)
-			.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+		OrderEntity order = orderService.get(orderId);
+		orderService.expire(order);
 
-		order.expire();
-
-		List<OrderItemEntity> orderItems = orderItemRepository.findOrderItemsByOrderId(orderId);
+		List<OrderItemEntity> orderItems = orderItemService.get(orderId);
 		List<UUID> holdIds = orderItems.stream()
 			.map(OrderItemEntity::getHoldId)
 			.toList();
@@ -46,13 +42,11 @@ public class OrderExpiryService {
 			.map(orderItem -> orderItem.getSeat().getId())
 			.toList();
 
-		Map<UUID, SeatHoldEntity> seatHoldMap = seatHoldRepository.findAllWithDetailsByIdIn(holdIds).stream()
-			.collect(Collectors.toMap(SeatHoldEntity::getId, seatHold -> seatHold));
-
-		Map<UUID, SeatStatusEntity> seatStatusMap = seatStatusRepository
-			.findAllByGameIdAndSeatIds(order.getGameSchedule().getId(), seatIds)
-			.stream()
-			.collect(Collectors.toMap(seatStatus -> seatStatus.getSeat().getId(), seatStatus -> seatStatus));
+		Map<UUID, SeatHoldEntity> seatHoldMap = seatHoldExpiryService.getByIds(holdIds);
+		Map<UUID, SeatStatusEntity> seatStatusMap = seatStatusService.getByGameIdAndSeatIds(
+			order.getGameSchedule().getId(),
+			seatIds
+		);
 
 		for (OrderItemEntity orderItem : orderItems) {
 			SeatHoldEntity seatHold = seatHoldMap.get(orderItem.getHoldId());
@@ -67,10 +61,8 @@ public class OrderExpiryService {
 				ErrorCode.SEAT_STATUS_NOT_FOUND
 			);
 
-			seatStatus.release();
-			seatHold.release();
-
-			orderItem.expire();
+			seatHoldExpiryService.expire(seatStatus, seatHold, LocalDateTime.now());
+			orderItemService.expire(orderItem);
 		}
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderExpiryService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderExpiryService.java
@@ -1,0 +1,36 @@
+package com.goti.ticketing.order.service.application;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goti.constants.messages.ErrorCode;
+import com.goti.exception.CustomException;
+import com.goti.ticketing.domain.entity.order.OrderEntity;
+import com.goti.ticketing.domain.entity.order.OrderItemEntity;
+import com.goti.ticketing.order.repository.OrderItemRepository;
+import com.goti.ticketing.order.repository.OrderRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class OrderExpiryService {
+	private final OrderRepository orderRepository;
+	private final OrderItemRepository orderItemRepository;
+
+	@Transactional
+	public void expire(UUID orderId) {
+		OrderEntity order = orderRepository.findById(orderId)
+			.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+
+		order.expire();
+
+		List<OrderItemEntity> orderItems = orderItemRepository.findOrderItemsByOrderId(orderId);
+		for (OrderItemEntity orderItem : orderItems) {
+			orderItem.expire();
+		}
+	}
+}

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderExpiryService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderExpiryService.java
@@ -1,7 +1,11 @@
 package com.goti.ticketing.order.service.application;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
+
+import com.goti.global.validation.Preconditions;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,6 +15,7 @@ import com.goti.exception.CustomException;
 import com.goti.ticketing.domain.entity.order.OrderEntity;
 import com.goti.ticketing.domain.entity.order.OrderItemEntity;
 import com.goti.ticketing.domain.entity.seat.SeatHoldEntity;
+import com.goti.ticketing.domain.entity.seat.SeatStatusEntity;
 import com.goti.ticketing.order.repository.OrderItemRepository;
 import com.goti.ticketing.order.repository.OrderRepository;
 import com.goti.ticketing.seat.repository.SeatHoldRepository;
@@ -34,13 +39,35 @@ public class OrderExpiryService {
 		order.expire();
 
 		List<OrderItemEntity> orderItems = orderItemRepository.findOrderItemsByOrderId(orderId);
-		for (OrderItemEntity orderItem : orderItems) {
-			SeatHoldEntity seatHold = seatHoldRepository.findById(orderItem.getHoldId())
-				.orElseThrow(() -> new CustomException(ErrorCode.SEAT_HOLD_NOT_FOUND));
+		List<UUID> holdIds = orderItems.stream()
+			.map(OrderItemEntity::getHoldId)
+			.toList();
+		List<UUID> seatIds = orderItems.stream()
+			.map(orderItem -> orderItem.getSeat().getId())
+			.toList();
 
-			seatStatusRepository.findByGameAndSeat(order.getGameSchedule(), orderItem.getSeat())
-				.orElseThrow(() -> new CustomException(ErrorCode.SEAT_STATUS_NOT_FOUND))
-				.release();
+		Map<UUID, SeatHoldEntity> seatHoldMap = seatHoldRepository.findAllWithDetailsByIdIn(holdIds).stream()
+			.collect(Collectors.toMap(SeatHoldEntity::getId, seatHold -> seatHold));
+
+		Map<UUID, SeatStatusEntity> seatStatusMap = seatStatusRepository
+			.findAllByGameIdAndSeatIds(order.getGameSchedule().getId(), seatIds)
+			.stream()
+			.collect(Collectors.toMap(seatStatus -> seatStatus.getSeat().getId(), seatStatus -> seatStatus));
+
+		for (OrderItemEntity orderItem : orderItems) {
+			SeatHoldEntity seatHold = seatHoldMap.get(orderItem.getHoldId());
+			Preconditions.validate(
+				seatHold != null,
+				ErrorCode.SEAT_HOLD_NOT_FOUND
+			);
+
+			SeatStatusEntity seatStatus = seatStatusMap.get(orderItem.getSeat().getId());
+			Preconditions.validate(
+				seatStatus != null,
+				ErrorCode.SEAT_STATUS_NOT_FOUND
+			);
+
+			seatStatus.release();
 			seatHold.release();
 
 			orderItem.expire();

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderExpiryService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderExpiryService.java
@@ -8,10 +8,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.goti.constants.messages.ErrorCode;
 import com.goti.exception.CustomException;
+import com.goti.ticketing.constants.SeatHoldStatus;
 import com.goti.ticketing.domain.entity.order.OrderEntity;
 import com.goti.ticketing.domain.entity.order.OrderItemEntity;
 import com.goti.ticketing.order.repository.OrderItemRepository;
 import com.goti.ticketing.order.repository.OrderRepository;
+import com.goti.ticketing.seat.repository.SeatHoldRepository;
+import com.goti.ticketing.seat.repository.SeatStatusRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -20,6 +23,8 @@ import lombok.RequiredArgsConstructor;
 public class OrderExpiryService {
 	private final OrderRepository orderRepository;
 	private final OrderItemRepository orderItemRepository;
+	private final SeatHoldRepository seatHoldRepository;
+	private final SeatStatusRepository seatStatusRepository;
 
 	@Transactional
 	public void expire(UUID orderId) {
@@ -30,6 +35,18 @@ public class OrderExpiryService {
 
 		List<OrderItemEntity> orderItems = orderItemRepository.findOrderItemsByOrderId(orderId);
 		for (OrderItemEntity orderItem : orderItems) {
+			seatHoldRepository.findLatestActiveHold(
+				order.getGameSchedule(),
+				orderItem.getSeat(),
+				order.getMemberId(),
+				SeatHoldStatus.HOLDING
+			).ifPresent(seatHold -> {
+				seatStatusRepository.findByGameAndSeat(order.getGameSchedule(), orderItem.getSeat())
+					.orElseThrow(() -> new CustomException(ErrorCode.SEAT_STATUS_NOT_FOUND))
+					.release();
+				seatHold.release();
+			});
+
 			orderItem.expire();
 		}
 	}

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/domain/OrderItemService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/domain/OrderItemService.java
@@ -1,5 +1,7 @@
 package com.goti.ticketing.order.service.domain;
 
+import java.util.UUID;
+
 import com.goti.ticketing.constants.TicketType;
 import com.goti.ticketing.domain.entity.order.OrderEntity;
 import com.goti.ticketing.domain.entity.order.OrderItemEntity;
@@ -9,6 +11,7 @@ public interface OrderItemService {
 	OrderItemEntity create(
 		OrderEntity order,
 		SeatEntity seat,
+		UUID holdId,
 		TicketType ticketType,
 		Integer ticketPrice
 	);

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/domain/OrderItemService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/domain/OrderItemService.java
@@ -1,5 +1,6 @@
 package com.goti.ticketing.order.service.domain;
 
+import java.util.List;
 import java.util.UUID;
 
 import com.goti.ticketing.constants.TicketType;
@@ -15,4 +16,8 @@ public interface OrderItemService {
 		TicketType ticketType,
 		Integer ticketPrice
 	);
+
+	List<OrderItemEntity> get(UUID orderId);
+
+	void expire(OrderItemEntity orderItem);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/domain/OrderItemServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/domain/OrderItemServiceImpl.java
@@ -1,5 +1,7 @@
 package com.goti.ticketing.order.service.domain;
 
+import java.util.UUID;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,10 +23,11 @@ public class OrderItemServiceImpl implements OrderItemService {
 	public OrderItemEntity create(
 		OrderEntity order,
 		SeatEntity seat,
+		UUID holdId,
 		TicketType ticketType,
 		Integer ticketPrice
 	) {
-		OrderItemEntity orderItem = OrderItemEntity.create(order, seat, ticketType, ticketPrice);
+		OrderItemEntity orderItem = OrderItemEntity.create(order, seat, holdId, ticketType, ticketPrice);
 		return orderItemRepository.save(orderItem);
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/domain/OrderItemServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/domain/OrderItemServiceImpl.java
@@ -1,5 +1,6 @@
 package com.goti.ticketing.order.service.domain;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
@@ -29,5 +30,16 @@ public class OrderItemServiceImpl implements OrderItemService {
 	) {
 		OrderItemEntity orderItem = OrderItemEntity.create(order, seat, holdId, ticketType, ticketPrice);
 		return orderItemRepository.save(orderItem);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<OrderItemEntity> get(UUID orderId) {
+		return orderItemRepository.findOrderItemsByOrderId(orderId);
+	}
+
+	@Override
+	public void expire(OrderItemEntity orderItem) {
+		orderItem.expire();
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/domain/OrderService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/domain/OrderService.java
@@ -15,5 +15,9 @@ public interface OrderService {
 		Integer totalAmount
 	);
 
+	OrderEntity get(UUID orderId);
+
+	void expire(OrderEntity order);
+
 	List<OrderListResponse> getMyOrders(UUID memberId);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/domain/OrderServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/domain/OrderServiceImpl.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.UUID;
 
 import com.goti.constants.messages.ErrorCode;
+import com.goti.exception.CustomException;
 import com.goti.global.validation.Preconditions;
 import com.goti.ticketing.order.dto.response.OrderListResponse;
 
@@ -43,6 +44,18 @@ public class OrderServiceImpl implements OrderService {
 		);
 
 		return orderRepository.save(order);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public OrderEntity get(UUID orderId) {
+		return orderRepository.findById(orderId)
+			.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+	}
+
+	@Override
+	public void expire(OrderEntity order) {
+		order.expire();
 	}
 
 	@Override

--- a/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatStatusRepository.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatStatusRepository.java
@@ -31,6 +31,18 @@ public interface SeatStatusRepository extends JpaRepository<SeatStatusEntity, UU
 		@Param("sectionId") UUID sectionId
 	);
 
+	@Query("""
+		SELECT ss
+			FROM SeatStatusEntity ss
+		JOIN FETCH ss.seat seat
+		WHERE ss.game.id = :gameId
+		  AND seat.id IN :seatIds
+	""")
+	List<SeatStatusEntity> findAllByGameIdAndSeatIds(
+		@Param("gameId") UUID gameId,
+		@Param("seatIds") List<UUID> seatIds
+	);
+
 	Optional<SeatStatusEntity> findByGameAndSeat(GameScheduleEntity game, SeatEntity seat);
 
 	@Query("""
@@ -38,7 +50,7 @@ public interface SeatStatusRepository extends JpaRepository<SeatStatusEntity, UU
 			ss.seat.seatSection.seatGrade.id,
 			COUNT(ss)
 		)
-		FROM SeatStatusEntity ss
+			FROM SeatStatusEntity ss
 		WHERE ss.game.id = :gameId
 		  AND ss.seat.seatSection.seatGrade.id IN :seatGradeIds
 		  AND ss.status = :status

--- a/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatStatusRepository.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatStatusRepository.java
@@ -18,7 +18,7 @@ import com.goti.ticketing.constants.SeatStatus;
 import com.goti.ticketing.seat.repository.dto.SeatGradeAvailableSeatCount;
 
 @Repository
-public interface SeatStatusRepository extends JpaRepository<SeatStatusEntity, UUID> {
+public interface SeatStatusRepository extends JpaRepository<SeatStatusEntity, UUID>, SeatStatusRepositoryCustom {
 
 	@Query("""
 		SELECT ss
@@ -29,18 +29,6 @@ public interface SeatStatusRepository extends JpaRepository<SeatStatusEntity, UU
 	List<SeatStatusEntity> findSeatStatuses(
 		@Param("gameId") UUID gameId,
 		@Param("sectionId") UUID sectionId
-	);
-
-	@Query("""
-		SELECT ss
-			FROM SeatStatusEntity ss
-		JOIN FETCH ss.seat seat
-		WHERE ss.game.id = :gameId
-		  AND seat.id IN :seatIds
-	""")
-	List<SeatStatusEntity> findAllByGameIdAndSeatIds(
-		@Param("gameId") UUID gameId,
-		@Param("seatIds") List<UUID> seatIds
 	);
 
 	Optional<SeatStatusEntity> findByGameAndSeat(GameScheduleEntity game, SeatEntity seat);

--- a/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatStatusRepositoryCustom.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatStatusRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.goti.ticketing.seat.repository;
+
+import java.util.List;
+import java.util.UUID;
+
+import com.goti.ticketing.domain.entity.seat.SeatStatusEntity;
+
+public interface SeatStatusRepositoryCustom {
+	List<SeatStatusEntity> findAllByGameAndSeatIds(UUID gameId, List<UUID> seatIds);
+}

--- a/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatStatusRepositoryImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatStatusRepositoryImpl.java
@@ -1,0 +1,34 @@
+package com.goti.ticketing.seat.repository;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Repository;
+
+import com.goti.ticketing.domain.entity.seat.QSeatEntity;
+import com.goti.ticketing.domain.entity.seat.QSeatStatusEntity;
+import com.goti.ticketing.domain.entity.seat.SeatStatusEntity;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class SeatStatusRepositoryImpl implements SeatStatusRepositoryCustom {
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<SeatStatusEntity> findAllByGameAndSeatIds(UUID gameId, List<UUID> seatIds) {
+		QSeatStatusEntity seatStatus = QSeatStatusEntity.seatStatusEntity;
+		QSeatEntity seat = QSeatEntity.seatEntity;
+
+		return queryFactory
+			.selectFrom(seatStatus)
+			.join(seatStatus.seat, seat).fetchJoin()
+			.where(
+				seatStatus.game.id.eq(gameId),
+				seat.id.in(seatIds)
+			)
+			.fetch();
+	}
+}

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatHoldExpiryService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatHoldExpiryService.java
@@ -4,8 +4,13 @@ import com.goti.ticketing.domain.entity.seat.SeatHoldEntity;
 import com.goti.ticketing.domain.entity.seat.SeatStatusEntity;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 public interface SeatHoldExpiryService {
+	Map<UUID, SeatHoldEntity> getByIds(List<UUID> holdIds);
+
 	void expire(
 		SeatStatusEntity seatStatus,
 		SeatHoldEntity seatHold,

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatHoldExpiryServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatHoldExpiryServiceImpl.java
@@ -3,12 +3,27 @@ package com.goti.ticketing.seat.service.domain;
 import com.goti.ticketing.domain.entity.seat.SeatHoldEntity;
 import com.goti.ticketing.domain.entity.seat.SeatStatusEntity;
 import com.goti.global.validation.Preconditions;
+import com.goti.ticketing.seat.repository.SeatHoldRepository;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
+@RequiredArgsConstructor
 public class SeatHoldExpiryServiceImpl implements SeatHoldExpiryService {
+	private final SeatHoldRepository seatHoldRepository;
+
+	@Override
+	public Map<UUID, SeatHoldEntity> getByIds(List<UUID> holdIds) {
+		return seatHoldRepository.findAllWithDetailsByIdIn(holdIds).stream()
+			.collect(Collectors.toMap(SeatHoldEntity::getId, seatHold -> seatHold));
+	}
 
 	@Override
 	public void expire(

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatStatusService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatStatusService.java
@@ -1,10 +1,16 @@
 package com.goti.ticketing.seat.service.domain;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
+import com.goti.ticketing.domain.entity.seat.SeatStatusEntity;
 import com.goti.ticketing.seat.dto.response.GameSeatStatusResponse;
 
 public interface SeatStatusService {
 	List<GameSeatStatusResponse> get(UUID gameId, UUID sectionId, UUID userId);
+
+	Map<UUID, SeatStatusEntity> getByGameIdAndSeatIds(UUID gameId, List<UUID> seatIds);
+
+	void release(SeatStatusEntity seatStatus);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatStatusServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatStatusServiceImpl.java
@@ -1,13 +1,16 @@
 package com.goti.ticketing.seat.service.domain;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.goti.constants.messages.ErrorCode;
 import com.goti.global.validation.Preconditions;
+import com.goti.ticketing.domain.entity.seat.SeatStatusEntity;
 import com.goti.ticketing.seat.dto.response.GameSeatStatusResponse;
 import com.goti.ticketing.seat.repository.SeatStatusRepository;
 
@@ -33,5 +36,22 @@ public class SeatStatusServiceImpl implements SeatStatusService {
 		return seatStatusRepository.findSeatStatuses(gameId, sectionId).stream()
 			.map(GameSeatStatusResponse::from)
 			.toList();
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Map<UUID, SeatStatusEntity> getByGameIdAndSeatIds(UUID gameId, List<UUID> seatIds) {
+		return seatStatusRepository.findAllByGameIdAndSeatIds(gameId, seatIds)
+			.stream()
+			.collect(Collectors.toMap(seatStatus -> seatStatus.getSeat().getId(), seatStatus -> seatStatus));
+	}
+
+	@Override
+	public void release(SeatStatusEntity seatStatus) {
+		Preconditions.domainValidate(
+			seatStatus != null,
+			"좌석 상태는 필수입니다."
+		);
+		seatStatus.release();
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatStatusServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatStatusServiceImpl.java
@@ -41,7 +41,7 @@ public class SeatStatusServiceImpl implements SeatStatusService {
 	@Override
 	@Transactional(readOnly = true)
 	public Map<UUID, SeatStatusEntity> getByGameIdAndSeatIds(UUID gameId, List<UUID> seatIds) {
-		return seatStatusRepository.findAllByGameIdAndSeatIds(gameId, seatIds)
+		return seatStatusRepository.findAllByGameAndSeatIds(gameId, seatIds)
 			.stream()
 			.collect(Collectors.toMap(seatStatus -> seatStatus.getSeat().getId(), seatStatus -> seatStatus));
 	}

--- a/ticketing/src/test/java/order/OrderCancellationItemEntityTest.java
+++ b/ticketing/src/test/java/order/OrderCancellationItemEntityTest.java
@@ -2,9 +2,11 @@ package order;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+import com.goti.domain.base.BaseUuidEntity;
 import com.goti.ticketing.constants.LeagueType;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -19,6 +21,7 @@ import com.goti.ticketing.domain.entity.order.OrderEntity;
 import com.goti.ticketing.domain.entity.order.OrderItemEntity;
 import com.goti.ticketing.domain.entity.seat.SeatEntity;
 import com.goti.ticketing.domain.entity.seat.SeatGradeEntity;
+import com.goti.ticketing.domain.entity.seat.SeatHoldEntity;
 import com.goti.ticketing.domain.entity.seat.SeatSectionEntity;
 import com.goti.exception.FieldValidationException;
 
@@ -53,7 +56,21 @@ class OrderCancellationItemEntityTest {
 		SeatGradeEntity seatGrade = SeatGradeEntity.create(UUID.randomUUID(), "VIP", "#FFAA00");
 		SeatSectionEntity seatSection = SeatSectionEntity.create(seatGrade, UUID.randomUUID(), "101", 120);
 		SeatEntity seat = SeatEntity.create(seatSection, "A", 1);
-		item = OrderItemEntity.create(order, seat, UUID.randomUUID(), com.goti.ticketing.constants.TicketType.ADULT, 12000);
+		SeatHoldEntity seatHold = SeatHoldEntity.create(
+			seat,
+			gameSchedule,
+			order.getMemberId(),
+			"queue-token-jti",
+			LocalDateTime.now().plusMinutes(10)
+		);
+		assignId(seatHold, UUID.randomUUID());
+		item = OrderItemEntity.create(
+			order,
+			seat,
+			seatHold.getId(),
+			com.goti.ticketing.constants.TicketType.ADULT,
+			12000
+		);
 	}
 
 	@Test
@@ -86,5 +103,15 @@ class OrderCancellationItemEntityTest {
 			() -> OrderCancellationItemEntity.create(cancellation, item, 11000, -1)
 		).isInstanceOf(FieldValidationException.class)
 			.hasMessageContaining("수수료는 0 이상이어야 합니다.");
+	}
+
+	private void assignId(SeatHoldEntity seatHold, UUID holdId) {
+		try {
+			Field idField = BaseUuidEntity.class.getDeclaredField("id");
+			idField.setAccessible(true);
+			idField.set(seatHold, holdId);
+		} catch (ReflectiveOperationException e) {
+			throw new IllegalStateException("테스트용 SeatHold ID 설정에 실패했습니다.", e);
+		}
 	}
 }

--- a/ticketing/src/test/java/order/OrderCancellationItemEntityTest.java
+++ b/ticketing/src/test/java/order/OrderCancellationItemEntityTest.java
@@ -53,7 +53,7 @@ class OrderCancellationItemEntityTest {
 		SeatGradeEntity seatGrade = SeatGradeEntity.create(UUID.randomUUID(), "VIP", "#FFAA00");
 		SeatSectionEntity seatSection = SeatSectionEntity.create(seatGrade, UUID.randomUUID(), "101", 120);
 		SeatEntity seat = SeatEntity.create(seatSection, "A", 1);
-		item = OrderItemEntity.create(order, seat, com.goti.ticketing.constants.TicketType.ADULT, 12000);
+		item = OrderItemEntity.create(order, seat, UUID.randomUUID(), com.goti.ticketing.constants.TicketType.ADULT, 12000);
 	}
 
 	@Test

--- a/ticketing/src/test/java/order/OrderEntityTest.java
+++ b/ticketing/src/test/java/order/OrderEntityTest.java
@@ -79,6 +79,38 @@ class OrderEntityTest {
 		assertThat(order.getConfirmedAt()).isNotNull();
 	}
 
+	@Test
+	void 주문_만료처리_성공() {
+		OrderEntity order = OrderEntity.create(
+			orderNumber,
+			userId,
+			gameSchedule,
+			totalQuantity,
+			totalAmount
+		);
+
+		order.expire();
+
+		assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.CANCELED);
+		assertThat(order.getCanceledAt()).isNotNull();
+	}
+
+	@Test
+	void 주문_만료처리_실패_확정후만료처리() {
+		OrderEntity order = OrderEntity.create(
+			orderNumber,
+			userId,
+			gameSchedule,
+			totalQuantity,
+			totalAmount
+		);
+		order.confirm();
+
+		assertThatThrownBy(order::expire)
+			.isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("PENDING 상태에서만 주문 만료 처리가 가능합니다.");
+	}
+
 	@ParameterizedTest
 	@NullAndEmptySource
 	@ValueSource(strings = {" ", "   "})

--- a/ticketing/src/test/java/order/OrderItemEntityTest.java
+++ b/ticketing/src/test/java/order/OrderItemEntityTest.java
@@ -2,6 +2,7 @@ package order;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -18,15 +19,17 @@ import com.goti.ticketing.domain.entity.order.OrderEntity;
 import com.goti.ticketing.domain.entity.order.OrderItemEntity;
 import com.goti.ticketing.domain.entity.seat.SeatEntity;
 import com.goti.ticketing.domain.entity.seat.SeatGradeEntity;
+import com.goti.ticketing.domain.entity.seat.SeatHoldEntity;
 import com.goti.ticketing.domain.entity.seat.SeatSectionEntity;
+import com.goti.domain.base.BaseUuidEntity;
 import com.goti.exception.FieldValidationException;
 
 @ActiveProfiles("test")
 class OrderItemEntityTest {
 
-	OrderEntity order;
-	SeatEntity seat;
-	UUID holdId;
+	private OrderEntity order;
+	private SeatEntity seat;
+	private UUID holdId;
 
 	@BeforeEach
 	void setup() {
@@ -38,11 +41,19 @@ class OrderItemEntityTest {
 			LeagueType.REGULAR
 		);
 		order = OrderEntity.create("ORD-20260309-0001", UUID.randomUUID(), gameSchedule, 2, 24000);
-		holdId = UUID.randomUUID();
 
 		SeatGradeEntity seatGrade = SeatGradeEntity.create(UUID.randomUUID(), "VIP", "#FFAA00");
 		SeatSectionEntity seatSection = SeatSectionEntity.create(seatGrade, UUID.randomUUID(), "101", 120);
 		seat = SeatEntity.create(seatSection, "A", 1);
+		SeatHoldEntity seatHold = SeatHoldEntity.create(
+			seat,
+			gameSchedule,
+			order.getMemberId(),
+			"queue-token-jti",
+			LocalDateTime.now().plusMinutes(10)
+		);
+		assignId(seatHold, UUID.randomUUID());
+		holdId = seatHold.getId();
 	}
 
 	@Test
@@ -99,5 +110,15 @@ class OrderItemEntityTest {
 			() -> OrderItemEntity.create(order, seat, holdId, TicketType.ADULT, -1)
 		).isInstanceOf(FieldValidationException.class)
 			.hasMessageContaining("티켓 가격은 0원 보다 커야합니다");
+	}
+
+	private void assignId(SeatHoldEntity seatHold, UUID holdId) {
+		try {
+			Field idField = BaseUuidEntity.class.getDeclaredField("id");
+			idField.setAccessible(true);
+			idField.set(seatHold, holdId);
+		} catch (ReflectiveOperationException e) {
+			throw new IllegalStateException("테스트용 SeatHold ID 설정에 실패했습니다.", e);
+		}
 	}
 }

--- a/ticketing/src/test/java/order/OrderItemEntityTest.java
+++ b/ticketing/src/test/java/order/OrderItemEntityTest.java
@@ -26,6 +26,7 @@ class OrderItemEntityTest {
 
 	OrderEntity order;
 	SeatEntity seat;
+	UUID holdId;
 
 	@BeforeEach
 	void setup() {
@@ -37,6 +38,7 @@ class OrderItemEntityTest {
 			LeagueType.REGULAR
 		);
 		order = OrderEntity.create("ORD-20260309-0001", UUID.randomUUID(), gameSchedule, 2, 24000);
+		holdId = UUID.randomUUID();
 
 		SeatGradeEntity seatGrade = SeatGradeEntity.create(UUID.randomUUID(), "VIP", "#FFAA00");
 		SeatSectionEntity seatSection = SeatSectionEntity.create(seatGrade, UUID.randomUUID(), "101", 120);
@@ -45,10 +47,11 @@ class OrderItemEntityTest {
 
 	@Test
 	void 주문상세_생성_성공() {
-		OrderItemEntity item = OrderItemEntity.create(order, seat, TicketType.ADULT, 12000);
+		OrderItemEntity item = OrderItemEntity.create(order, seat, holdId, TicketType.ADULT, 12000);
 
 		assertThat(item.getOrder()).isEqualTo(order);
 		assertThat(item.getSeat()).isEqualTo(seat);
+		assertThat(item.getHoldId()).isEqualTo(holdId);
 		assertThat(item.getTicketType()).isEqualTo(TicketType.ADULT);
 		assertThat(item.getTicketPrice()).isEqualTo(12000);
 		assertThat(item.getItemStatus()).isEqualTo(OrderItemStatus.RESERVED);
@@ -56,7 +59,7 @@ class OrderItemEntityTest {
 
 	@Test
 	void 주문상세_결제완료_성공() {
-		OrderItemEntity item = OrderItemEntity.create(order, seat, TicketType.ADULT, 12000);
+		OrderItemEntity item = OrderItemEntity.create(order, seat, holdId, TicketType.ADULT, 12000);
 
 		item.pay();
 
@@ -65,7 +68,7 @@ class OrderItemEntityTest {
 
 	@Test
 	void 주문상세_만료처리_성공() {
-		OrderItemEntity item = OrderItemEntity.create(order, seat, TicketType.ADULT, 12000);
+		OrderItemEntity item = OrderItemEntity.create(order, seat, holdId, TicketType.ADULT, 12000);
 
 		item.expire();
 
@@ -74,7 +77,7 @@ class OrderItemEntityTest {
 
 	@Test
 	void 주문상세_만료처리_실패_결제완료후만료처리() {
-		OrderItemEntity item = OrderItemEntity.create(order, seat, TicketType.ADULT, 12000);
+		OrderItemEntity item = OrderItemEntity.create(order, seat, holdId, TicketType.ADULT, 12000);
 		item.pay();
 
 		assertThatThrownBy(item::expire)
@@ -85,7 +88,7 @@ class OrderItemEntityTest {
 	@Test
 	void 주문상세_생성_실패_권종_null() {
 		assertThatThrownBy(
-			() -> OrderItemEntity.create(order, seat, null, 12000)
+			() -> OrderItemEntity.create(order, seat, holdId, null, 12000)
 		).isInstanceOf(FieldValidationException.class)
 			.hasMessageContaining("권종은 필수입니다.");
 	}
@@ -93,7 +96,7 @@ class OrderItemEntityTest {
 	@Test
 	void 주문상세_생성_실패_판매금액_음수() {
 		assertThatThrownBy(
-			() -> OrderItemEntity.create(order, seat, TicketType.ADULT, -1)
+			() -> OrderItemEntity.create(order, seat, holdId, TicketType.ADULT, -1)
 		).isInstanceOf(FieldValidationException.class)
 			.hasMessageContaining("티켓 가격은 0원 보다 커야합니다");
 	}

--- a/ticketing/src/test/java/order/OrderItemEntityTest.java
+++ b/ticketing/src/test/java/order/OrderItemEntityTest.java
@@ -64,6 +64,25 @@ class OrderItemEntityTest {
 	}
 
 	@Test
+	void 주문상세_만료처리_성공() {
+		OrderItemEntity item = OrderItemEntity.create(order, seat, TicketType.ADULT, 12000);
+
+		item.expire();
+
+		assertThat(item.getItemStatus()).isEqualTo(OrderItemStatus.CANCELED);
+	}
+
+	@Test
+	void 주문상세_만료처리_실패_결제완료후만료처리() {
+		OrderItemEntity item = OrderItemEntity.create(order, seat, TicketType.ADULT, 12000);
+		item.pay();
+
+		assertThatThrownBy(item::expire)
+			.isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("RESERVED 상태에서만 주문 상세 만료 처리가 가능합니다.");
+	}
+
+	@Test
 	void 주문상세_생성_실패_권종_null() {
 		assertThatThrownBy(
 			() -> OrderItemEntity.create(order, seat, null, 12000)

--- a/ticketing/src/test/java/ticket/TicketEntityTest.java
+++ b/ticketing/src/test/java/ticket/TicketEntityTest.java
@@ -47,7 +47,7 @@ class TicketEntityTest {
 		SeatGradeEntity seatGrade = SeatGradeEntity.create(UUID.randomUUID(), "VIP", "#FFAA00");
 		SeatSectionEntity seatSection = SeatSectionEntity.create(seatGrade, UUID.randomUUID(), "101", 120);
 		SeatEntity seat = SeatEntity.create(seatSection, "A", 1);
-		orderItem = OrderItemEntity.create(order, seat, TicketType.ADULT, 12000);
+		orderItem = OrderItemEntity.create(order, seat, UUID.randomUUID(), TicketType.ADULT, 12000);
 		orderItemId = UUID.randomUUID();
 		gameId = UUID.randomUUID();
 		userId = UUID.randomUUID();


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#238 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
미결제 주문 만료 처리를 위한 상태 전이와 주문-좌석점유 연결 기반 로직 추가
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
> 미결제 주문 만료용 상태 전이 메서드 추가
>> OrderEntity: PENDING -> CANCELED용 expire() 추가
>> OrderItemEntity: RESERVED -> CANCELED용 expire() 추가

> 미결제 주문 만료 처리 서비스 추가 - OrderExpiryService
>> 주문 만료 시 주문/주문아이템 상태 변경 로직 구현

> 주문 생성 시 사용한 좌석 점유 이력 추적을 위해 OrderItemEntity에 holdId 추가
> 주문 생성 시 SeatHoldEntity.id 저장되도록 로직 수정
> OrderExpiryService에서 holdId 기반으로 정확한 SeatHoldEntity 조회하도록 변경




<br/>