### PR TITLE
[FIX] SecurityConfig 멤버 권한 허용 경로 분리

### DIFF
--- a/ticketing/src/main/java/com/goti/ticketing/seat/controller/GameSeatStatusController.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/controller/GameSeatStatusController.java
@@ -23,7 +23,7 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "Game Seat Status", description = "경기별 좌석 상태 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/games")
+@RequestMapping("/api/v1/game-seats")
 public class GameSeatStatusController {
 	private final SeatStatusService seatStatusService;
 

--- a/user/src/main/java/com/goti/user/config/jwt/JwtAuthenticationFilter.java
+++ b/user/src/main/java/com/goti/user/config/jwt/JwtAuthenticationFilter.java
@@ -1,6 +1,6 @@
 package com.goti.user.config.jwt;
 
-import com.goti.user.config.security.SecurityConfig;
+import static com.goti.user.constants.SecurityPathConstants.*;
 
 import com.goti.constants.messages.ErrorCode;
 
@@ -41,7 +41,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 		String requestURI = request.getRequestURI();
 
-		boolean isPublic = Arrays.stream(SecurityConfig.PERMIT_PUBLIC_PATH)
+		boolean isPublic = Arrays.stream(PUBLIC_URLS)
 			.anyMatch(pattern -> matches(pattern, requestURI));
 
 		if (isPublic) {

--- a/user/src/main/java/com/goti/user/config/security/SecurityConfig.java
+++ b/user/src/main/java/com/goti/user/config/security/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.goti.user.config.security;
 
+import static com.goti.user.constants.SecurityPathConstants.*;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -29,34 +31,6 @@ public class SecurityConfig {
 	private final JwtAuthenticationEntryPoint entryPoint;
 	private final JwtAccessDeniedHandler accessDeniedHandler;
 
-	public static final String[] PERMIT_PUBLIC_PATH = {
-		"/api/v1/auth/**",
-		"/api/v1/stadiums/**",
-		"/api/v1/resales/histories/**",
-		"/api/v1/baseball-teams/**",
-		"/api/v1/games/**",
-		"/api/v1/seats/bulk",
-		"/api/v1/stadium-seats/seat-sections",
-		"/api/v1/stadium-seats/seat-grades",
-		"/actuator/**",
-		"/swagger-ui/**",
-		"/v3/api-docs/**",
-	};
-
-	public static final String[] PERMIT_MEMBER_PATH = {
-		"/api/v1/resales/listings/**",
-		"/api/v1/resales/holds/**",
-		"/api/v1/resales/orders/**",
-		"/api/v1/resales/payments/**",
-		"/api/v1/orders/**",
-		"/api/v1/payments/**",
-		"/api/v1/seat-reservations/**",
-		"/api/v1/seats/seat-sections/**",
-		"/api/v1/stadium-seats/stadiums/**",
-		"/api/v1/tickets/**",
-		"/api/v1/game-seats/**",
-	};
-
 	@Bean
 	public PasswordEncoder passwordEncoder() {
 		return new BCryptPasswordEncoder();
@@ -79,8 +53,8 @@ public class SecurityConfig {
 					.accessDeniedHandler(accessDeniedHandler)
 			).authorizeHttpRequests(
 				auth -> auth
-					.requestMatchers(PERMIT_PUBLIC_PATH).permitAll()
-					.requestMatchers(PERMIT_MEMBER_PATH).hasRole("MEMBER")
+					.requestMatchers(PUBLIC_URLS).permitAll()
+					.requestMatchers(MEMBER_URLS).hasRole("MEMBER")
 					.anyRequest().authenticated()
 			).addFilterBefore(
 				jwtAuthenticationFilter,

--- a/user/src/main/java/com/goti/user/config/security/SecurityConfig.java
+++ b/user/src/main/java/com/goti/user/config/security/SecurityConfig.java
@@ -32,12 +32,15 @@ public class SecurityConfig {
 	public static final String[] PERMIT_PUBLIC_PATH = {
 		"/api/v1/auth/**",
 		"/api/v1/stadiums/**",
-		"/api/v1/games/**",
 		"/api/v1/resales/histories/**",
 		"/api/v1/baseball-teams/**",
+		"/api/v1/games/**",
+		"/api/v1/seats/bulk",
+		"/api/v1/stadium-seats/seat-sections",
+		"/api/v1/stadium-seats/seat-grades",
 		"/actuator/**",
 		"/swagger-ui/**",
-		"/v3/api-docs/**"
+		"/v3/api-docs/**",
 	};
 
 	public static final String[] PERMIT_MEMBER_PATH = {
@@ -45,7 +48,13 @@ public class SecurityConfig {
 		"/api/v1/resales/holds/**",
 		"/api/v1/resales/orders/**",
 		"/api/v1/resales/payments/**",
-		"/api/v1/orders/**"
+		"/api/v1/orders/**",
+		"/api/v1/payments/**",
+		"/api/v1/seat-reservations/**",
+		"/api/v1/seats/seat-sections/**",
+		"/api/v1/stadium-seats/stadiums/**",
+		"/api/v1/tickets/**",
+		"/api/v1/game-seats/**",
 	};
 
 	@Bean

--- a/user/src/main/java/com/goti/user/constants/SecurityPathConstants.java
+++ b/user/src/main/java/com/goti/user/constants/SecurityPathConstants.java
@@ -1,0 +1,36 @@
+package com.goti.user.constants;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class SecurityPathConstants {
+
+	public static final String[] PUBLIC_URLS = {
+		"/api/v1/auth/**",
+		"/api/v1/stadiums/**",
+		"/api/v1/resales/histories/**",
+		"/api/v1/baseball-teams/**",
+		"/api/v1/games/**",
+		"/api/v1/seats/bulk",
+		"/api/v1/stadium-seats/seat-sections",
+		"/api/v1/stadium-seats/seat-grades",
+		"/actuator/**",
+		"/swagger-ui/**",
+		"/v3/api-docs/**",
+	};
+
+	public static final String[] MEMBER_URLS = {
+		"/api/v1/resales/listings/**",
+		"/api/v1/resales/holds/**",
+		"/api/v1/resales/orders/**",
+		"/api/v1/resales/payments/**",
+		"/api/v1/orders/**",
+		"/api/v1/payments/**",
+		"/api/v1/seat-reservations/**",
+		"/api/v1/seats/seat-sections/**",
+		"/api/v1/stadium-seats/stadiums/**",
+		"/api/v1/tickets/**",
+		"/api/v1/game-seats/**"
+	};
+}


### PR DESCRIPTION
SecurityConfig 멤버 권한 허용 경로 분리

<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#249 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
SecurityConfig 멤버 권한 허용 경로 분리
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
> SecurityConfig 멤버 권한 허용 경로 분리
> 관리자용 API -> PERMIT_PUBLIC_PATH
> 맴버용 API -> PERMIT_MEMBER_PATH

> GameSeatStatusController prefix 변경

<br/>