### PR TITLE
[FEAT] 토큰 재발급 서비스 로직 구현

### DIFF
--- a/common/src/main/java/com/goti/constants/messages/ErrorCode.java
+++ b/common/src/main/java/com/goti/constants/messages/ErrorCode.java
@@ -52,6 +52,7 @@ public enum ErrorCode {
 	AUTH_INVALID(HttpStatus.UNAUTHORIZED, "올바르지 않은 인증 정보입니다."),
 	AUTH_ACCESS_EXPIRED(HttpStatus.UNAUTHORIZED, "엑세스 토큰이 만료되었습니다."),
 	AUTH_SIGNUP_EXPIRED(HttpStatus.GONE, "회원가입 유효 시간이 만료되었습니다. 다시 소셜 로그인을 진행해주세요."),
+	AUTH_REFRESH_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다. 재로그인이 필요합니다."),
 	AUTH_CODE_NOT_FOUND(HttpStatus.UNAUTHORIZED, "인증 시간이 만료되었거나 해당 휴대전화번호로 인증번호 전송 이력이 없습니다."),
 	AUTH_CODE_INVALID(HttpStatus.UNAUTHORIZED, "인증 코드가 일치하지 않습니다."),
 

--- a/user/src/main/java/com/goti/user/config/jwt/JwtTokenProvider.java
+++ b/user/src/main/java/com/goti/user/config/jwt/JwtTokenProvider.java
@@ -124,6 +124,10 @@ public class JwtTokenProvider {
 		return getClaims(token).getId();
 	}
 
+	public String extractSubject(String token) {
+		return getClaims(token).getSubject();
+	}
+
 	private Claims getClaims(String token) {
 		return Jwts.parser()
 			.verifyWith(jwtProperties.secretKey())

--- a/user/src/main/java/com/goti/user/repository/MemberRepository.java
+++ b/user/src/main/java/com/goti/user/repository/MemberRepository.java
@@ -1,5 +1,7 @@
 package com.goti.user.repository;
 
+import com.goti.constants.messages.ErrorCode;
+import com.goti.exception.CustomException;
 import com.goti.user.domain.entity.user.MemberEntity;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,4 +15,9 @@ public interface MemberRepository extends JpaRepository<MemberEntity, UUID> {
 
 	Optional<MemberEntity> findByMobile(String mobile);
 
+	default MemberEntity findByIdOrThrow(UUID memberId) {
+		return findById(memberId).orElseThrow(
+			() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND)
+		);
+	}
 }

--- a/user/src/main/java/com/goti/user/service/auth/application/SocialAuthService.java
+++ b/user/src/main/java/com/goti/user/service/auth/application/SocialAuthService.java
@@ -91,10 +91,7 @@ public class SocialAuthService {
 				return new CustomException(ErrorCode.MEMBER_NOT_FOUND);
 			}
 		);
-		String accessToken = createToken(member, TokenType.ACCESS);
-		String refreshToken = createToken(member, TokenType.REFRESH);
-		saveRefreshTokenJti(member.getId(), refreshToken);
-		return Pair.of(accessToken, refreshToken);
+		return authService.issueTokens(member);
 	}
 
 	public Pair<String, String> signup(
@@ -110,15 +107,17 @@ public class SocialAuthService {
 		MemberEntity member = getOrCreateMember(name, mobile, gender, birthDate);
 
 		createSocialProvider(member, verifiedSocialInfo);
-
-		String accessToken = createToken(member, TokenType.ACCESS);
-		String refreshToken = createToken(member, TokenType.REFRESH);
-		saveRefreshTokenJti(member.getId(), refreshToken);
-		return Pair.of(accessToken, refreshToken);
+		return authService.issueTokens(member);
 	}
 
 	public void sendSignupSmsCode(String socialVerifyToken, String mobile) {
 		authService.sendSmsCode(socialVerifyToken, mobile);
+	}
+
+	public Pair<String, String> reissueToken(String refreshToken) {
+		UUID memberId = authService.identifyByToken(refreshToken);
+		MemberEntity member = memberService.getById(memberId);
+		return authService.issueTokens(member);
 	}
 
 	private void validateState(OAuthProvider provider, String state) {
@@ -190,20 +189,6 @@ public class SocialAuthService {
 				}
 			}
 		);
-	}
-
-	private String createToken(MemberEntity member, TokenType tokenType) {
-		return jwtTokenProvider.create(
-			member.getId(),
-			member.getMobile(),
-			member.getRole(),
-			tokenType
-		);
-	}
-
-	private void saveRefreshTokenJti(UUID memberId, String token) {
-		String refreshJti = jwtTokenProvider.extractJti(token);
-		redisCache.set(RedisKey.REFRESH_TOKEN, memberId, refreshJti);
 	}
 
 

--- a/user/src/main/java/com/goti/user/service/domain/auth/AuthService.java
+++ b/user/src/main/java/com/goti/user/service/domain/auth/AuthService.java
@@ -1,7 +1,16 @@
 package com.goti.user.service.domain.auth;
 
+import com.goti.user.domain.entity.user.MemberEntity;
+import org.springframework.data.util.Pair;
+
+import java.util.UUID;
+
 public interface AuthService {
 	void sendSmsCode(String socialVerifyToken, String mobile);
 
 	void verifySmsCode(String mobile, String authCode);
+
+	UUID identifyByToken(String token);
+
+	Pair<String, String> issueTokens(MemberEntity member);
 }

