### PR TITLE
[FEAT] 주문 내역 조회 시 기간 필터링 기능 구현

### DIFF
--- a/common/src/main/java/com/goti/constants/messages/ErrorCode.java
+++ b/common/src/main/java/com/goti/constants/messages/ErrorCode.java
@@ -61,6 +61,10 @@ public enum ErrorCode {
 
 	ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 주문입니다."),
 	ORDER_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "주문자 정보를 찾을 수 없습니다."),
+	ORDER_HISTORY_PERIOD_DATE_REQUIRED(HttpStatus.BAD_REQUEST, "시작 날짜와 종료 날짜는 함께 요청되어야 합니다."),
+	ORDER_HISTORY_PERIOD_FILTER_CONFLICT(HttpStatus.BAD_REQUEST, "개월 조회와 직접 기간 조회는 함께 사용할 수 없습니다."),
+	ORDER_HISTORY_PERIOD_MONTHS_INVALID(HttpStatus.BAD_REQUEST, "조회 기간은 1개월, 3개월, 6개월만 허용됩니다."),
+	ORDER_HISTORY_PERIOD_INVALID_RANGE(HttpStatus.BAD_REQUEST, "시작 날짜는 종료 날짜보다 이후일 수 없습니다."),
 	ORDER_PAYMENT_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "결제 가능한 주문 상태가 아닙니다."),
 	PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 결제 정보입니다."),
 	PAYMENT_IDEMPOTENCY_KEY_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 사용된 결제 멱등 키입니다."),

--- a/ticketing/src/main/java/com/goti/ticketing/order/controller/OrderController.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/controller/OrderController.java
@@ -2,7 +2,6 @@ package com.goti.ticketing.order.controller;
 
 import static com.goti.global.api.ApiSuccessResponse.*;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -18,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.goti.global.api.ApiSuccessResponse;
 import com.goti.ticketing.order.dto.request.OrderCreateRequest;
+import com.goti.ticketing.order.dto.request.OrderPeriodFilterRequest;
 import com.goti.ticketing.order.dto.request.OrderPaymentConfirmRequest;
 import com.goti.ticketing.order.dto.response.OrderCreateResponse;
 import com.goti.ticketing.order.dto.response.OrderListResponse;
@@ -31,6 +31,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 
 @Tag(name = "Order", description = "주문 API")
 @RestController
