### PR TITLE
[FEAT] 가격 정책 조회 로직 구현

### DIFF
--- a/ticketing/src/main/java/com/goti/ticketing/pricing/controller/TicketPricingPolicyController.java
+++ b/ticketing/src/main/java/com/goti/ticketing/pricing/controller/TicketPricingPolicyController.java
@@ -5,6 +5,8 @@ import static com.goti.global.api.ApiSuccessResponse.*;
 import java.util.UUID;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -14,7 +16,9 @@ import org.springframework.web.bind.annotation.RestController;
 import com.goti.global.api.ApiSuccessResponse;
 import com.goti.ticketing.pricing.dto.request.TicketPricingPolicyCreateRequest;
 import com.goti.ticketing.pricing.dto.response.TicketPricingPolicyCreateResponse;
+import com.goti.ticketing.pricing.dto.response.TicketPricingPolicyResponse;
 import com.goti.ticketing.pricing.service.domain.TicketPricingPolicyService;
+import com.goti.ticketing.pricing.service.domain.command.TicketPriceCreateCommand;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -30,7 +34,7 @@ public class TicketPricingPolicyController {
 
 	@Operation(
 		summary = "가격 정책 생성",
-		description = "관리자가 가격 정책과 티켓 가격 상세를 함께 생성하는 API"
+		description = "가격 정책과 티켓 가격 상세 생성 API"
 	)
 	@PostMapping
 	public ResponseEntity<ApiSuccessResponse<TicketPricingPolicyCreateResponse>> create(
@@ -43,7 +47,7 @@ public class TicketPricingPolicyController {
 			request.policyStartAt(),
 			request.policyEndAt(),
 			request.prices().stream()
-				.map(price -> new TicketPricingPolicyService.TicketPriceCreateParam(
+				.map(price -> new TicketPriceCreateCommand(
 					price.gradeId(),
 					price.ticketType(),
 					price.dayType(),
@@ -53,5 +57,17 @@ public class TicketPricingPolicyController {
 				.toList()
 		);
 		return wrap(response);
+	}
+
+	@Operation(
+		summary = "가격 정책 조회",
+		description = "가격 정책과 티켓 가격 조회 API"
+	)
+	@GetMapping
+	public ResponseEntity<ApiSuccessResponse<TicketPricingPolicyResponse>> get(
+		@PathVariable UUID teamId,
+		@AuthenticationPrincipal(expression = "id") UUID memberId
+	) {
+		return wrap(ticketPricingPolicyService.get(teamId, memberId));
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/pricing/controller/TicketPricingPolicyController.java
+++ b/ticketing/src/main/java/com/goti/ticketing/pricing/controller/TicketPricingPolicyController.java
@@ -34,7 +34,7 @@ public class TicketPricingPolicyController {
 
 	@Operation(
 		summary = "가격 정책 생성",
-		description = "가격 정책과 티켓 가격 상세 생성 API"
+		description = "가격 정책 및 티켓 가격 상세 생성 API"
 	)
 	@PostMapping
 	public ResponseEntity<ApiSuccessResponse<TicketPricingPolicyCreateResponse>> create(
@@ -61,7 +61,7 @@ public class TicketPricingPolicyController {
 
 	@Operation(
 		summary = "가격 정책 조회",
-		description = "가격 정책과 티켓 가격 조회 API"
+		description = "가격 정책 및 티켓 가격 조회 API"
 	)
 	@GetMapping
 	public ResponseEntity<ApiSuccessResponse<TicketPricingPolicyResponse>> get(

--- a/ticketing/src/main/java/com/goti/ticketing/pricing/dto/response/TicketPriceResponse.java
+++ b/ticketing/src/main/java/com/goti/ticketing/pricing/dto/response/TicketPriceResponse.java
@@ -1,0 +1,41 @@
+package com.goti.ticketing.pricing.dto.response;
+
+import com.goti.ticketing.constants.TicketPricingDayType;
+import com.goti.ticketing.constants.TicketPricingMatchType;
+import com.goti.ticketing.constants.TicketType;
+import com.goti.ticketing.domain.entity.pricing.TicketPriceEntity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+
+public record TicketPriceResponse(
+	@Schema(description = "티켓 가격 ID", example = "33333333-3333-3333-3333-333333333333")
+	UUID priceId,
+
+	@Schema(description = "좌석 등급 ID", example = "22222222-2222-2222-2222-222222222222")
+	UUID gradeId,
+
+	@Schema(description = "권종", example = "ADULT")
+	TicketType ticketType,
+
+	@Schema(description = "요일 유형", example = "WEEKDAY")
+	TicketPricingDayType dayType,
+
+	@Schema(description = "매치 유형", example = "REGULAR")
+	TicketPricingMatchType matchType,
+
+	@Schema(description = "가격", example = "15000")
+	Integer price
+) {
+	public static TicketPriceResponse from(TicketPriceEntity ticketPrice) {
+		return new TicketPriceResponse(
+			ticketPrice.getId(),
+			ticketPrice.getGrade().getId(),
+			ticketPrice.getTicketType(),
+			ticketPrice.getDayType(),
+			ticketPrice.getMatchType(),
+			ticketPrice.getPrice()
+		);
+	}
+}

--- a/ticketing/src/main/java/com/goti/ticketing/pricing/dto/response/TicketPricingPolicyResponse.java
+++ b/ticketing/src/main/java/com/goti/ticketing/pricing/dto/response/TicketPricingPolicyResponse.java
@@ -46,35 +46,4 @@ public record TicketPricingPolicyResponse(
 				.toList()
 		);
 	}
-
-	public record TicketPriceResponse(
-		@Schema(description = "티켓 가격 ID", example = "33333333-3333-3333-3333-333333333333")
-		UUID priceId,
-
-		@Schema(description = "좌석 등급 ID", example = "22222222-2222-2222-2222-222222222222")
-		UUID gradeId,
-
-		@Schema(description = "권종", example = "ADULT")
-		TicketType ticketType,
-
-		@Schema(description = "요일 유형", example = "WEEKDAY")
-		TicketPricingDayType dayType,
-
-		@Schema(description = "매치 유형", example = "REGULAR")
-		TicketPricingMatchType matchType,
-
-		@Schema(description = "가격", example = "15000")
-		Integer price
-	) {
-		public static TicketPriceResponse from(TicketPriceEntity ticketPrice) {
-			return new TicketPriceResponse(
-				ticketPrice.getId(),
-				ticketPrice.getGrade().getId(),
-				ticketPrice.getTicketType(),
-				ticketPrice.getDayType(),
-				ticketPrice.getMatchType(),
-				ticketPrice.getPrice()
-			);
-		}
-	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/pricing/repository/TicketPriceRepository.java
+++ b/ticketing/src/main/java/com/goti/ticketing/pricing/repository/TicketPriceRepository.java
@@ -1,5 +1,6 @@
 package com.goti.ticketing.pricing.repository;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +10,5 @@ import com.goti.ticketing.domain.entity.pricing.TicketPriceEntity;
 
 @Repository
 public interface TicketPriceRepository extends JpaRepository<TicketPriceEntity, UUID>, TicketPriceRepositoryCustom {
+	List<TicketPriceEntity> findAllByPolicyId(UUID policyId);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/pricing/repository/TicketPricingPolicyRepository.java
+++ b/ticketing/src/main/java/com/goti/ticketing/pricing/repository/TicketPricingPolicyRepository.java
@@ -1,12 +1,23 @@
 package com.goti.ticketing.pricing.repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.goti.ticketing.domain.entity.pricing.TicketPricingPolicyEntity;
 
 @Repository
 public interface TicketPricingPolicyRepository extends JpaRepository<TicketPricingPolicyEntity, UUID> {
+	@Query("""
+		SELECT tpp
+			FROM TicketPricingPolicyEntity tpp
+		WHERE tpp.teamId = :teamId
+		  AND tpp.isActive = true
+		ORDER BY tpp.policyStartAt DESC
+	""")
+	Optional<TicketPricingPolicyEntity> findLatestActivePolicy(@Param("teamId") UUID teamId);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/pricing/service/domain/TicketPricingPolicyService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/pricing/service/domain/TicketPricingPolicyService.java
@@ -4,25 +4,17 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
-import com.goti.ticketing.constants.TicketPricingDayType;
-import com.goti.ticketing.constants.TicketPricingMatchType;
-import com.goti.ticketing.constants.TicketType;
 import com.goti.ticketing.pricing.dto.response.TicketPricingPolicyCreateResponse;
+import com.goti.ticketing.pricing.dto.response.TicketPricingPolicyResponse;
+import com.goti.ticketing.pricing.service.domain.command.TicketPriceCreateCommand;
 
 public interface TicketPricingPolicyService {
 	TicketPricingPolicyCreateResponse create(
 		UUID teamId,
 		LocalDate policyStartAt,
 		LocalDate policyEndAt,
-		List<TicketPriceCreateParam> prices
+		List<TicketPriceCreateCommand> prices
 	);
 
-	record TicketPriceCreateParam(
-		UUID gradeId,
-		TicketType ticketType,
-		TicketPricingDayType dayType,
-		TicketPricingMatchType matchType,
-		Integer price
-	) {
-	}
+	TicketPricingPolicyResponse get(UUID teamId, UUID memberId);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/pricing/service/domain/TicketPricingPolicyServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/pricing/service/domain/TicketPricingPolicyServiceImpl.java
@@ -9,6 +9,8 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import com.goti.exception.CustomException;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,7 +54,7 @@ public class TicketPricingPolicyServiceImpl implements TicketPricingPolicyServic
 		ticketPricingPolicyRepository.save(policy);
 
 		Map<UUID, SeatGradeEntity> gradesById = getGrades(ticketPriceRequest);
-		validateDuplicateticketPrice(ticketPriceRequest);
+		validateDuplicateTicketPrice(ticketPriceRequest);
 
 		List<TicketPriceEntity> ticketPrices = ticketPriceRequest.stream()
 			.map(price -> TicketPriceEntity.create(
@@ -79,7 +81,7 @@ public class TicketPricingPolicyServiceImpl implements TicketPricingPolicyServic
 
 		TicketPricingPolicyEntity policy = ticketPricingPolicyRepository
 			.findLatestActivePolicy(teamId)
-			.orElseThrow(() -> new com.goti.exception.CustomException(ErrorCode.TICKET_PRICING_POLICY_NOT_FOUND));
+			.orElseThrow(() -> new CustomException(ErrorCode.TICKET_PRICING_POLICY_NOT_FOUND));
 
 		List<TicketPriceEntity> prices = ticketPriceRepository.findAllByPolicyId(policy.getId());
 
@@ -102,7 +104,7 @@ public class TicketPricingPolicyServiceImpl implements TicketPricingPolicyServic
 			.collect(Collectors.toMap(SeatGradeEntity::getId, Function.identity()));
 	}
 
-	private void validateDuplicateticketPrice(
+	private void validateDuplicateTicketPrice(
 		List<TicketPriceCreateCommand> ticketPriceRequest
 	) {
 		Set<TicketPriceCondition> uniqueConditions = new HashSet<>();

--- a/ticketing/src/main/java/com/goti/ticketing/pricing/service/domain/TicketPricingPolicyServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/pricing/service/domain/TicketPricingPolicyServiceImpl.java
@@ -20,8 +20,10 @@ import com.goti.ticketing.domain.entity.pricing.TicketPricingPolicyEntity;
 import com.goti.ticketing.domain.entity.seat.SeatGradeEntity;
 import com.goti.global.validation.Preconditions;
 import com.goti.ticketing.pricing.dto.response.TicketPricingPolicyCreateResponse;
+import com.goti.ticketing.pricing.dto.response.TicketPricingPolicyResponse;
 import com.goti.ticketing.pricing.repository.TicketPriceRepository;
 import com.goti.ticketing.pricing.repository.TicketPricingPolicyRepository;
+import com.goti.ticketing.pricing.service.domain.command.TicketPriceCreateCommand;
 import com.goti.ticketing.seat.repository.SeatGradeRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -39,7 +41,7 @@ public class TicketPricingPolicyServiceImpl implements TicketPricingPolicyServic
 		UUID teamId,
 		LocalDate policyStartAt,
 		LocalDate policyEndAt,
-		List<TicketPriceCreateParam> ticketPriceRequest
+		List<TicketPriceCreateCommand> ticketPriceRequest
 	) {
 		TicketPricingPolicyEntity policy = TicketPricingPolicyEntity.create(
 			teamId,
@@ -67,9 +69,26 @@ public class TicketPricingPolicyServiceImpl implements TicketPricingPolicyServic
 		return TicketPricingPolicyCreateResponse.from(policy, ticketPrices);
 	}
 
-	private Map<UUID, SeatGradeEntity> getGrades(List<TicketPriceCreateParam> ticketPriceRequest) {
+	@Override
+	@Transactional(readOnly = true)
+	public TicketPricingPolicyResponse get(UUID teamId, UUID memberId) {
+		Preconditions.validate(
+			memberId != null,
+			ErrorCode.AUTH_INVALID
+		);
+
+		TicketPricingPolicyEntity policy = ticketPricingPolicyRepository
+			.findLatestActivePolicy(teamId)
+			.orElseThrow(() -> new com.goti.exception.CustomException(ErrorCode.TICKET_PRICING_POLICY_NOT_FOUND));
+
+		List<TicketPriceEntity> prices = ticketPriceRepository.findAllByPolicyId(policy.getId());
+
+		return TicketPricingPolicyResponse.from(policy, prices);
+	}
+
+	private Map<UUID, SeatGradeEntity> getGrades(List<TicketPriceCreateCommand> ticketPriceRequest) {
 		List<UUID> gradeIds = ticketPriceRequest.stream()
-			.map(TicketPriceCreateParam::gradeId)
+			.map(TicketPriceCreateCommand::gradeId)
 			.distinct()
 			.toList();
 
@@ -84,11 +103,11 @@ public class TicketPricingPolicyServiceImpl implements TicketPricingPolicyServic
 	}
 
 	private void validateDuplicateticketPrice(
-		List<TicketPriceCreateParam> ticketPriceRequest
+		List<TicketPriceCreateCommand> ticketPriceRequest
 	) {
 		Set<TicketPriceCondition> uniqueConditions = new HashSet<>();
 
-		for (TicketPriceCreateParam price : ticketPriceRequest) {
+		for (TicketPriceCreateCommand price : ticketPriceRequest) {
 			Preconditions.validate(
 				uniqueConditions.add(
 					new TicketPriceCondition(

--- a/ticketing/src/main/java/com/goti/ticketing/pricing/service/domain/command/TicketPriceCreateCommand.java
+++ b/ticketing/src/main/java/com/goti/ticketing/pricing/service/domain/command/TicketPriceCreateCommand.java
@@ -1,0 +1,16 @@
+package com.goti.ticketing.pricing.service.domain.command;
+
+import java.util.UUID;
+
+import com.goti.ticketing.constants.TicketPricingDayType;
+import com.goti.ticketing.constants.TicketPricingMatchType;
+import com.goti.ticketing.constants.TicketType;
+
+public record TicketPriceCreateCommand(
+	UUID gradeId,
+	TicketType ticketType,
+	TicketPricingDayType dayType,
+	TicketPricingMatchType matchType,
+	Integer price
+) {
+}

--- a/user/src/main/java/com/goti/user/constants/SecurityPathConstants.java
+++ b/user/src/main/java/com/goti/user/constants/SecurityPathConstants.java
@@ -17,7 +17,7 @@ public final class SecurityPathConstants {
 		"/api/v1/stadium-seats/seat-grades",
 		"/actuator/**",
 		"/swagger-ui/**",
-		"/v3/api-docs/**",
+		"/v3/api-docs/**"
 	};
 
 	public static final String[] MEMBER_URLS = {
@@ -31,6 +31,7 @@ public final class SecurityPathConstants {
 		"/api/v1/seats/seat-sections/**",
 		"/api/v1/stadium-seats/stadiums/**",
 		"/api/v1/tickets/**",
-		"/api/v1/game-seats/**"
+		"/api/v1/game-seats/**",
+		"/api/v1/teams/**"
 	};
 }


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#145 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
팀별 활성 티켓 가격 정책과 좌석 등급별 가격 정보 조회 기능 추가
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
> GET /api/v1/teams/{teamId}/ticket-pricing-policies 가격 정책 조회 API 추가
활성 상태인 최신 가격 정책 조회하도록 repository 로직 추가
가격 정책 조회 시 해당 정책에 연결된 티켓 가격 목록 함께 반환하도록 서비스 로직 구현
가격 정책 조회 응답에 정책 정보와 가격 상세 목록 매핑

> 맨 앞 두 커밋 `feat:`으로 작성해야했는데 `refactor:`로 적어버렸습니다ㅠ `feat`으로 봐주세요!
<br/>