--- a/user/src/main/java/com/goti/user/service/domain/auth/AuthServiceImpl.java
+++ b/user/src/main/java/com/goti/user/service/domain/auth/AuthServiceImpl.java
@@ -1,5 +1,6 @@
 package com.goti.user.service.domain.auth;
 
+import com.goti.global.validation.Preconditions;
 import com.goti.user.config.jwt.JwtTokenProvider;
 import com.goti.constants.messages.ErrorCode;
 import com.goti.exception.CustomException;
@@ -8,11 +9,17 @@ import com.goti.infra.cache.RedisCache;
 import com.goti.infra.constants.redis.RedisKey;
 import com.goti.infra.sms.SmsProvider;
 
+import com.goti.user.constants.TokenType;
+import com.goti.user.domain.entity.user.MemberEntity;
+import org.springframework.data.util.Pair;
+
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import java.security.SecureRandom;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +28,7 @@ public class AuthServiceImpl implements AuthService {
 	private final JwtTokenProvider jwtTokenProvider;
 	private final SmsProvider smsProvider;
 	private final RedisCache redisCache;
+
 	private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
 	@Override
@@ -44,6 +52,41 @@ public class AuthServiceImpl implements AuthService {
 			throw new CustomException(ErrorCode.AUTH_CODE_NOT_FOUND);
 	}
 
+	@Override
+	public UUID identifyByToken(String token) {
+		UUID memberId = parseMemberId(token);
+		validateJti(token, memberId);
+		return memberId;
+	}
+
+	@Override
+	public Pair<String, String> issueTokens(MemberEntity member) {
+		deleteCachedToken(member.getId());
+		String accessToken = createToken(member, TokenType.ACCESS);
+		String refreshToken = createToken(member, TokenType.REFRESH);
+		saveTokenJti(member.getId(), refreshToken);
+		return Pair.of(accessToken, refreshToken);
+	}
+
+	private void saveTokenJti(UUID memberId, String token) {
+		String jti = jwtTokenProvider.extractJti(token);
+		redisCache.set(RedisKey.REFRESH_TOKEN, memberId, jti);
+	}
+
+	private String createToken(MemberEntity member, TokenType tokenType) {
+		return jwtTokenProvider.create(
+			member.getId(),
+			member.getMobile(),
+			member.getRole(),
+			tokenType
+		);
+	}
+
+	private UUID parseMemberId(String token) {
+		jwtTokenProvider.validateToken(token);
+		return UUID.fromString(jwtTokenProvider.extractSubject(token));
+	}
+
 	private String createAuthCode() {
 		int code = SECURE_RANDOM.nextInt(900000) + 100000;
 		return String.valueOf(code);
@@ -60,6 +103,31 @@ public class AuthServiceImpl implements AuthService {
 		if (cachedCode == null)
 			throw new CustomException(ErrorCode.AUTH_CODE_NOT_FOUND);
 		return cachedCode;
+	}
+
+	private void validateJti(String token, UUID memberId) {
+		String cachedJti = redisCache.get(
+			RedisKey.REFRESH_TOKEN.getKey(memberId),
+			String.class
+		);
+
+		Preconditions.validate(
+			StringUtils.hasText(cachedJti),
+			ErrorCode.AUTH_REFRESH_EXPIRED
+		);
+
+		String requestedJti = jwtTokenProvider.extractJti(token);
+
+		Preconditions.validate(
+			cachedJti.equals(requestedJti),
+			ErrorCode.AUTH_INVALID
+		);
+	}
+
+	private void deleteCachedToken(UUID memberId) {
+		redisCache.delete(
+			RedisKey.REFRESH_TOKEN.getKey(memberId)
+		);
 	}
 
 }

--- a/user/src/main/java/com/goti/user/service/domain/user/MemberService.java
+++ b/user/src/main/java/com/goti/user/service/domain/user/MemberService.java
@@ -5,6 +5,7 @@ import com.goti.user.domain.entity.user.MemberEntity;
 
 import java.time.LocalDate;
 import java.util.Optional;
+import java.util.UUID;
 
 public interface MemberService {
 
@@ -12,4 +13,5 @@ public interface MemberService {
 
   Optional<MemberEntity> findByMobile(String mobile);
 
+	MemberEntity getById(UUID memberId);
 }

--- a/user/src/main/java/com/goti/user/service/domain/user/MemberServiceImpl.java
+++ b/user/src/main/java/com/goti/user/service/domain/user/MemberServiceImpl.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.Optional;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -31,5 +32,10 @@ public class MemberServiceImpl implements MemberService {
 	@Override
 	public Optional<MemberEntity> findByMobile(String mobile) {
 		return memberRepository.findByMobile(mobile);
+	}
+
+	@Override
+	public MemberEntity getById(UUID memberId) {
+		return memberRepository.findByIdOrThrow(memberId);
 	}
 }


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#239 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
- ErrorCode AUTH_REFRESH_EXPIRED (토큰 (Refresh) 만료 ErrorCode 추가)
- findByIdOrThrow 추가 (In MemberRepository)
- subject 추출 (MemberId 값 = Jwt - subject) Method 추가 (In JwtTokenProvider)
- MemberService -> getById(Override) Method 추가
- AuthService -> IssueTokens 추가 및 기존 SocialAuthService(application Service) 에서의 signup, login createToken(access, refresh) 로직 IssueTokens 로 이관(호출하여 응답)
- 토큰재발급 로직 추가 (SocialAuthService(applicationService) + AuthService(domainService))
- IssueTokens 생성 시 초기 token delete 로직 실행 -> refresh 토큰 등 재발급 시 기존 토큰 삭제 로직 통합으로 적용
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->


<br/>