### PR TITLE
[REFACTOR] 경기 일정 조회 시 (Search) 응답 데이터 추가 및 수정

### DIFF
--- a/stadium/src/main/java/com/goti/stadium/domain/entity/team/BaseballTeamEntity.java
+++ b/stadium/src/main/java/com/goti/stadium/domain/entity/team/BaseballTeamEntity.java
@@ -34,6 +34,9 @@ public class BaseballTeamEntity extends ModificationTimestampEntity {
 	private TeamCode teamCode;
 
 	@Column(nullable = false)
+	private String displayName;
+
+	@Column(nullable = false)
 	private String teamName;
 
 	@Column(nullable = false)
@@ -77,6 +80,7 @@ public class BaseballTeamEntity extends ModificationTimestampEntity {
 
 	private BaseballTeamEntity(
 		TeamCode teamCode,
+		String displayName,
 		String teamName,
 		String teamNameEn,
 		String sponsor,
@@ -93,6 +97,7 @@ public class BaseballTeamEntity extends ModificationTimestampEntity {
 		String logoUrl
 	) {
 		this.teamCode = teamCode;
+		this.displayName = displayName;
 		this.teamName = teamName;
 		this.teamNameEn = teamNameEn;
 		this.sponsor = sponsor;
@@ -111,6 +116,7 @@ public class BaseballTeamEntity extends ModificationTimestampEntity {
 
 	public static BaseballTeamEntity create(
 		TeamCode teamCode,
+		String displayName,
 		String teamName,
 		String teamNameEn,
 		String sponsor,
@@ -128,13 +134,13 @@ public class BaseballTeamEntity extends ModificationTimestampEntity {
 	) {
 
 		validate(
-			teamCode, teamName, teamNameEn, sponsor,
+			teamCode, displayName, teamName, teamNameEn, sponsor,
 			homeGround, foundedYear, officeAddress, zipCode,
 			siteAddress, owner, generalManager, director
 		);
 
 		return new BaseballTeamEntity(
-			teamCode, teamName, teamNameEn, sponsor, homeGround, foundedYear,
+			teamCode, displayName, teamName, teamNameEn, sponsor, homeGround, foundedYear,
 			officeAddress, zipCode, siteAddress, owner,
 			ownerAgency, ceo, generalManager, director, logoUrl
 		);
@@ -143,6 +149,7 @@ public class BaseballTeamEntity extends ModificationTimestampEntity {
 
 	private static void validate(
 		TeamCode teamCode,
+		String displayName,
 		String teamName,
 		String teamNameEn,
 		String sponsor,
@@ -159,6 +166,11 @@ public class BaseballTeamEntity extends ModificationTimestampEntity {
 		Preconditions.domainValidate(
 			teamCode != null,
 			"구단(팀)코드는 비어있을 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			StringUtils.hasText(displayName),
+			"구단(팀) 표시명은 비어있을 수 없습니다."
 		);
 
 		Preconditions.domainValidate(

--- a/stadium/src/main/java/com/goti/stadium/dto/request/BaseballTeamCreateRequest.java
+++ b/stadium/src/main/java/com/goti/stadium/dto/request/BaseballTeamCreateRequest.java
@@ -15,6 +15,10 @@ public record BaseballTeamCreateRequest(
 	@NotNull(message = "구단(팀) 코드는 필수 항목입니다.")
 	TeamCode teamCode,
 
+	@Schema(description = "구단명(표시명)", example = "SS")
+	@NotNull(message = "구단명(표시명)은 필수 항목입니다.")
+	String displayName,
+
 	@Schema(description = "구단명", example = "삼성라이온즈")
 	@NotBlank(message = "구단(팀)이름은 필수 항목입니다.")
 	String teamName,
@@ -76,7 +80,7 @@ public record BaseballTeamCreateRequest(
 
 	public BaseballTeamCreateCommand toCommand() {
 		return new BaseballTeamCreateCommand(
-			teamCode, teamName, teamNameEn, sponsor, homeGround,
+			teamCode, displayName, teamName, teamNameEn, sponsor, homeGround,
 			foundedYear, officeAddress, zipCode, siteAddress,
 			owner, ownerAgency, ceo, generalManager, director, logoUrl
 		);

--- a/stadium/src/main/java/com/goti/stadium/dto/request/BaseballTeamCreateRequest.java
+++ b/stadium/src/main/java/com/goti/stadium/dto/request/BaseballTeamCreateRequest.java
@@ -16,7 +16,7 @@ public record BaseballTeamCreateRequest(
 	TeamCode teamCode,
 
 	@Schema(description = "구단명(표시명)", example = "SS")
-	@NotNull(message = "구단명(표시명)은 필수 항목입니다.")
+	@NotBlank(message = "구단명(표시명)은 필수 항목입니다.")
 	String displayName,
 
 	@Schema(description = "구단명", example = "삼성라이온즈")

--- a/stadium/src/main/java/com/goti/stadium/service/domain/baseballteam/BaseballTeamServiceImpl.java
+++ b/stadium/src/main/java/com/goti/stadium/service/domain/baseballteam/BaseballTeamServiceImpl.java
@@ -25,6 +25,7 @@ public class BaseballTeamServiceImpl implements BaseballTeamService {
 	public BaseballTeamCreateResponse create(BaseballTeamCreateCommand command) {
 		BaseballTeamEntity baseballTeam = BaseballTeamEntity.create(
 			command.teamCode(),
+			command.displayName(),
 			command.teamName(),
 			command.teamNameEn(),
 			command.sponsor(),

--- a/stadium/src/main/java/com/goti/stadium/service/domain/baseballteam/command/BaseballTeamCreateCommand.java
+++ b/stadium/src/main/java/com/goti/stadium/service/domain/baseballteam/command/BaseballTeamCreateCommand.java
@@ -4,6 +4,7 @@ import com.goti.stadium.constants.TeamCode;
 
 public record BaseballTeamCreateCommand(
 	TeamCode teamCode,
+	String displayName,
 	String teamName,
 	String teamNameEn,
 	String sponsor,

--- a/stadium/src/test/java/com/goti/stadium/api/BaseballTeamCreateApiTest.java
+++ b/stadium/src/test/java/com/goti/stadium/api/BaseballTeamCreateApiTest.java
@@ -40,6 +40,7 @@ public class BaseballTeamCreateApiTest {
 		BaseballTeamCreateRequest request =
 			new BaseballTeamCreateRequest(
 				TeamCode.SS,
+				"삼성",
 				"삼성라이온즈",
 				"Samsung Lions",
 				"삼성",

--- a/stadium/src/test/java/com/goti/stadium/api/BaseballTeamDetailApiTest.java
+++ b/stadium/src/test/java/com/goti/stadium/api/BaseballTeamDetailApiTest.java
@@ -1,4 +1,5 @@
 package com.goti.stadium.api;
+
 import com.goti.stadium.GotiStadiumApplication;
 
 import com.goti.stadium.constants.TeamCode;
@@ -71,6 +72,7 @@ public class BaseballTeamDetailApiTest {
 		BaseballTeamCreateRequest request =
 			new BaseballTeamCreateRequest(
 				TeamCode.SS,
+				"삼성",
 				"삼성라이온즈",
 				"Samsung Lions",
 				"삼성",

--- a/stadium/src/test/java/com/goti/stadium/api/HomeStadiumCreateApiTest.java
+++ b/stadium/src/test/java/com/goti/stadium/api/HomeStadiumCreateApiTest.java
@@ -91,6 +91,7 @@ public class HomeStadiumCreateApiTest {
 	private void saveBaseballTeam() {
 		baseballTeam = BaseballTeamEntity.create(
 			TeamCode.SS,
+			"삼성",
 			"삼성라이온즈",
 			"Samsung Lions",
 			"삼성",

--- a/stadium/src/test/java/com/goti/stadium/service/application/HomeStadiumManagementServiceTest.java
+++ b/stadium/src/test/java/com/goti/stadium/service/application/HomeStadiumManagementServiceTest.java
@@ -72,6 +72,7 @@ public class HomeStadiumManagementServiceTest {
 	private void saveBaseballTeam() {
 		baseballTeam = BaseballTeamEntity.create(
 			TeamCode.SS,
+			"삼성",
 			"삼성라이온즈",
 			"Samsung Lions",
 			"삼성",

--- a/stadium/src/test/java/com/goti/stadium/service/domain/baseballteam/BaseballTeamServiceTest.java
+++ b/stadium/src/test/java/com/goti/stadium/service/domain/baseballteam/BaseballTeamServiceTest.java
@@ -32,6 +32,7 @@ public class BaseballTeamServiceTest {
 	void setup() {
 		baseballTeamCreateRequest = new BaseballTeamCreateRequest(
 			TeamCode.SS,
+			"삼성",
 			"삼성라이온즈",
 			"Samsung Lions",
 			"삼성",

--- a/stadium/src/test/java/stadium/BaseballTeamEntityTest.java
+++ b/stadium/src/test/java/stadium/BaseballTeamEntityTest.java
@@ -30,6 +30,7 @@ public class BaseballTeamEntityTest {
 	void 구단_생성_성공() {
 		baseballTeam = BaseballTeamEntity.create(
 			TeamCode.SS,
+			"삼성",
 			"삼성라이온즈",
 			"Samsung Lions",
 			"삼성",
@@ -54,6 +55,7 @@ public class BaseballTeamEntityTest {
 		assertThatThrownBy(
 			() -> BaseballTeamEntity.create(
 				null,
+				"삼성",
 				"삼성라이온즈",
 				"Samsung Lions",
 				"삼성",
@@ -76,6 +78,35 @@ public class BaseballTeamEntityTest {
 			}
 		);
 	}
+	@NullAndEmptySource
+	@ParameterizedTest
+	void 구단_생성_실패_displayName_null_또는_공백(String displayName) {
+		assertThatThrownBy(
+			() -> BaseballTeamEntity.create(
+				TeamCode.SS,
+				displayName,
+				"삼성라이온즈",
+				"Samsung Lions",
+				"삼성",
+				"대구",
+				1982,
+				"대구광역시 수성구 야구전설로 1",
+				"42250",
+				"https://www.samsunglions.com/",
+				"홍길동",
+				"삼성그룹",
+				"이재용",
+				"이종열",
+				"박진만",
+				"https://image.url/logo.png"
+			)
+		).isInstanceOfSatisfying(
+			FieldValidationException.class, ex -> {
+				log.info("BaseballTeamEntity:Field-displayName invalid ErrorMessage : {}", ex.getMessage());
+				assertEquals("도메인 필드 오류 : 구단(팀) 표시명은 비어있을 수 없습니다.", ex.getMessage());
+			}
+		);
+	}
 
 	@NullAndEmptySource
 	@ParameterizedTest
@@ -83,6 +114,7 @@ public class BaseballTeamEntityTest {
 		assertThatThrownBy(
 			() -> BaseballTeamEntity.create(
 				TeamCode.SS,
+				"삼성",
 				teamName,
 				"Samsung Lions",
 				"삼성",
@@ -112,6 +144,7 @@ public class BaseballTeamEntityTest {
 		assertThatThrownBy(
 			() -> BaseballTeamEntity.create(
 				TeamCode.SS,
+				"삼성",
 				"삼성라이온즈",
 				teamNameEn,
 				"삼성",
@@ -141,6 +174,7 @@ public class BaseballTeamEntityTest {
 		assertThatThrownBy(
 			() -> BaseballTeamEntity.create(
 				TeamCode.SS,
+				"삼성",
 				"삼성라이온즈",
 				"Samsung Lions",
 				sponsor,
@@ -170,6 +204,7 @@ public class BaseballTeamEntityTest {
 		assertThatThrownBy(
 			() -> BaseballTeamEntity.create(
 				TeamCode.SS,
+				"삼성",
 				"삼성라이온즈",
 				"Samsung Lions",
 				"삼성",
@@ -200,6 +235,7 @@ public class BaseballTeamEntityTest {
 		assertThatThrownBy(() ->
 			BaseballTeamEntity.create(
 				TeamCode.SS,
+				"삼성",
 				"삼성라이온즈",
 				"Samsung Lions",
 				"삼성",
@@ -227,6 +263,7 @@ public class BaseballTeamEntityTest {
 		assertThatThrownBy(
 			() -> BaseballTeamEntity.create(
 				TeamCode.SS,
+				"삼성",
 				"삼성라이온즈",
 				"Samsung Lions",
 				"삼성",
@@ -256,6 +293,7 @@ public class BaseballTeamEntityTest {
 		assertThatThrownBy(
 			() -> BaseballTeamEntity.create(
 				TeamCode.SS,
+				"삼성",
 				"삼성라이온즈",
 				"Samsung Lions",
 				"삼성",
@@ -285,6 +323,7 @@ public class BaseballTeamEntityTest {
 		assertThatThrownBy(
 			() -> BaseballTeamEntity.create(
 				TeamCode.SS,
+				"삼성",
 				"삼성라이온즈",
 				"Samsung Lions",
 				"삼성",
@@ -314,6 +353,7 @@ public class BaseballTeamEntityTest {
 		assertThatThrownBy(
 			() -> BaseballTeamEntity.create(
 				TeamCode.SS,
+				"삼성",
 				"삼성라이온즈",
 				"Samsung Lions",
 				"삼성",
@@ -343,6 +383,7 @@ public class BaseballTeamEntityTest {
 		assertThatThrownBy(
 			() -> BaseballTeamEntity.create(
 				TeamCode.SS,
+				"삼성",
 				"삼성라이온즈",
 				"Samsung Lions",
 				"삼성",
@@ -372,6 +413,7 @@ public class BaseballTeamEntityTest {
 		assertThatThrownBy(
 			() -> BaseballTeamEntity.create(
 				TeamCode.SS,
+				"삼성",
 				"삼성라이온즈",
 				"Samsung Lions",
 				"삼성",

--- a/stadium/src/test/java/stadium/HomeStadiumEntityTest.java
+++ b/stadium/src/test/java/stadium/HomeStadiumEntityTest.java
@@ -96,6 +96,7 @@ public class HomeStadiumEntityTest {
 	private void createBaseballTeam() {
 		baseballTeam = BaseballTeamEntity.create(
 			TeamCode.SS,
+			"삼성",
 			"삼성라이온즈",
 			"Samsung Lions",
 			"삼성",

--- a/ticketing/src/main/java/com/goti/ticketing/game/dto/response/GameScheduleSearchResponse.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/dto/response/GameScheduleSearchResponse.java
@@ -8,6 +8,14 @@ import com.goti.ticketing.constants.LeagueType;
 
 import com.goti.ticketing.constants.TicketingStatus;
 
+import com.goti.ticketing.domain.entity.game.GameScheduleEntity;
+
+import com.goti.ticketing.domain.entity.game.GameStatusEntity;
+
+import com.goti.ticketing.domain.entity.game.GameTicketingStatusEntity;
+
+import com.querydsl.core.annotations.QueryProjection;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
@@ -34,6 +42,15 @@ public record GameScheduleSearchResponse(
 	@Schema(description = "경기장 ID", example = "770g0622-g41d-63e6-c938-668877662222")
 	UUID stadiumId,
 
+	@Schema(description = "홈 팀 표시명", example = "삼성")
+	String homeTeamDisplayName,
+
+	@Schema(description = "원정 팀 표시명", example = "KIA")
+	String awayTeamDisplayName,
+
+	@Schema(description = "구장 위치", example = "대구")
+	String stadiumLocation,
+
 	@Schema(description = "경기 진행 상태", example = "FINISHED")
 	GameStatus gameStatus,
 
@@ -46,10 +63,46 @@ public record GameScheduleSearchResponse(
 	@Schema(description = "경기 결과", example = "WIN")
 	GameResult gameResult,
 
-	@Schema(description = "티켓팅 상태", example = "AVAILABLE")
+	@Schema(description = "예매(티켓팅) 상태", example = "AVAILABLE")
 	TicketingStatus ticketingStatus,
 
-	@Schema(description = "티켓팅 오픈 일시 (yyyy-MM-dd HH:mm)", example = "2026-03-15 11:00")
+	@Schema(description = "예매(티켓팅) 오픈 일시 (yyyy-MM-dd HH:mm)", example = "2026-03-15 11:00")
 	@JsonFormat(pattern = "yyyy-MM-dd HH:mm")
-	LocalDateTime ticketingOpenedAt
-) {}
+	LocalDateTime ticketingOpenedAt,
+
+	@Schema(description = "예매(티켓팅) 마감 일시 (yyyy-MM-dd HH:mm)", example = "2026-03-27 19:00")
+	@JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+	LocalDateTime ticketingEndAt
+) {
+
+	@QueryProjection
+	public GameScheduleSearchResponse {}
+
+	public static GameScheduleSearchResponse of(
+		final GameScheduleEntity game,
+		final String homeTeamDisplayName,
+		final String awayTeamDisplayName,
+		final String stadiumLocation,
+		final GameStatusEntity status,
+		final GameTicketingStatusEntity ticketing
+	) {
+		return new GameScheduleSearchResponse(
+			game.getId(),
+			game.getStartAt(),
+			game.getLeagueType(),
+			game.getHomeTeamId(),
+			game.getAwayTeamId(),
+			game.getStadiumId(),
+			homeTeamDisplayName,
+			awayTeamDisplayName,
+			stadiumLocation,
+			status.getGameStatus(),
+			status.getHomeTeamScore(),
+			status.getAwayTeamScore(),
+			status.getGameResult(),
+			ticketing.getStatus(),
+			ticketing.getTicketingOpenedAt(),
+			ticketing.getTicketingEndAt()
+		);
+	}
+}

--- a/ticketing/src/main/java/com/goti/ticketing/game/repository/gameschedule/GameScheduleRepositoryCustom.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/repository/gameschedule/GameScheduleRepositoryCustom.java
@@ -1,7 +1,7 @@
 package com.goti.ticketing.game.repository.gameschedule;
 
-import com.goti.ticketing.domain.entity.game.GameScheduleEntity;
 import com.goti.ticketing.game.dto.request.GameScheduleSearchCondition;
+import com.goti.ticketing.game.dto.response.GameScheduleSearchResponse;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -15,7 +15,7 @@ public interface GameScheduleRepositoryCustom {
 		LocalDateTime startAt
 	);
 
-	List<GameScheduleEntity> searchSchedules(GameScheduleSearchCondition request);
+	List<GameScheduleSearchResponse> searchSchedules(GameScheduleSearchCondition request);
 
 
 }

--- a/ticketing/src/main/java/com/goti/ticketing/game/repository/gameschedule/GameScheduleRepositoryImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/repository/gameschedule/GameScheduleRepositoryImpl.java
@@ -1,10 +1,13 @@
 package com.goti.ticketing.game.repository.gameschedule;
 
-import com.goti.ticketing.domain.entity.game.GameScheduleEntity;
+import com.goti.stadium.domain.entity.stadium.QStadiumEntity;
+import com.goti.stadium.domain.entity.team.QBaseballTeamEntity;
 import com.goti.ticketing.domain.entity.game.QGameScheduleEntity;
 import com.goti.ticketing.domain.entity.game.QGameStatusEntity;
 import com.goti.ticketing.domain.entity.game.QGameTicketingStatusEntity;
 import com.goti.ticketing.game.dto.request.GameScheduleSearchCondition;
+import com.goti.ticketing.game.dto.response.GameScheduleSearchResponse;
+import com.goti.ticketing.game.dto.response.QGameScheduleSearchResponse;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -28,6 +31,8 @@ public class GameScheduleRepositoryImpl implements GameScheduleRepositoryCustom 
 	private final QGameScheduleEntity gameSchedule = gameScheduleEntity;
 	private final QGameStatusEntity gameStatus = QGameStatusEntity.gameStatusEntity;
 	private final QGameTicketingStatusEntity ticketingStatus = QGameTicketingStatusEntity.gameTicketingStatusEntity;
+
+
 	@Override
 	public boolean existsDuplicateSchedule(
 		UUID homeTeamId,
@@ -45,11 +50,39 @@ public class GameScheduleRepositoryImpl implements GameScheduleRepositoryCustom 
 	}
 
 	@Override
-	public List<GameScheduleEntity> searchSchedules(GameScheduleSearchCondition condition) {
+	public List<GameScheduleSearchResponse> searchSchedules(GameScheduleSearchCondition condition) {
+
+		QBaseballTeamEntity homeTeam = new QBaseballTeamEntity("homeTeam");
+		QBaseballTeamEntity awayTeam = new QBaseballTeamEntity("awayTeam");
+		QStadiumEntity stadium = QStadiumEntity.stadiumEntity;
+
 		return jpaQueryFactory
-			.selectFrom(gameSchedule)
-			.leftJoin(gameStatus).on(gameStatus.gameSchedule.eq(gameSchedule)).fetchJoin()
-			.leftJoin(ticketingStatus).on(ticketingStatus.gameSchedule.eq(gameSchedule)).fetchJoin()
+			.select(
+				new QGameScheduleSearchResponse(
+					gameSchedule.id,
+					gameSchedule.startAt,
+					gameSchedule.leagueType,
+					gameSchedule.homeTeamId,
+					gameSchedule.awayTeamId,
+					gameSchedule.stadiumId,
+					homeTeam.displayName,
+					awayTeam.displayName,
+					stadium.location,
+					gameStatus.gameStatus,
+					gameStatus.homeTeamScore,
+					gameStatus.awayTeamScore,
+					gameStatus.gameResult,
+					ticketingStatus.status,
+					ticketingStatus.ticketingOpenedAt,
+					ticketingStatus.ticketingEndAt
+				)
+			)
+			.from(gameSchedule)
+			.leftJoin(gameStatus).on(gameStatus.gameSchedule.eq(gameSchedule))
+			.leftJoin(ticketingStatus).on(ticketingStatus.gameSchedule.eq(gameSchedule))
+			.leftJoin(homeTeam).on(homeTeam.id.eq(gameSchedule.homeTeamId))
+			.leftJoin(awayTeam).on(awayTeam.id.eq(gameSchedule.awayTeamId))
+			.leftJoin(stadium).on(stadium.id.eq(gameSchedule.stadiumId))
 			.where(
 				teamIdEq(gameSchedule, condition.teamId()),
 				dateFilter(gameSchedule, condition)

--- a/ticketing/src/main/java/com/goti/ticketing/game/service/application/GameScheduleSearchService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/service/application/GameScheduleSearchService.java
@@ -1,6 +1,5 @@
 package com.goti.ticketing.game.service.application;
 
-import com.goti.ticketing.domain.entity.game.GameScheduleEntity;
 import com.goti.ticketing.game.dto.request.GameScheduleSearchCondition;
 import com.goti.ticketing.game.dto.response.GameScheduleSearchResponse;
 import com.goti.ticketing.game.repository.gameschedule.GameScheduleRepository;
@@ -19,27 +18,7 @@ public class GameScheduleSearchService {
 
 	@Transactional(readOnly = true)
 	public List<GameScheduleSearchResponse> searchSchedules(GameScheduleSearchCondition condition) {
-		List<GameScheduleEntity> schedules = gameScheduleRepository.searchSchedules(condition);
-
-		return schedules.stream().map(
-			this::toGameScheduleSearchResponse
-		).toList();
+		return gameScheduleRepository.searchSchedules(condition);
 	}
 
-	private GameScheduleSearchResponse toGameScheduleSearchResponse(GameScheduleEntity schedule) {
-		return new GameScheduleSearchResponse(
-			schedule.getId(),
-			schedule.getStartAt(),
-			schedule.getLeagueType(),
-			schedule.getHomeTeamId(),
-			schedule.getAwayTeamId(),
-			schedule.getStadiumId(),
-			schedule.getGameStatus().getGameStatus(),
-			schedule.getGameStatus().getHomeTeamScore(),
-			schedule.getGameStatus().getAwayTeamScore(),
-			schedule.getGameStatus().getGameResult(),
-			schedule.getTicketingStatus().getStatus(),
-			schedule.getTicketingStatus().getTicketingOpenedAt()
-		);
-	}
 }

--- a/ticketing/src/test/java/com/goti/ticketing/game/api/game/GameRegistrationTest.java
+++ b/ticketing/src/test/java/com/goti/ticketing/game/api/game/GameRegistrationTest.java
@@ -154,6 +154,7 @@ public class GameRegistrationTest {
 	void saveHomeTeam() {
 		homeTeam = BaseballTeamEntity.create(
 			TeamCode.KIA,
+			"KIA",
 			"KIA 타이거즈",
 			"KIA Tigers",
 			"기아",
@@ -175,6 +176,7 @@ public class GameRegistrationTest {
 	void saveAwayTeam() {
 		awayTeam = BaseballTeamEntity.create(
 			TeamCode.SS,
+			"삼성",
 			"삼성 라이온즈",
 			"Samsung Lions",
 			"삼성",

--- a/ticketing/src/test/java/com/goti/ticketing/game/api/game/GameSchedulesSearchApiTest.java
+++ b/ticketing/src/test/java/com/goti/ticketing/game/api/game/GameSchedulesSearchApiTest.java
@@ -21,6 +21,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
@@ -117,7 +118,7 @@ public class GameSchedulesSearchApiTest {
 			samsung.getId(), kia.getId(), stadium.getId(), secondGameDate, LeagueType.REGULAR
 		);
 
-		mockMvc.perform(
+		MvcResult result = mockMvc.perform(
 				get("/api/v1/games/schedules")
 					.with(csrf())
 					.param("year", String.valueOf(testYear))
@@ -126,7 +127,12 @@ public class GameSchedulesSearchApiTest {
 					.contentType(MediaType.APPLICATION_JSON)
 			)
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.data.length()").value(2));
+			.andExpect(
+				jsonPath("$.data.length()").value(2)
+			).andReturn();
+
+		String responseJson = result.getResponse().getContentAsString();
+		log.info("response : {}", responseJson);
 	}
 
 	private void saveSamsung() {

--- a/ticketing/src/test/java/com/goti/ticketing/game/api/game/GameSchedulesSearchApiTest.java
+++ b/ticketing/src/test/java/com/goti/ticketing/game/api/game/GameSchedulesSearchApiTest.java
@@ -132,6 +132,7 @@ public class GameSchedulesSearchApiTest {
 	private void saveSamsung() {
 		samsung = BaseballTeamEntity.create(
 			TeamCode.SS,
+			"삼성",
 			"삼성 라이온즈",
 			"Samsung Lions",
 			"삼성",
@@ -153,6 +154,7 @@ public class GameSchedulesSearchApiTest {
 	private void saveKia() {
 		kia = BaseballTeamEntity.create(
 			TeamCode.KIA,
+			"KIA",
 			"KIA 타이거즈",
 			"KIA Tigers",
 			"기아",

--- a/ticketing/src/test/java/com/goti/ticketing/game/service/GameManagementServiceTest.java
+++ b/ticketing/src/test/java/com/goti/ticketing/game/service/GameManagementServiceTest.java
@@ -102,6 +102,7 @@ public class GameManagementServiceTest {
 	void saveHomeTeam() {
 		homeTeam = BaseballTeamEntity.create(
 			TeamCode.KIA,
+			"KIA",
 			"KIA 타이거즈",
 			"KIA Tigers",
 			"기아",
@@ -123,6 +124,7 @@ public class GameManagementServiceTest {
 	void saveAwayTeam() {
 		awayTeam = BaseballTeamEntity.create(
 			TeamCode.SS,
+			"삼성",
 			"삼성 라이온즈",
 			"Samsung Lions",
 			"삼성",

--- a/ticketing/src/test/java/com/goti/ticketing/game/service/GameScheduleSearchServiceTest.java
+++ b/ticketing/src/test/java/com/goti/ticketing/game/service/GameScheduleSearchServiceTest.java
@@ -153,6 +153,7 @@ public class GameScheduleSearchServiceTest {
 	private void saveKia() {
 		kia = BaseballTeamEntity.create(
 			TeamCode.KIA,
+			"KIA",
 			"KIA 타이거즈",
 			"KIA Tigers",
 			"기아",
@@ -174,6 +175,7 @@ public class GameScheduleSearchServiceTest {
 	private void saveSamsung() {
 		samsung = BaseballTeamEntity.create(
 			TeamCode.SS,
+			"삼성",
 			"삼성 라이온즈",
 			"Samsung Lions",
 			"삼성",


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#256 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
경기 일정 조회(GameScheduleSearch) 시 응답 데이터 추가 및 수정 (화면기획에 맞춰 응답데이터 개선)
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- BaseballTeamEntity (야구구단(팀)) 엔티티 displayName 추가 (짧은 구단명 -> ex: 삼성, KIA, 한화, 두산, LG 등)
- displayName 추가로 인한 테스트코드 일괄 수정 (domain, service, api)
- 게임 일정 조회 응답 데이터 수정(stadiumName 제거)
- 게임 일정 조회 응답 데이터 추가(homeTeamDisplayName, awayTeamDisplayName, StadiumLocation, ticketingEndAt)
- 게임 일정 조회 응답 로직 및 쿼리 개선 (join 테이블 추가 및 select절 변경 : GameScheduleEntity -> GameScheduleSearchResponse (@QueryProjection 추가))
  - #258  이슈 PR 리베이스 이후 재커밋발생 -> #258 PR 은 무시하고 검토바랍니다!
  - 변경 파일
    - BaseballTeamEntity -> String displayName 추가 및 그에 대한 도메인 서비스 api 필드 추가에 대한 변경
    - BaseballTeamCreateRequest 필드 추가
    - GameScheduleSearchResponse 필드 추가
    - GameScheduleRepositoryCustom, GameScheduleRepositoryImpl
    - GameScheduleSearchService
  

<br/>