### PR TITLE
[FEAT] 회원가입 및 로그인시 RefreshToken CookieSet 추가

### DIFF
--- a/integration/src/main/java/com/goti/infra/constants/redis/RedisKey.java
+++ b/integration/src/main/java/com/goti/infra/constants/redis/RedisKey.java
@@ -10,7 +10,8 @@ import lombok.RequiredArgsConstructor;
 public enum RedisKey {
 	SMS_AUTH_CODE("auth:sms:", Duration.ofMinutes(3)),
 	OAUTH_STATE("oauth:state:", Duration.ofMinutes(5)),
-	TICKET_QR("ticket:qr-token:", Duration.ofMinutes(3));
+	TICKET_QR("ticket:qr-token:", Duration.ofMinutes(3)),
+	REFRESH_TOKEN("auth:refresh-token:", Duration.ofDays(7));
 
 	private final String prefix;
 

--- a/user/src/main/java/com/goti/user/config/jwt/JwtTokenProvider.java
+++ b/user/src/main/java/com/goti/user/config/jwt/JwtTokenProvider.java
@@ -3,6 +3,7 @@ package com.goti.user.config.jwt;
 import com.goti.user.config.properties.JwtProperties;
 
 import com.goti.constants.OAuthProvider;
+import com.goti.user.constants.TokenType;
 import com.goti.user.constants.UserRole;
 
 import com.goti.constants.messages.ErrorCode;
@@ -45,10 +46,12 @@ public class JwtTokenProvider {
 	private static final String PROVIDER_EMAIL_KEY = "provider_email";
 	static final String SOCIAL_VERIFY_SUBJECT = "social_verify";
 
-	public String create(UUID id, String mobile, UserRole role) {
+	public String create(UUID id, String mobile, UserRole role, TokenType tokenType) {
 		Date issuedAt = new Date();
-		Date expireAt = new Date(issuedAt.getTime() + jwtProperties.accessValidTime().toMillis());
-		String jwtId = getJwtId();
+		Duration validTime = tokenType == TokenType.ACCESS ?
+			jwtProperties.accessValidTime() : jwtProperties.refreshValidTime();
+		Date expireAt = new Date(issuedAt.getTime() + validTime.toMillis());
+		String jwtId = createJwtId();
 		return Jwts.builder()
 			.subject(id.toString())
 			.id(jwtId)
@@ -63,7 +66,7 @@ public class JwtTokenProvider {
 	public String createSocialVerifyToken(OAuthProvider provider, String providerId, String email) {
 		Date issuedAt = new Date();
 		Date expireAt = new Date(issuedAt.getTime() + Duration.ofMinutes(10).toMillis());
-		String jwtId = getJwtId();
+		String jwtId = createJwtId();
 		return Jwts.builder()
 			.subject(SOCIAL_VERIFY_SUBJECT)
 			.id(jwtId)
@@ -117,6 +120,10 @@ public class JwtTokenProvider {
 		);
 	}
 
+	public String extractJti(String token) {
+		return getClaims(token).getId();
+	}
+
 	private Claims getClaims(String token) {
 		return Jwts.parser()
 			.verifyWith(jwtProperties.secretKey())
@@ -125,7 +132,9 @@ public class JwtTokenProvider {
 			.getPayload();
 	}
 
-	private String getJwtId() {
+	private String createJwtId() {
 		return UUID.randomUUID().toString();
 	}
+
+
 }

--- a/user/src/main/java/com/goti/user/config/properties/RefreshCookieProperties.java
+++ b/user/src/main/java/com/goti/user/config/properties/RefreshCookieProperties.java
@@ -1,0 +1,15 @@
+package com.goti.user.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.cookie")
+public record RefreshCookieProperties(
+	boolean secure,
+	String sameSite,
+	Refresh refresh
+) {
+	public record Refresh(
+		String name,
+		String path
+	) {}
+}

--- a/user/src/main/java/com/goti/user/constants/TokenType.java
+++ b/user/src/main/java/com/goti/user/constants/TokenType.java
@@ -1,0 +1,15 @@
+package com.goti.user.constants;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TokenType {
+
+	ACCESS("AccessToken"),
+	REFRESH("RefreshToken")
+	;
+
+	private final String description;
+}

--- a/user/src/main/java/com/goti/user/controller/AuthController.java
+++ b/user/src/main/java/com/goti/user/controller/AuthController.java
@@ -12,11 +12,17 @@ import com.goti.infra.api.dto.response.common.SocialStateResponse;
 
 import com.goti.user.service.auth.application.SocialAuthService;
 
+import com.goti.user.util.CookieProvider;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.data.util.Pair;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -34,6 +40,7 @@ import static com.goti.global.api.ApiSuccessResponse.*;
 public class AuthController {
 
 	private final SocialAuthService socialAuthService;
+	private final CookieProvider cookieProvider;
 
 	@Operation(
 		summary = "소셜 인증 State 발급",
@@ -68,11 +75,19 @@ public class AuthController {
 	)
 	@PostMapping("/login")
 	public ResponseEntity<ApiSuccessResponse<TokenResponse>> login(
-		@RequestBody @Valid LoginRequest request
+		@RequestBody @Valid LoginRequest request, HttpServletResponse response
 	) {
-		String accessToken = socialAuthService.login(
+
+		Pair<String, String> tokens = socialAuthService.login(
 			request.socialVerifyToken()
-		).getFirst();
+		);
+
+		String accessToken = tokens.getFirst();
+		String refreshToken = tokens.getSecond();
+
+		ResponseCookie cookie = cookieProvider.createRefreshTokenCookie(refreshToken);
+		response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
 		return wrap(new TokenResponse(accessToken));
 	}
 
@@ -82,17 +97,20 @@ public class AuthController {
 	)
 	@PostMapping("/signup")
 	public ResponseEntity<ApiSuccessResponse<TokenResponse>> signup(
-		@RequestBody @Valid SignupRequest request
+		@RequestBody @Valid SignupRequest request, HttpServletResponse response
 	) {
-		String accessToken = socialAuthService.signup(
+		Pair<String, String> tokens = socialAuthService.signup(
 			request.socialVerifyToken(),
 			request.name(),
 			request.mobile(),
 			request.gender(),
 			request.birthDate(),
 			request.authCode()
-		).getFirst();
-
+		);
+		String accessToken = tokens.getFirst();
+		String refreshToken = tokens.getSecond();
+		ResponseCookie cookie = cookieProvider.createRefreshTokenCookie(refreshToken);
+		response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 		return wrap(new TokenResponse(accessToken));
 	}
 

--- a/user/src/main/java/com/goti/user/service/auth/application/SocialAuthService.java
+++ b/user/src/main/java/com/goti/user/service/auth/application/SocialAuthService.java
@@ -4,6 +4,7 @@ import com.goti.user.config.jwt.JwtTokenProvider;
 import com.goti.constants.Gender;
 import com.goti.constants.OAuthProvider;
 import com.goti.constants.messages.ErrorCode;
+import com.goti.user.constants.TokenType;
 import com.goti.user.domain.entity.user.MemberEntity;
 import com.goti.user.dto.response.SocialVerifyResponse;
 import com.goti.exception.CustomException;
@@ -90,12 +91,10 @@ public class SocialAuthService {
 				return new CustomException(ErrorCode.MEMBER_NOT_FOUND);
 			}
 		);
-		String accessToken = jwtTokenProvider.create(
-			member.getId(),
-			member.getMobile(),
-			member.getRole()
-		);
-		return Pair.of(accessToken, "");
+		String accessToken = createToken(member, TokenType.ACCESS);
+		String refreshToken = createToken(member, TokenType.REFRESH);
+		saveRefreshTokenJti(member.getId(), refreshToken);
+		return Pair.of(accessToken, refreshToken);
 	}
 
 	public Pair<String, String> signup(
@@ -112,12 +111,10 @@ public class SocialAuthService {
 
 		createSocialProvider(member, verifiedSocialInfo);
 
-		String accessToken = jwtTokenProvider.create(
-			member.getId(),
-			member.getMobile(),
-			member.getRole()
-		);
-		return Pair.of(accessToken, "");
+		String accessToken = createToken(member, TokenType.ACCESS);
+		String refreshToken = createToken(member, TokenType.REFRESH);
+		saveRefreshTokenJti(member.getId(), refreshToken);
+		return Pair.of(accessToken, refreshToken);
 	}
 
 	public void sendSignupSmsCode(String socialVerifyToken, String mobile) {
@@ -193,6 +190,20 @@ public class SocialAuthService {
 				}
 			}
 		);
+	}
+
+	private String createToken(MemberEntity member, TokenType tokenType) {
+		return jwtTokenProvider.create(
+			member.getId(),
+			member.getMobile(),
+			member.getRole(),
+			tokenType
+		);
+	}
+
+	private void saveRefreshTokenJti(UUID memberId, String token) {
+		String refreshJti = jwtTokenProvider.extractJti(token);
+		redisCache.set(RedisKey.REFRESH_TOKEN, memberId, refreshJti);
 	}
 
 

--- a/user/src/main/java/com/goti/user/service/test/TestUserService.java
+++ b/user/src/main/java/com/goti/user/service/test/TestUserService.java
@@ -2,6 +2,8 @@ package com.goti.user.service.test;
 
 import java.time.LocalDate;
 
+import com.goti.user.constants.TokenType;
+
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,7 +43,7 @@ public class TestUserService {
 			));
 
 		String accessToken = jwtTokenProvider.create(
-			member.getId(), member.getMobile(), UserRole.MEMBER
+			member.getId(), member.getMobile(), UserRole.MEMBER, TokenType.ACCESS
 		);
 
 		return new TestUserResponse(
@@ -85,7 +87,7 @@ public class TestUserService {
 			.orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
 		String accessToken = jwtTokenProvider.create(
-			member.getId(), member.getMobile(), UserRole.MEMBER
+			member.getId(), member.getMobile(), UserRole.MEMBER, TokenType.ACCESS
 		);
 
 		return new TokenResponse(accessToken);

--- a/user/src/main/java/com/goti/user/util/CookieProvider.java
+++ b/user/src/main/java/com/goti/user/util/CookieProvider.java
@@ -30,23 +30,24 @@ public class CookieProvider {
 	}
 
 	public ResponseCookie createCookie(String name, String value, String path, long maxAge) {
-		return ResponseCookie.from(name, value)
-			.httpOnly(true)
-			.secure(properties.secure())
-			.path(path)
+		return createBaseCookieBuilder(name, path)
+			.value(value)
 			.maxAge(maxAge)
-			.sameSite(properties.sameSite())
 			.build();
 	}
 
 	public ResponseCookie deleteCookie(String name, String path) {
+		return createBaseCookieBuilder(name, path)
+			.maxAge(0)
+			.build();
+	}
+
+	private ResponseCookie.ResponseCookieBuilder createBaseCookieBuilder(String name, String path) {
 		return ResponseCookie.from(name, "")
 			.httpOnly(true)
 			.secure(properties.secure())
 			.path(path)
-			.maxAge(0)
-			.sameSite(properties.sameSite())
-			.build();
+			.sameSite(properties.sameSite());
 	}
 
 }

--- a/user/src/main/java/com/goti/user/util/CookieProvider.java
+++ b/user/src/main/java/com/goti/user/util/CookieProvider.java
@@ -1,0 +1,52 @@
+package com.goti.user.util;
+
+import com.goti.infra.constants.redis.RedisKey;
+import com.goti.user.config.properties.RefreshCookieProperties;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CookieProvider {
+
+	private final RefreshCookieProperties properties;
+
+	public ResponseCookie createRefreshTokenCookie(String token) {
+		return createCookie(
+			properties.refresh().name(),
+			token,
+			properties.refresh().path(),
+			RedisKey.REFRESH_TOKEN.getTtl().toSeconds()
+		);
+	}
+
+	public ResponseCookie deleteRefreshTokenCookie() {
+		return deleteCookie(
+			properties.refresh().name(), properties.refresh().path()
+		);
+	}
+
+	public ResponseCookie createCookie(String name, String value, String path, long maxAge) {
+		return ResponseCookie.from(name, value)
+			.httpOnly(true)
+			.secure(properties.secure())
+			.path(path)
+			.maxAge(maxAge)
+			.sameSite(properties.sameSite())
+			.build();
+	}
+
+	public ResponseCookie deleteCookie(String name, String path) {
+		return ResponseCookie.from(name, "")
+			.httpOnly(true)
+			.secure(properties.secure())
+			.path(path)
+			.maxAge(0)
+			.sameSite(properties.sameSite())
+			.build();
+	}
+
+}

--- a/user/src/main/resources/application.yml
+++ b/user/src/main/resources/application.yml
@@ -42,6 +42,15 @@ jwt:
   refresh-valid-time: ${JWT_REFRESH_TIME}
   social-verify-valid-time: ${JWT_SOCIAL_VERIFY_TIME:300000}
 
+app:
+  cookie:
+    secure: ${COOKIE_SECURE:false}
+    same-site: ${COOKIE_SAME_SITE:Lax}
+    refresh:
+      name: ${REFRESH_COOKIE_NAME:refreshToken}
+      path: ${REFRESH_REISSUE_PATH:/api/v1/auth/reissue}
+
+
 management:
   endpoints:
     web:


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#234
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
회원가입 및 로그인 시 RefreshToken CookieSet 추가
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- refreshToken cookieSet 로직 추가 (In AuthController)
- RefreshToken 관련 cookie 정의 추가 (user module: application.yml) 및 RefreshCookieProperties 추가
- TokenType 추가(Enum: 엑세스토큰, 리프래쉬토큰),
- CookieProvider 추가 (쿠키 저장 및 삭제 Provider)
- Token Arguments 추가 및 Token(access, refresh) 생성 시 분기처리(in JwtTokenProvider)
- 로그인 및 회원가입 서비스 -> RefreshToken 생성 및 Redis 저장 로직 추가 (+ token(refresh, access) 생성 및 jti 저장 로직 메소드화)
<br/>