### PR TITLE
[TEST] 로그인(verify 이후 및 회원가입(signup) 후) 소셜인증 서비스 로직 및 reIssueToken 서비스 로직 테스트 구현

### DIFF
--- a/user/src/main/java/com/goti/user/service/domain/auth/AuthServiceImpl.java
+++ b/user/src/main/java/com/goti/user/service/domain/auth/AuthServiceImpl.java
@@ -61,7 +61,7 @@ public class AuthServiceImpl implements AuthService {
 
 	@Override
 	public Pair<String, String> issueTokens(MemberEntity member) {
-		deleteCachedToken(member.getId());
+		deleteCachedTokenId(member.getId());
 		String accessToken = createToken(member, TokenType.ACCESS);
 		String refreshToken = createToken(member, TokenType.REFRESH);
 		saveTokenJti(member.getId(), refreshToken);
@@ -124,7 +124,7 @@ public class AuthServiceImpl implements AuthService {
 		);
 	}
 
-	private void deleteCachedToken(UUID memberId) {
+	private void deleteCachedTokenId(UUID memberId) {
 		redisCache.delete(
 			RedisKey.REFRESH_TOKEN.getKey(memberId)
 		);

--- a/user/src/test/java/com/goti/user/service/auth/application/AuthApplicationServiceTest.java
+++ b/user/src/test/java/com/goti/user/service/auth/application/AuthApplicationServiceTest.java
@@ -47,19 +47,7 @@ public class AuthApplicationServiceTest {
 	static final String KEY_SEPARATOR = ":";
 
 	@Test
-	@DisplayName("method: issueState()")
-	void state_발급_실패_카카오() {
-		assertThatThrownBy(
-			() -> socialAuthService.issueState(
-				OAuthProvider.KAKAO
-			)
-		).isInstanceOf(CustomException.class)
-			.hasMessageContaining("잘못된 요청입니다.");
-	}
-
-	// todo : socialVerifyToken 으로 로그인 성공 및 테스트
-	@Test
-	// @Disabled("개별적으로 테스트 시에만 @Disabled 주석 해제 후 테스트")
+	@Disabled("개별적으로 테스트 시에만 @Disabled 주석 해제 후 테스트")
 	@DisplayName("method: verify()")
 	void verify_성공_for_kakao_isRegistered_false_값_기대() {
 		// 브라우저 단에서 직접 호출 후 실제 받은 데이터 주입

--- a/user/src/test/java/com/goti/user/service/auth/application/AuthApplicationServiceTest.java
+++ b/user/src/test/java/com/goti/user/service/auth/application/AuthApplicationServiceTest.java
@@ -3,16 +3,20 @@ package com.goti.user.service.auth.application;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.goti.constants.Gender;
 import com.goti.constants.OAuthProvider;
 import com.goti.user.GotiUserApplication;
 
 import com.goti.infra.constants.redis.RedisKey;
 
+import com.goti.user.domain.entity.user.MemberEntity;
+import com.goti.user.dto.response.SocialVerifyResponse;
+
+import com.goti.user.repository.MemberRepository;
+
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -23,6 +27,8 @@ import com.goti.infra.api.dto.response.common.SocialStateResponse;
 import com.goti.infra.cache.RedisCache;
 
 import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDate;
 
 @Slf4j
 @ActiveProfiles("test")
@@ -35,37 +41,115 @@ public class AuthApplicationServiceTest {
 	@Autowired
 	RedisCache redisCache;
 
+	@Autowired
+	MemberRepository memberRepository;
+
 	static final String KEY_SEPARATOR = ":";
 
-	// todo : verify 테스트
+	@Test
+	@DisplayName("method: issueState()")
+	void state_발급_실패_카카오() {
+		assertThatThrownBy(
+			() -> socialAuthService.issueState(
+				OAuthProvider.KAKAO
+			)
+		).isInstanceOf(CustomException.class)
+			.hasMessageContaining("잘못된 요청입니다.");
+	}
+
 	// todo : socialVerifyToken 으로 로그인 성공 및 테스트
 	@Test
-	@Disabled("개별적으로 테스트 시에만 @Disabled 주석 해제 후 테스트")
-	@DisplayName("method : login()")
-	void 카카오_로그인_성공() {
-		// 브라우저에서 직접 호출하여 응답받은 code 직접 기입 후 테스트
-		String code = "";
+	// @Disabled("개별적으로 테스트 시에만 @Disabled 주석 해제 후 테스트")
+	@DisplayName("method: verify()")
+	void verify_성공_for_kakao_isRegistered_false_값_기대() {
+		// 브라우저 단에서 직접 호출 후 실제 받은 데이터 주입
+		String realAuthCode = "";
+		SocialVerifyResponse response = socialAuthService.verify(
+			OAuthProvider.KAKAO, realAuthCode, null
+		);
+
+		assertNotNull(response);
+		assertFalse(response.isRegistered());
+		log.info("response isRegistered :: {}", response.isRegistered());
 	}
 
 	@Test
-	@DisplayName("method : login()")
 	@Disabled("개별적으로 테스트 시에만 @Disabled 주석 해제 후 테스트")
-	void 네이버_로그인_성공() {
-		// 브라우저에서 직접 호출하여 응답받은 code
-		// springServer (issueState API) 에서 받은 state 직접 기입 후 테스트
-		String code = "";
-		String state = "";
+	@DisplayName("method: signup()")
+	void signup_성공_verify_이후_socialVerifyToken_발급_sms_code_생략() {
+		// 브라우저 단에서 직접 호출 후 실제 받은 데이터 주입
+		String realAuthCode = "";
+		String mobile = "01012341234";
+		String smsCode = "123456";
+		SocialVerifyResponse response = socialAuthService.verify(
+			OAuthProvider.KAKAO, realAuthCode, null
+		);
+		String verifyToken = response.socialVerifyToken();
+		redisCache.set(
+			RedisKey.SMS_AUTH_CODE,
+			mobile,
+			smsCode
+		);
+		var signResponse = socialAuthService.signup(
+			verifyToken,
+			"테스트회원",
+			mobile,
+			Gender.MALE,
+			LocalDate.of(2000, 02, 10),
+			smsCode
+		);
+		assertNotNull(signResponse);
+		log.info("signupResponse first : {}", signResponse.getFirst());
+
+		MemberEntity member = memberRepository.findByMobile(mobile).orElse(null);
+		assertNotNull(member);
+		log.info("member id : {}", member.getId());
 	}
 
 	@Test
-	@DisplayName("method : login()")
 	@Disabled("개별적으로 테스트 시에만 @Disabled 주석 해제 후 테스트")
-	void 구글_로그인_성공() {
-		// 브라우저에서 직접 호출하여 응답받은 code
-		// springServer (issueState API) 에서 받은 state 직접 기입 후 테스트
-		String code = "";
-		String state = "";
+	@DisplayName("method: login()")
+	void login_성공_verify_이후_test_db_signup_사전_회원저장_필수() {
+		// 브라우저 단에서 직접 호출 후 실제 받은 데이터 주입
+		String realAuthCode = "";
+		SocialVerifyResponse verifyResponse = socialAuthService.verify(
+			OAuthProvider.KAKAO, realAuthCode, null
+		);
+		log.info("response isRegistered : {}", verifyResponse.isRegistered());
+
+		String verifyToken = verifyResponse.socialVerifyToken();
+		var loginResponse = socialAuthService.login(verifyToken);
+		assertNotNull(loginResponse);
+		log.info("accessToken : {}", loginResponse.getFirst());
 	}
+
+	@Test
+	@Disabled("개별적으로 테스트 시에만 @Disabled 주석 해제 후 테스트")
+	@DisplayName("Method : reIssueToken()")
+	void reIssueToken_성공_로그인_이후_accessToken_refreshToken_재발급() {
+		// 브라우저 단에서 직접 호출 후 실제 받은 데이터 주입
+		String realAuthCode = "";
+		SocialVerifyResponse verifyResponse = socialAuthService.verify(
+			OAuthProvider.KAKAO, realAuthCode, null
+		);
+		log.info("response isRegistered : {}", verifyResponse.isRegistered());
+
+		String verifyToken = verifyResponse.socialVerifyToken();
+		var loginResponse = socialAuthService.login(verifyToken);
+		String firstAccessToken = loginResponse.getFirst();
+		String firstRefreshToken = loginResponse.getSecond();
+		var reIssueResponse = socialAuthService.reissueToken(firstRefreshToken);
+		assertNotNull(reIssueResponse);
+		log.info("firstAccessToken : {}", firstAccessToken);
+		log.info("firstRefreshToken : {}", firstRefreshToken);
+		String reIssuedAccessToken = reIssueResponse.getFirst();
+		String reIssuedRefreshToken = reIssueResponse.getSecond();
+		assertNotEquals(firstAccessToken, reIssuedAccessToken);
+		assertNotEquals(firstRefreshToken, reIssuedRefreshToken);
+		log.info("reIssuedAccessToken : {}", reIssuedAccessToken);
+		log.info("reIssuedRefreshToken : {}", reIssuedRefreshToken);
+	}
+
 
 	@Test
 	@DisplayName("method : issueState()")
@@ -90,4 +174,5 @@ public class AuthApplicationServiceTest {
 		).isInstanceOf(CustomException.class)
 			.hasMessageContaining(ErrorCode.BAD_REQUEST.getMessage());
 	}
+
 }


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#268 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
소셜로그인 통합 서비스 로직 테스트 코드 추가 및 구현
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- verify (Disabled) 테스트 코드 추가(실제 authCode 발급 후 진행) 
- signup(Disabled) 테스트 코드 추가(실제 authCode 발급 후 진행)
- login (Disabled) 테스트 코드 추가(실제 authCode 발급 후 진행)
- 위 세 테스트코드 진행 시 test Database 데이터 유지 필수 (create-drop -> update(or create) 및 위 테스트 개별적 진행시에만 Disabled 주석처리 후 실행
- 변경된 파일
  - AuthApplicationServiceTest (verify, login, signup, reissue 테스트)
  - AuthService(메소드명 변경: deleteCachedToken -> deleteCachedTokenId)
<br/>