### PR TITLE
[BUG] 야구게임일정 생성 시 야구구단 및 야구구장 서비스 직접참조 -> 내부 API 호출 로직 수정

### DIFF
--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -89,3 +89,8 @@ internal:
     base-url: ${RESALE_BASE_URL:http://localhost:8080}
   payment:
     base-url: ${PAYMENT_BASE_URL:http://localhost:8080}
+
+infra:
+  api:
+    endpoints:
+      stadium: ${STADIUM_API_URL:http://localhost:8080}

--- a/integration/src/main/java/com/goti/config/properties/ApiEndpointProperties.java
+++ b/integration/src/main/java/com/goti/config/properties/ApiEndpointProperties.java
@@ -1,0 +1,9 @@
+package com.goti.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "infra.api.endpoints")
+public record ApiEndpointProperties(
+	String stadium
+) {
+}

--- a/integration/src/main/java/com/goti/infra/api/base/BaseRestClient.java
+++ b/integration/src/main/java/com/goti/infra/api/base/BaseRestClient.java
@@ -13,6 +13,10 @@ public abstract class BaseRestClient {
 	protected final RestClient restClient;
 
 	protected BaseRestClient(RestClient.Builder builder) {
+		this(builder, null);
+	}
+
+	protected BaseRestClient(RestClient.Builder builder, String baseUrl) {
 		this.restClient = builder
 			.defaultHeaders(headers -> {
 				headers.setContentType(MediaType.APPLICATION_JSON);

--- a/integration/src/main/java/com/goti/infra/api/base/BaseRestClient.java
+++ b/integration/src/main/java/com/goti/infra/api/base/BaseRestClient.java
@@ -109,6 +109,28 @@ public abstract class BaseRestClient {
 			.body(responseType);
 	}
 
+	protected void getVoid(String uri, Map<String, String> headers, Map<String, ?> queryParams) {
+		restClient.get()
+			.uri(uriBuilder -> {
+				UriBuilder builder = getActualUriBuilder(uri, uriBuilder);
+				if (queryParams != null) builder.queryParams(toParams(queryParams));
+				return builder.build();
+			})
+			.headers(header -> {
+				if (headers != null) headers.forEach(header::add);
+			})
+			.retrieve()
+			.toBodilessEntity();
+	}
+
+	protected void postVoid(String uri, Object body) {
+		restClient.post()
+			.uri(uriBuilder -> getActualUriBuilder(uri, uriBuilder).build())
+			.body(body)
+			.retrieve()
+			.toBodilessEntity();
+	}
+
 	protected Map<String, String> createBearerHeader(String accessToken) {
 		return Map.of("Authorization", "Bearer " + accessToken);
 	}

--- a/integration/src/main/java/com/goti/infra/api/base/BaseRestClient.java
+++ b/integration/src/main/java/com/goti/infra/api/base/BaseRestClient.java
@@ -18,6 +18,7 @@ public abstract class BaseRestClient {
 
 	protected BaseRestClient(RestClient.Builder builder, String baseUrl) {
 		this.restClient = builder
+			.baseUrl(baseUrl != null ? baseUrl : "")
 			.defaultHeaders(headers -> {
 				headers.setContentType(MediaType.APPLICATION_JSON);
 				headers.setAccept(java.util.List.of(MediaType.APPLICATION_JSON));

--- a/integration/src/main/java/com/goti/infra/api/client/google/GoogleApiClient.java
+++ b/integration/src/main/java/com/goti/infra/api/client/google/GoogleApiClient.java
@@ -23,8 +23,8 @@ public class GoogleApiClient extends BaseRestClient implements SocialApiClient {
 
 	private final GoogleOauthProperties properties;
 
-	public GoogleApiClient(RestClient restClient, GoogleOauthProperties properties) {
-		super(restClient.mutate());
+	public GoogleApiClient(RestClient.Builder builder, GoogleOauthProperties properties) {
+		super(builder);
 		this.properties = properties;
 	}
 

--- a/integration/src/main/java/com/goti/infra/api/client/kakao/KakaoApiClient.java
+++ b/integration/src/main/java/com/goti/infra/api/client/kakao/KakaoApiClient.java
@@ -21,8 +21,8 @@ public class KakaoApiClient extends BaseRestClient implements SocialApiClient {
 
 	private final KakaoOauthProperties properties;
 
-	public KakaoApiClient(RestClient restClient, KakaoOauthProperties properties) {
-		super(restClient.mutate());
+	public KakaoApiClient(RestClient.Builder builder, KakaoOauthProperties properties) {
+		super(builder);
 		this.properties = properties;
 	}
 

--- a/integration/src/main/java/com/goti/infra/api/client/naver/NaverApiClient.java
+++ b/integration/src/main/java/com/goti/infra/api/client/naver/NaverApiClient.java
@@ -21,8 +21,8 @@ public class NaverApiClient extends BaseRestClient implements SocialApiClient {
 
 	private final NaverOauthProperties properties;
 
-	public NaverApiClient(RestClient restClient, NaverOauthProperties properties) {
-		super(restClient.mutate());
+	public NaverApiClient(RestClient.Builder builder, NaverOauthProperties properties) {
+		super(builder);
 		this.properties = properties;
 	}
 

--- a/stadium/src/main/java/com/goti/stadium/controller/BaseballTeamController.java
+++ b/stadium/src/main/java/com/goti/stadium/controller/BaseballTeamController.java
@@ -4,7 +4,12 @@ import static com.goti.global.api.ApiSuccessResponse.*;
 
 import java.util.UUID;
 
+import com.goti.stadium.domain.entity.team.BaseballTeamEntity;
+
+import io.swagger.v3.oas.annotations.Operation;
+
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -32,6 +37,10 @@ public class BaseballTeamController {
 	private final BaseballTeamService baseballTeamService;
 	private final HomeStadiumManagementService homeStadiumManagementService;
 
+	@Operation(
+		summary = "구단(팀) 생성",
+		description = "야구구단(팀) 생성 API"
+	)
 	@PostMapping
 	public ResponseEntity<ApiSuccessResponse<BaseballTeamCreateResponse>> register(
 		@RequestBody @Valid BaseballTeamCreateRequest request
@@ -41,6 +50,23 @@ public class BaseballTeamController {
 		);
 	}
 
+	@Operation(
+		summary = "구단(팀) 상세 조회",
+		description = "야구구단(팀) 상세 조회 API"
+	)
+	@GetMapping("/{teamId}")
+	public ResponseEntity<ApiSuccessResponse<BaseballTeamEntity>> get(
+		@PathVariable UUID teamId
+	) {
+		return wrap(
+			baseballTeamService.getById(teamId)
+		);
+	}
+
+	@Operation(
+		summary = "구단(팀) 홈구장 등록",
+		description = "야구구단(팀) 홈구장(제1구장, 제2구장) 등록 API"
+	)
 	@PostMapping("/{teamId}/home-stadiums")
 	public ResponseEntity<ApiSuccessResponse<HomeStadiumCreateResponse>> assignHomeStadium(
 		@PathVariable UUID teamId,

--- a/stadium/src/main/java/com/goti/stadium/controller/StadiumController.java
+++ b/stadium/src/main/java/com/goti/stadium/controller/StadiumController.java
@@ -1,5 +1,6 @@
 package com.goti.stadium.controller;
 
+import com.goti.stadium.domain.entity.stadium.StadiumEntity;
 import com.goti.stadium.dto.request.StadiumCreateRequest;
 import com.goti.stadium.dto.response.StadiumCreateResponse;
 import com.goti.global.api.ApiSuccessResponse;
@@ -11,10 +12,14 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
 
 import static com.goti.global.api.ApiSuccessResponse.wrap;
 
@@ -47,5 +52,16 @@ public class StadiumController {
 				request.seatMapConfig()
 			)
 		);
+	}
+
+	@Operation(
+		summary = "야구 구장 조회",
+		description = "야구 구장 조회 API"
+	)
+	@GetMapping("/{stadiumId}")
+	public ResponseEntity<ApiSuccessResponse<StadiumEntity>> get(
+		@PathVariable UUID stadiumId
+	) {
+		return wrap(stadiumService.getById(stadiumId));
 	}
 }

--- a/stadium/src/test/java/com/goti/stadium/api/BaseballTeamDetailApiTest.java
+++ b/stadium/src/test/java/com/goti/stadium/api/BaseballTeamDetailApiTest.java
@@ -1,0 +1,94 @@
+package com.goti.stadium.api;
+import com.goti.stadium.GotiStadiumApplication;
+
+import com.goti.stadium.constants.TeamCode;
+import com.goti.stadium.dto.request.BaseballTeamCreateRequest;
+
+import com.goti.stadium.dto.response.BaseballTeamCreateResponse;
+
+import com.goti.stadium.service.domain.baseballteam.BaseballTeamService;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@Slf4j
+@SpringBootTest(classes = GotiStadiumApplication.class)
+@Transactional
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DisplayName("야구구단 조회 - GET /api/v1/baseball-teams")
+public class BaseballTeamDetailApiTest {
+
+	@Autowired
+	public MockMvc mockMvc;
+
+	@Autowired
+	BaseballTeamService baseballTeamService;
+
+	UUID teamId;
+
+	@BeforeEach
+	void setup() {
+		saveBaseballTeam();
+	}
+
+	@Test
+	void 야구구단_조회_성공__200_OK() throws Exception {
+		MvcResult result = mockMvc.perform(
+				get("/api/v1/baseball-teams/{teamId}", teamId)
+			)
+			.andExpectAll(
+				status().isOk(),
+				jsonPath("$.code").value("ok"),
+				jsonPath("$.message").value("성공"),
+				jsonPath("$.data").exists(),
+				jsonPath("$.data.id").value(teamId.toString()),
+				jsonPath("$.data.teamCode").value(TeamCode.SS.name())
+			).andReturn();
+
+		String responseJson = result.getResponse().getContentAsString();
+		log.info("response : {}", responseJson);
+		log.info("teamId : {}", teamId);
+	}
+
+	private void saveBaseballTeam() {
+		BaseballTeamCreateRequest request =
+			new BaseballTeamCreateRequest(
+				TeamCode.SS,
+				"삼성라이온즈",
+				"Samsung Lions",
+				"삼성",
+				"대구",
+				1982,
+				"대구광역시 수성구 야구전설로 1",
+				"42250",
+				"https://www.samsunglions.com/",
+				"홍길동",
+				"삼성그룹",
+				"이재용",
+				"이종열",
+				"박진만",
+				"https://image.url/logo.png"
+			);
+		BaseballTeamCreateResponse response = baseballTeamService.create(
+			request.toCommand()
+		);
+		teamId = response.teamId();
+	}
+}

--- a/stadium/src/test/java/com/goti/stadium/api/BaseballTeamDetailApiTest.java
+++ b/stadium/src/test/java/com/goti/stadium/api/BaseballTeamDetailApiTest.java
@@ -32,7 +32,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Transactional
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-@DisplayName("야구구단 조회 - GET /api/v1/baseball-teams")
+@DisplayName("야구구단 조회 - GET /api/v1/baseball-teams/{teamId}")
 public class BaseballTeamDetailApiTest {
 
 	@Autowired
@@ -58,7 +58,7 @@ public class BaseballTeamDetailApiTest {
 				jsonPath("$.code").value("ok"),
 				jsonPath("$.message").value("성공"),
 				jsonPath("$.data").exists(),
-				jsonPath("$.data.id").value(teamId.toString()),
+				jsonPath("$.data.id").value(String.valueOf(teamId)),
 				jsonPath("$.data.teamCode").value(TeamCode.SS.name())
 			).andReturn();
 

--- a/stadium/src/test/java/com/goti/stadium/api/StadiumDetailApiTest.java
+++ b/stadium/src/test/java/com/goti/stadium/api/StadiumDetailApiTest.java
@@ -1,0 +1,92 @@
+package com.goti.stadium.api;
+
+import com.goti.stadium.GotiStadiumApplication;
+import com.goti.stadium.constants.TeamCode;
+import com.goti.stadium.domain.entity.stadium.StadiumEntity;
+import com.goti.stadium.repository.StadiumRepository;
+import com.goti.stadium.service.domain.baseballteam.BaseballTeamService;
+
+import com.goti.stadium.service.domain.stadium.StadiumService;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@Slf4j
+@SpringBootTest(classes = GotiStadiumApplication.class)
+@Transactional
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DisplayName("야구구장 조회 - GET /api/v1/stadiums/{stadiumId}")
+public class StadiumDetailApiTest {
+
+	@Autowired
+	public MockMvc mockMvc;
+
+	@Autowired
+	StadiumRepository stadiumRepository;
+
+	StadiumEntity stadium;
+
+	static final String STADIUM_NAME = "대구삼성라이온즈파크";
+
+	@BeforeEach
+	void setup() {
+		saveStadium();
+	}
+
+	@Test
+	void 야구구장_조회_성공__200_OK() throws Exception {
+		MvcResult result = mockMvc.perform(
+				get("/api/v1/stadiums/{stadiumId}", stadium.getId())
+			)
+			.andExpectAll(
+				status().isOk(),
+				jsonPath("$.code").value("ok"),
+				jsonPath("$.message").value("성공"),
+				jsonPath("$.data").exists(),
+				jsonPath("$.data.id").exists(),
+				jsonPath("$.data.id").value(String.valueOf(stadium.getId())),
+				jsonPath("$.data.stadiumName").value(STADIUM_NAME)
+			).andReturn();
+
+		String responseJson = result.getResponse().getContentAsString();
+		log.info("response : {}", responseJson);
+		log.info("stadiumId : {}", stadium.getId());
+	}
+
+	private void saveStadium() {
+		stadium = StadiumEntity.create(
+			"대구삼성라이온즈파크",
+			"대구",
+			"대구광역시",
+			"수성구",
+			"대구광역시 수성구 야구전설로 1",
+			new BigDecimal("35.84112000"),
+			new BigDecimal("128.68152000"),
+			24000,
+			Map.of(
+				"shape", "octagon",
+				"openedYear", 2016,
+				"turf", "natural"
+			)
+		);
+		stadiumRepository.save(stadium);
+	}
+}

--- a/ticketing/build.gradle
+++ b/ticketing/build.gradle
@@ -1,3 +1,7 @@
+ext {
+    set('springCloudVersion', "2023.0.3")
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
@@ -23,6 +27,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'
 
+    testImplementation 'org.springframework.cloud:spring-cloud-contract-wiremock'
 
     implementation project(':common')
     implementation project(':integration')
@@ -30,4 +35,10 @@ dependencies {
 
     // TODO: MSA 분리 시 테스트용 Security 설정을 각 모듈에 별도로 두고 제거
     testImplementation project(':user')
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }

--- a/ticketing/src/main/java/com/goti/ticketing/game/service/application/GameManagementService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/service/application/GameManagementService.java
@@ -10,9 +10,7 @@ import com.goti.ticketing.game.service.domain.GameScheduleService;
 import com.goti.ticketing.game.service.domain.GameStatusService;
 
 import com.goti.ticketing.game.service.domain.GameTicketingStatusService;
-import com.goti.stadium.service.domain.baseballteam.BaseballTeamService;
-
-import com.goti.stadium.service.domain.stadium.StadiumService;
+import com.goti.ticketing.infra.api.StadiumApiClient;
 
 import lombok.RequiredArgsConstructor;
 
@@ -29,8 +27,7 @@ public class GameManagementService {
 	private final GameScheduleService gameScheduleService;
 	private final GameStatusService gameStatusService;
 	private final GameTicketingStatusService gameTicketingStatusService;
-	private final BaseballTeamService baseballTeamService;
-	private final StadiumService stadiumService;
+	private final StadiumApiClient stadiumApiClient;
 
 	@Transactional
 	public GameCreateResponse register(
@@ -72,10 +69,10 @@ public class GameManagementService {
 	}
 
 	private void validateBaseballTeam(UUID teamId) {
-		baseballTeamService.getById(teamId);
+		stadiumApiClient.getBaseballTeam(teamId);
 	}
 
 	private void validateStadium(UUID stadiumId) {
-		stadiumService.getById(stadiumId);
+		stadiumApiClient.getStadium(stadiumId);
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/game/service/application/GameManagementService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/service/application/GameManagementService.java
@@ -69,10 +69,10 @@ public class GameManagementService {
 	}
 
 	private void validateBaseballTeam(UUID teamId) {
-		stadiumApiClient.getBaseballTeam(teamId);
+		stadiumApiClient.validateBaseballTeam(teamId);
 	}
 
 	private void validateStadium(UUID stadiumId) {
-		stadiumApiClient.getStadium(stadiumId);
+		stadiumApiClient.validateStadium(stadiumId);
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/game/service/application/GameManagementService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/service/application/GameManagementService.java
@@ -10,7 +10,8 @@ import com.goti.ticketing.game.service.domain.GameScheduleService;
 import com.goti.ticketing.game.service.domain.GameStatusService;
 
 import com.goti.ticketing.game.service.domain.GameTicketingStatusService;
-import com.goti.ticketing.infra.api.StadiumApiClient;
+
+import com.goti.ticketing.infra.api.StadiumClient;
 
 import lombok.RequiredArgsConstructor;
 
@@ -27,7 +28,7 @@ public class GameManagementService {
 	private final GameScheduleService gameScheduleService;
 	private final GameStatusService gameStatusService;
 	private final GameTicketingStatusService gameTicketingStatusService;
-	private final StadiumApiClient stadiumApiClient;
+	private final StadiumClient stadiumClient;
 
 	@Transactional
 	public GameCreateResponse register(
@@ -69,10 +70,10 @@ public class GameManagementService {
 	}
 
 	private void validateBaseballTeam(UUID teamId) {
-		stadiumApiClient.validateBaseballTeam(teamId);
+		stadiumClient.validateBaseballTeam(teamId);
 	}
 
 	private void validateStadium(UUID stadiumId) {
-		stadiumApiClient.validateStadium(stadiumId);
+		stadiumClient.validateStadium(stadiumId);
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/infra/api/StadiumApiClient.java
+++ b/ticketing/src/main/java/com/goti/ticketing/infra/api/StadiumApiClient.java
@@ -1,0 +1,35 @@
+package com.goti.ticketing.infra.api;
+
+import com.goti.config.properties.ApiEndpointProperties;
+import com.goti.infra.api.base.BaseRestClient;
+
+import com.goti.stadium.domain.entity.stadium.StadiumEntity;
+import com.goti.stadium.domain.entity.team.BaseballTeamEntity;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.util.UUID;
+
+@Component
+public class StadiumApiClient extends BaseRestClient implements StadiumClient {
+
+	private final static String BASEBALL_TEAM_GET_API = "/api/v1/baseball-teams/";
+	private final static String STADIUM_GET_API = "/api/v1/stadiums/";
+
+	public StadiumApiClient(RestClient.Builder builder, ApiEndpointProperties properties) {
+		super(builder, properties.stadium());
+	}
+
+	@Override
+	public BaseballTeamEntity getBaseballTeam(UUID teamId) {
+		String uri = BASEBALL_TEAM_GET_API + teamId;
+		return get(uri, null, null, BaseballTeamEntity.class);
+	}
+
+	@Override
+	public StadiumEntity getStadium(UUID stadiumId) {
+		String uri = STADIUM_GET_API + stadiumId;
+		return get(uri, null, null, StadiumEntity.class);
+	}
+}

--- a/ticketing/src/main/java/com/goti/ticketing/infra/api/StadiumApiClient.java
+++ b/ticketing/src/main/java/com/goti/ticketing/infra/api/StadiumApiClient.java
@@ -3,9 +3,6 @@ package com.goti.ticketing.infra.api;
 import com.goti.config.properties.ApiEndpointProperties;
 import com.goti.infra.api.base.BaseRestClient;
 
-import com.goti.stadium.domain.entity.stadium.StadiumEntity;
-import com.goti.stadium.domain.entity.team.BaseballTeamEntity;
-
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
@@ -22,14 +19,14 @@ public class StadiumApiClient extends BaseRestClient implements StadiumClient {
 	}
 
 	@Override
-	public BaseballTeamEntity getBaseballTeam(UUID teamId) {
+	public void validateBaseballTeam(UUID teamId) {
 		String uri = BASEBALL_TEAM_GET_API + teamId;
-		return get(uri, null, null, BaseballTeamEntity.class);
+		getVoid(uri, null, null);
 	}
 
 	@Override
-	public StadiumEntity getStadium(UUID stadiumId) {
+	public void validateStadium(UUID stadiumId) {
 		String uri = STADIUM_GET_API + stadiumId;
-		return get(uri, null, null, StadiumEntity.class);
+		getVoid(uri, null, null);
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/infra/api/StadiumClient.java
+++ b/ticketing/src/main/java/com/goti/ticketing/infra/api/StadiumClient.java
@@ -1,11 +1,8 @@
 package com.goti.ticketing.infra.api;
 
-import com.goti.stadium.domain.entity.stadium.StadiumEntity;
-import com.goti.stadium.domain.entity.team.BaseballTeamEntity;
-
 import java.util.UUID;
 
 public interface StadiumClient {
-	BaseballTeamEntity getBaseballTeam(UUID teamId);
-	StadiumEntity getStadium(UUID stadiumId);
+	void validateBaseballTeam(UUID teamId);
+	void validateStadium(UUID stadiumId);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/infra/api/StadiumClient.java
+++ b/ticketing/src/main/java/com/goti/ticketing/infra/api/StadiumClient.java
@@ -1,0 +1,11 @@
+package com.goti.ticketing.infra.api;
+
+import com.goti.stadium.domain.entity.stadium.StadiumEntity;
+import com.goti.stadium.domain.entity.team.BaseballTeamEntity;
+
+import java.util.UUID;
+
+public interface StadiumClient {
+	BaseballTeamEntity getBaseballTeam(UUID teamId);
+	StadiumEntity getStadium(UUID stadiumId);
+}

--- a/ticketing/src/test/java/com/goti/ticketing/game/api/game/GameRegistrationTest.java
+++ b/ticketing/src/test/java/com/goti/ticketing/game/api/game/GameRegistrationTest.java
@@ -75,6 +75,7 @@ public class GameRegistrationTest {
 
 	private static final String BASEBALL_GET_API_URI = "/api/v1/baseball-teams/";
 	private static final String STADIUM_GET_API_URI = "/api/v1/stadiums/";
+
 	@BeforeEach
 	void setup() {
 		saveAwayTeam();

--- a/ticketing/src/test/java/com/goti/ticketing/game/api/game/GameRegistrationTest.java
+++ b/ticketing/src/test/java/com/goti/ticketing/game/api/game/GameRegistrationTest.java
@@ -34,11 +34,14 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 @Slf4j
 @SpringBootTest(classes = GotiTicketingApplication.class)
@@ -46,6 +49,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 @DisplayName("야구 경기 등록 - POST /api/v1/games")
+@AutoConfigureWireMock(port = 8080)
 public class GameRegistrationTest {
 
 	@Autowired
@@ -69,12 +73,31 @@ public class GameRegistrationTest {
 	private static final LeagueType LEAGUE_TYPE = LeagueType.REGULAR;
 	private static final int TICKETING_START_HOUR = 11;
 
+	private static final String BASEBALL_GET_API_URI = "/api/v1/baseball-teams/";
+	private static final String STADIUM_GET_API_URI = "/api/v1/stadiums/";
 	@BeforeEach
 	void setup() {
 		saveAwayTeam();
 		saveHomeTeam();
 		saveStadium();
 
+		stubFor(
+			get(
+				urlEqualTo(BASEBALL_GET_API_URI + homeTeam.getId())
+			).willReturn(aResponse().withStatus(200))
+		);
+
+		stubFor(
+			get(
+				urlEqualTo(BASEBALL_GET_API_URI + awayTeam.getId())
+			).willReturn(aResponse().withStatus(200))
+		);
+
+		stubFor(
+			get(
+				urlEqualTo(STADIUM_GET_API_URI + stadium.getId())
+			).willReturn(aResponse().withStatus(200))
+		);
 	}
 
 

--- a/ticketing/src/test/java/com/goti/ticketing/game/api/game/GameSchedulesSearchApiTest.java
+++ b/ticketing/src/test/java/com/goti/ticketing/game/api/game/GameSchedulesSearchApiTest.java
@@ -1,5 +1,6 @@
 package com.goti.ticketing.game.api.game;
 
+import com.github.tomakehurst.wiremock.client.WireMock;
 import com.goti.ticketing.GotiTicketingApplication;
 import com.goti.ticketing.constants.LeagueType;
 import com.goti.stadium.constants.TeamCode;
@@ -26,11 +27,14 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Map;
 
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
 
 @Slf4j
 @SpringBootTest(classes = GotiTicketingApplication.class)
@@ -38,29 +42,52 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 @DisplayName("야구 게임 일정 조회 - GET /api/v1/games/schedules")
+@AutoConfigureWireMock(port = 8080)
 public class GameSchedulesSearchApiTest {
 
 	@Autowired
-	private MockMvc mockMvc;
+	MockMvc mockMvc;
 
 	@Autowired
-	private GameManagementService gameManagementService;
+	GameManagementService gameManagementService;
 
 	@Autowired
-	private BaseballTeamRepository baseballTeamRepository;
+	BaseballTeamRepository baseballTeamRepository;
 
 	@Autowired
-	private StadiumRepository stadiumRepository;
+	StadiumRepository stadiumRepository;
 
-	private BaseballTeamEntity kia;
-	private BaseballTeamEntity samsung;
-	private StadiumEntity stadium;
+	BaseballTeamEntity kia;
+	BaseballTeamEntity samsung;
+	StadiumEntity stadium;
+
+	private static final String BASEBALL_GET_API_URI = "/api/v1/baseball-teams/";
+	private static final String STADIUM_GET_API_URI = "/api/v1/stadiums/";
 
 	@BeforeEach
 	void setup() {
-		saveSamsung();
+
 		saveKia();
+		saveSamsung();
 		saveStadium();
+
+		stubFor(
+			WireMock.get(
+				urlEqualTo(BASEBALL_GET_API_URI + kia.getId())
+			).willReturn(aResponse().withStatus(200))
+		);
+
+		stubFor(
+			WireMock.get(
+				urlEqualTo(BASEBALL_GET_API_URI + samsung.getId())
+			).willReturn(aResponse().withStatus(200))
+		);
+
+		stubFor(
+			WireMock.get(
+				urlEqualTo(STADIUM_GET_API_URI + stadium.getId())
+			).willReturn(aResponse().withStatus(200))
+		);
 
 		gameManagementService.register(
 			kia.getId(), samsung.getId(), stadium.getId(),

--- a/ticketing/src/test/java/com/goti/ticketing/game/api/game/GameSchedulesSearchApiTest.java
+++ b/ticketing/src/test/java/com/goti/ticketing/game/api/game/GameSchedulesSearchApiTest.java
@@ -28,7 +28,7 @@ import java.util.Map;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 

--- a/ticketing/src/test/java/com/goti/ticketing/game/service/GameManagementServiceTest.java
+++ b/ticketing/src/test/java/com/goti/ticketing/game/service/GameManagementServiceTest.java
@@ -14,6 +14,8 @@ import com.goti.stadium.repository.BaseballTeamRepository;
 
 import com.goti.stadium.repository.StadiumRepository;
 
+import com.goti.ticketing.infra.api.StadiumClient;
+
 import lombok.extern.slf4j.Slf4j;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -21,7 +23,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
@@ -45,6 +49,9 @@ public class GameManagementServiceTest {
 
 	@Autowired
 	StadiumRepository stadiumRepository;
+
+	@MockitoBean
+	private StadiumClient stadiumClient;
 
 	BaseballTeamEntity homeTeam;
 	BaseballTeamEntity awayTeam;

--- a/ticketing/src/test/java/com/goti/ticketing/game/service/GameScheduleSearchServiceTest.java
+++ b/ticketing/src/test/java/com/goti/ticketing/game/service/GameScheduleSearchServiceTest.java
@@ -12,12 +12,15 @@ import com.goti.ticketing.game.service.application.GameScheduleSearchService;
 import com.goti.stadium.repository.BaseballTeamRepository;
 import com.goti.stadium.repository.StadiumRepository;
 
+import com.goti.ticketing.infra.api.StadiumClient;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
@@ -44,6 +47,9 @@ public class GameScheduleSearchServiceTest {
 
 	@Autowired
 	StadiumRepository stadiumRepository;
+
+	@MockitoBean
+	private StadiumClient stadiumClient;
 
 	private BaseballTeamEntity kia;
 	private BaseballTeamEntity samsung;

--- a/ticketing/src/test/resources/application-test.yml
+++ b/ticketing/src/test/resources/application-test.yml
@@ -25,3 +25,7 @@ spring:
     import:
       - application-integration.yml
       - optional:file:.env.test[.properties]
+infra:
+  api:
+    endpoints:
+      stadium: ${STADIUM_API_URL:http://localhost:8080}


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#236 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
야구게임일정 생성 시 야구구단 및 야구구장 서비스 의존 제거 및 내부 API 호출 로직 추가 (Stadium 내부 API 데이터 요청 및 반환 로직 추가)
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- SocialApiClient(kakao, naver, google ApiClient) 생성자 인자 RestClient -> RestClient.Builder 수정
- ApiEndpointProperties 추가 및 application.yml(in api module) 정의
- 야구구단(팀) 상세 조회 API(/api/v1/baseball-teams/{teamId} 추가 및 BaseballTeamController API 일괄 Operation 추가 (description...)
- 야구구장 상세 조회 API(/api/v1/stadiums/{stadiumId}) 추가 및 Swagger Operation(description API 설명 및 정의) 추가
- 야구구단(팀) 상세 조회 API 테스트 코드 추가
- 야구구장 상세 조회 API 테스트 코드 추가
- StadiumApiClient 추가 (Stadium 모듈 내부 API 호출 restClient 모듈)
- 기존 GameManagementService: 구장 및 구단 서비스 의존 참조 제거 -> StadiumApiClient 내부 API 호출로직으로 수정
- 내부 API 통신으로 -> BaseRestClient 생성자 오버로딩 (baseUrl null -> 기존 SocialApiClient 등 수정 최소화)
- restClient.Builder baseUrl 추가
<br/>