@@ -60,11 +61,14 @@ public class OrderController {
 	@GetMapping
 	public ResponseEntity<ApiSuccessResponse<List<OrderListResponse>>> getMyOrders(
 		@AuthenticationPrincipal(expression = "id") UUID memberId,
-		@RequestParam(required = false) Integer months,
-		@RequestParam(required = false) LocalDate startDate,
-		@RequestParam(required = false) LocalDate endDate
+		@ParameterObject OrderPeriodFilterRequest request
 	) {
-		return wrap(orderService.getMyOrders(memberId, months, startDate, endDate));
+		return wrap(orderService.getMyOrders(
+			memberId,
+			request.months(),
+			request.startDate(),
+			request.endDate()
+		));
 	}
 
 	@Operation(

--- a/ticketing/src/main/java/com/goti/ticketing/order/controller/OrderController.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/controller/OrderController.java
@@ -2,6 +2,7 @@ package com.goti.ticketing.order.controller;
 
 import static com.goti.global.api.ApiSuccessResponse.*;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -58,9 +59,12 @@ public class OrderController {
 	)
 	@GetMapping
 	public ResponseEntity<ApiSuccessResponse<List<OrderListResponse>>> getMyOrders(
-		@AuthenticationPrincipal(expression = "id") UUID memberId
+		@AuthenticationPrincipal(expression = "id") UUID memberId,
+		@RequestParam(required = false) Integer months,
+		@RequestParam(required = false) LocalDate startDate,
+		@RequestParam(required = false) LocalDate endDate
 	) {
-		return wrap(orderService.getMyOrders(memberId));
+		return wrap(orderService.getMyOrders(memberId, months, startDate, endDate));
 	}
 
 	@Operation(

--- a/ticketing/src/main/java/com/goti/ticketing/order/dto/request/OrderPeriodFilterRequest.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/dto/request/OrderPeriodFilterRequest.java
@@ -1,0 +1,18 @@
+package com.goti.ticketing.order.dto.request;
+
+import java.time.LocalDate;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "주문 목록 기간 필터 요청")
+public record OrderPeriodFilterRequest(
+	@Schema(description = "기간 조회 (개월)", example = "3")
+	Integer months,
+
+	@Schema(description = "조회 시작 날짜", example = "2026-01-01")
+	LocalDate startDate,
+
+	@Schema(description = "조회 종료 날짜", example = "2026-03-31")
+	LocalDate endDate
+) {
+}

--- a/ticketing/src/main/java/com/goti/ticketing/order/repository/OrderRepository.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/repository/OrderRepository.java
@@ -13,6 +13,5 @@ import com.goti.ticketing.domain.entity.order.OrderEntity;
 @Repository
 public interface OrderRepository extends JpaRepository<OrderEntity, UUID>, OrderRepositoryCustom {
 	@EntityGraph(attributePaths = "gameSchedule")
-	List<OrderEntity> findAllByMemberIdOrderByCreatedAtDesc(UUID memberId);
 	Optional<OrderEntity> findByIdAndMemberId(UUID id, UUID memberId);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/order/repository/OrderRepository.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/repository/OrderRepository.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Repository;
 import com.goti.ticketing.domain.entity.order.OrderEntity;
 
 @Repository
-public interface OrderRepository extends JpaRepository<OrderEntity, UUID> {
+public interface OrderRepository extends JpaRepository<OrderEntity, UUID>, OrderRepositoryCustom {
 	@EntityGraph(attributePaths = "gameSchedule")
 	List<OrderEntity> findAllByMemberIdOrderByCreatedAtDesc(UUID memberId);
 	Optional<OrderEntity> findByIdAndMemberId(UUID id, UUID memberId);

--- a/ticketing/src/main/java/com/goti/ticketing/order/repository/OrderRepositoryCustom.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/repository/OrderRepositoryCustom.java
@@ -1,0 +1,16 @@
+package com.goti.ticketing.order.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import com.goti.ticketing.domain.entity.order.OrderEntity;
+
+public interface OrderRepositoryCustom {
+	List<OrderEntity> findMyOrders(
+		UUID memberId,
+		Integer months,
+		LocalDate startDate,
+		LocalDate endDate
+	);
+}

--- a/ticketing/src/main/java/com/goti/ticketing/order/repository/OrderRepositoryImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/repository/OrderRepositoryImpl.java
@@ -50,19 +50,24 @@ public class OrderRepositoryImpl implements OrderRepositoryCustom {
 	) {
 		if (startDate != null && endDate != null) {
 			return order.createdAt.between(
-				startDate.atStartOfDay().toInstant(ZoneOffset.UTC),
-				endDate.plusDays(1).atStartOfDay().minusNanos(1).toInstant(ZoneOffset.UTC)
+				toStartInstant(startDate),
+				toEndInstant(endDate)
 			);
 		}
 
 		if (months != null) {
-			Instant from = LocalDate.now()
-				.minusMonths(months)
-				.atStartOfDay()
-				.toInstant(ZoneOffset.UTC);
+			Instant from = toStartInstant(LocalDate.now().minusMonths(months));
 			return order.createdAt.goe(from);
 		}
 
 		return null;
+	}
+
+	private Instant toStartInstant(LocalDate date) {
+		return date.atStartOfDay().toInstant(ZoneOffset.UTC);
+	}
+
+	private Instant toEndInstant(LocalDate date) {
+		return date.plusDays(1).atStartOfDay().minusNanos(1).toInstant(ZoneOffset.UTC);
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/order/repository/OrderRepositoryImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/repository/OrderRepositoryImpl.java
@@ -1,0 +1,68 @@
+package com.goti.ticketing.order.repository;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Repository;
+
+import com.goti.ticketing.domain.entity.game.QGameScheduleEntity;
+import com.goti.ticketing.domain.entity.order.OrderEntity;
+import com.goti.ticketing.domain.entity.order.QOrderEntity;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderRepositoryImpl implements OrderRepositoryCustom {
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<OrderEntity> findMyOrders(
+		UUID memberId,
+		Integer months,
+		LocalDate startDate,
+		LocalDate endDate
+	) {
+		QOrderEntity order = QOrderEntity.orderEntity;
+		QGameScheduleEntity gameSchedule = QGameScheduleEntity.gameScheduleEntity;
+
+		return queryFactory
+			.selectFrom(order)
+			.join(order.gameSchedule, gameSchedule).fetchJoin()
+			.where(
+				order.memberId.eq(memberId),
+				dateCondition(order, months, startDate, endDate)
+			)
+			.orderBy(order.createdAt.desc())
+			.fetch();
+	}
+
+	private BooleanExpression dateCondition(
+		QOrderEntity order,
+		Integer months,
+		LocalDate startDate,
+		LocalDate endDate
+	) {
+		if (startDate != null && endDate != null) {
+			return order.createdAt.between(
+				startDate.atStartOfDay().toInstant(ZoneOffset.UTC),
+				endDate.plusDays(1).atStartOfDay().minusNanos(1).toInstant(ZoneOffset.UTC)
+			);
+		}
+
+		if (months != null) {
+			Instant from = LocalDate.now()
+				.minusMonths(months)
+				.atStartOfDay()
+				.toInstant(ZoneOffset.UTC);
+			return order.createdAt.goe(from);
+		}
+
+		return null;
+	}
+}

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/domain/OrderService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/domain/OrderService.java
@@ -1,5 +1,6 @@
 package com.goti.ticketing.order.service.domain;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -20,7 +21,12 @@ public interface OrderService {
 
 	void expire(OrderEntity order);
 
-	List<OrderListResponse> getMyOrders(UUID memberId);
+	List<OrderListResponse> getMyOrders(
+		UUID memberId,
+		Integer months,
+		LocalDate startDate,
+		LocalDate endDate
+	);
 
 	OrderPaymentInfoResponse getPaymentOrder(UUID orderId, UUID memberId);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/domain/OrderServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/domain/OrderServiceImpl.java
@@ -25,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class OrderServiceImpl implements OrderService {
 	private static final DateTimeFormatter ORDER_NUMBER_FORMATTER = DateTimeFormatter.ofPattern("yyMMdd");
+	private static final List<Integer> ALLOWED_MONTHS = List.of(1, 3, 6);
 
 	private final OrderRepository orderRepository;
 
@@ -71,6 +72,7 @@ public class OrderServiceImpl implements OrderService {
 			memberId != null,
 			ErrorCode.AUTH_INVALID
 		);
+		validatePeriodFilter(months, startDate, endDate);
 
 		return orderRepository.findMyOrders(memberId, months, startDate, endDate).stream()
 			.map(OrderListResponse::from)
@@ -95,6 +97,34 @@ public class OrderServiceImpl implements OrderService {
 		return "ORD" + "-" +
 			LocalDate.now().format(ORDER_NUMBER_FORMATTER) +
 			tsidSuffix.substring(tsidSuffix.length() - 6);
+	}
+
+	private void validatePeriodFilter(
+		Integer months,
+		LocalDate startDate,
+		LocalDate endDate
+	) {
+		Preconditions.validate(
+			(startDate == null) == (endDate == null),
+			ErrorCode.BAD_REQUEST,
+			"시작 날짜와 종료 날짜는 함께 요청되어야 합니다."
+		);
+
+		if (months != null) {
+			Preconditions.validate(
+				ALLOWED_MONTHS.contains(months),
+				ErrorCode.BAD_REQUEST,
+				"조회 기간은 1개월, 3개월, 6개월만 허용됩니다."
+			);
+		}
+
+		if (startDate != null && endDate != null) {
+			Preconditions.validate(
+				!startDate.isAfter(endDate),
+				ErrorCode.BAD_REQUEST,
+				"시작 날짜는 종료 날짜보다 이후일 수 없습니다."
+			);
+		}
 	}
 
 }

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/domain/OrderServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/domain/OrderServiceImpl.java
@@ -105,24 +105,26 @@ public class OrderServiceImpl implements OrderService {
 		LocalDate endDate
 	) {
 		Preconditions.validate(
+			months == null || (startDate == null && endDate == null),
+			ErrorCode.ORDER_HISTORY_PERIOD_FILTER_CONFLICT
+		);
+
+		Preconditions.validate(
 			(startDate == null) == (endDate == null),
-			ErrorCode.BAD_REQUEST,
-			"시작 날짜와 종료 날짜는 함께 요청되어야 합니다."
+			ErrorCode.ORDER_HISTORY_PERIOD_DATE_REQUIRED
 		);
 
 		if (months != null) {
 			Preconditions.validate(
 				ALLOWED_MONTHS.contains(months),
-				ErrorCode.BAD_REQUEST,
-				"조회 기간은 1개월, 3개월, 6개월만 허용됩니다."
+				ErrorCode.ORDER_HISTORY_PERIOD_MONTHS_INVALID
 			);
 		}
 
 		if (startDate != null && endDate != null) {
 			Preconditions.validate(
 				!startDate.isAfter(endDate),
-				ErrorCode.BAD_REQUEST,
-				"시작 날짜는 종료 날짜보다 이후일 수 없습니다."
+				ErrorCode.ORDER_HISTORY_PERIOD_INVALID_RANGE
 			);
 		}
 	}

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/domain/OrderServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/domain/OrderServiceImpl.java
@@ -61,13 +61,18 @@ public class OrderServiceImpl implements OrderService {
 
 	@Override
 	@Transactional(readOnly = true)
-	public List<OrderListResponse> getMyOrders(UUID memberId) {
+	public List<OrderListResponse> getMyOrders(
+		UUID memberId,
+		Integer months,
+		LocalDate startDate,
+		LocalDate endDate
+	) {
 		Preconditions.validate(
 			memberId != null,
 			ErrorCode.AUTH_INVALID
 		);
 
-		return orderRepository.findAllByMemberIdOrderByCreatedAtDesc(memberId).stream()
+		return orderRepository.findMyOrders(memberId, months, startDate, endDate).stream()
 			.map(OrderListResponse::from)
 			.toList();
 	}


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#284 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
주문 내역 조회 시 기간 필터링 기능 추가
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
> 주문 내역 조회 API에 기간 필터 query parameter 추가 : `months`, `startDate`, `endDate`
> 주문 내역 조회 repository를 QueryDSL 기반 custom repository로 확장
> 회원별 주문 목록 조회 시 기간 조건이 적용되도록 조회 로직 추가
> startDate, endDate가 모두 있을 경우 직접 기간 조회를 우선 적용하도록 구현

> 기간 필터 유효성 검증 추가
>> months 허용값 제한
>> startDate/endDate 동시 요청 검증
>> startDate > endDate 검증

<br/>