### PR TITLE
[FEAT] seat status 일괄 생성 로직 구현

### DIFF
--- a/ticketing/src/main/java/com/goti/ticketing/game/service/domain/GameScheduleService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/service/domain/GameScheduleService.java
@@ -15,4 +15,6 @@ public interface GameScheduleService {
 		LocalDateTime startAt,
 		LeagueType leagueType
 	);
+
+	GameScheduleEntity get(UUID gameId);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/game/service/domain/GameScheduleServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/service/domain/GameScheduleServiceImpl.java
@@ -3,6 +3,7 @@ package com.goti.ticketing.game.service.domain;
 import com.goti.ticketing.constants.LeagueType;
 import com.goti.constants.messages.ErrorCode;
 import com.goti.ticketing.domain.entity.game.GameScheduleEntity;
+import com.goti.exception.CustomException;
 
 import com.goti.ticketing.game.repository.gameschedule.GameScheduleRepository;
 
@@ -41,5 +42,12 @@ public class GameScheduleServiceImpl implements GameScheduleService {
 		);
 
 		return gameScheduleRepository.save(gameSchedule);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public GameScheduleEntity get(UUID gameId) {
+		return gameScheduleRepository.findById(gameId)
+			.orElseThrow(() -> new CustomException(ErrorCode.GAME_NOT_FOUND));
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/controller/GameSeatStatusController.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/controller/GameSeatStatusController.java
@@ -9,11 +9,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.goti.global.api.ApiSuccessResponse;
+import com.goti.ticketing.seat.dto.response.GameSeatStatusInitResponse;
 import com.goti.ticketing.seat.dto.response.GameSeatStatusResponse;
+import com.goti.ticketing.seat.service.application.GameSeatStatusInitService;
 import com.goti.ticketing.seat.service.domain.SeatStatusService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,6 +29,18 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v1/game-seats")
 public class GameSeatStatusController {
 	private final SeatStatusService seatStatusService;
+	private final GameSeatStatusInitService gameSeatStatusInitService;
+
+	@Operation(
+		summary = "경기 좌석 상태 초기화",
+		description = "해당 경기 구장의 모든 좌석에 대해 좌석 상태 AVAILABLE로 생성"
+	)
+	@PostMapping("/{gameId}/init")
+	public ResponseEntity<ApiSuccessResponse<GameSeatStatusInitResponse>> init(
+		@PathVariable UUID gameId
+	) {
+		return wrap(gameSeatStatusInitService.init(gameId));
+	}
 
 	@Operation(
 		summary = "경기별 좌석 상태 조회",

--- a/ticketing/src/main/java/com/goti/ticketing/seat/dto/response/GameSeatStatusInitResponse.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/dto/response/GameSeatStatusInitResponse.java
@@ -2,9 +2,15 @@ package com.goti.ticketing.seat.dto.response;
 
 import java.util.UUID;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "경기 좌석 상태 초기화 응답")
 public record GameSeatStatusInitResponse(
+	@Schema(description = "경기 ID", example = "11111111-1111-1111-1111-111111111111")
 	UUID gameId,
+	@Schema(description = "새로 생성된 좌석 상태 개수", example = "480")
 	int createdCount,
+	@Schema(description = "이미 존재해 생성하지 않고 건너뛴 좌석 상태 개수", example = "0")
 	int skippedCount
 ) {
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/dto/response/GameSeatStatusInitResponse.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/dto/response/GameSeatStatusInitResponse.java
@@ -1,0 +1,10 @@
+package com.goti.ticketing.seat.dto.response;
+
+import java.util.UUID;
+
+public record GameSeatStatusInitResponse(
+	UUID gameId,
+	int createdCount,
+	int skippedCount
+) {
+}

--- a/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatRepositoryCustom.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatRepositoryCustom.java
@@ -7,4 +7,6 @@ import com.goti.ticketing.domain.entity.seat.SeatEntity;
 
 public interface SeatRepositoryCustom {
 	List<SeatEntity> findAllBySection(UUID sectionId);
+
+	List<SeatEntity> findAllByStadiumId(UUID stadiumId);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatRepositoryImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatRepositoryImpl.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import org.springframework.stereotype.Repository;
 
 import com.goti.ticketing.domain.entity.seat.QSeatEntity;
+import com.goti.ticketing.domain.entity.seat.QSeatSectionEntity;
 import com.goti.ticketing.domain.entity.seat.SeatEntity;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -25,6 +26,19 @@ public class SeatRepositoryImpl implements SeatRepositoryCustom {
 			.join(seat.seatSection).fetchJoin()
 			.where(seat.seatSection.id.eq(sectionId))
 			.orderBy(seat.rowName.asc(), seat.seatNum.asc())
+			.fetch();
+	}
+
+	@Override
+	public List<SeatEntity> findAllByStadiumId(UUID stadiumId) {
+		QSeatEntity seat = QSeatEntity.seatEntity;
+		QSeatSectionEntity seatSection = QSeatSectionEntity.seatSectionEntity;
+
+		return queryFactory
+			.selectFrom(seat)
+			.join(seat.seatSection, seatSection).fetchJoin()
+			.where(seatSection.stadiumId.eq(stadiumId))
+			.orderBy(seat.id.asc())
 			.fetch();
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatStatusRepositoryCustom.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatStatusRepositoryCustom.java
@@ -7,4 +7,6 @@ import com.goti.ticketing.domain.entity.seat.SeatStatusEntity;
 
 public interface SeatStatusRepositoryCustom {
 	List<SeatStatusEntity> findAllByGameAndSeatIds(UUID gameId, List<UUID> seatIds);
+
+	List<UUID> findSeatIdsByGameId(UUID gameId);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatStatusRepositoryImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatStatusRepositoryImpl.java
@@ -31,4 +31,15 @@ public class SeatStatusRepositoryImpl implements SeatStatusRepositoryCustom {
 			)
 			.fetch();
 	}
+
+	@Override
+	public List<UUID> findSeatIdsByGameId(UUID gameId) {
+		QSeatStatusEntity seatStatus = QSeatStatusEntity.seatStatusEntity;
+
+		return queryFactory
+			.select(seatStatus.seat.id)
+			.from(seatStatus)
+			.where(seatStatus.game.id.eq(gameId))
+			.fetch();
+	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/application/GameSeatStatusInitService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/application/GameSeatStatusInitService.java
@@ -1,0 +1,51 @@
+package com.goti.ticketing.seat.service.application;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goti.constants.messages.ErrorCode;
+import com.goti.exception.CustomException;
+import com.goti.ticketing.domain.entity.game.GameScheduleEntity;
+import com.goti.ticketing.domain.entity.seat.SeatEntity;
+import com.goti.ticketing.domain.entity.seat.SeatStatusEntity;
+import com.goti.ticketing.game.repository.gameschedule.GameScheduleRepository;
+import com.goti.ticketing.seat.dto.response.GameSeatStatusInitResponse;
+import com.goti.ticketing.seat.repository.SeatRepository;
+import com.goti.ticketing.seat.repository.SeatStatusRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GameSeatStatusInitService {
+	private final GameScheduleRepository gameScheduleRepository;
+	private final SeatRepository seatRepository;
+	private final SeatStatusRepository seatStatusRepository;
+
+	@Transactional
+	public GameSeatStatusInitResponse init(UUID gameId) {
+		GameScheduleEntity game = gameScheduleRepository.findById(gameId)
+			.orElseThrow(() -> new CustomException(ErrorCode.GAME_NOT_FOUND));
+
+		List<SeatEntity> seats = seatRepository.findAllByStadiumId(game.getStadiumId());
+		Set<UUID> existingSeatIds = new HashSet<>(seatStatusRepository.findSeatIdsByGameId(gameId));
+
+		List<SeatStatusEntity> newSeatStatuses = seats.stream()
+			.filter(seat -> !existingSeatIds.contains(seat.getId()))
+			.map(seat -> SeatStatusEntity.create(game, seat))
+			.toList();
+
+		seatStatusRepository.saveAll(newSeatStatuses);
+
+		return new GameSeatStatusInitResponse(
+			gameId,
+			newSeatStatuses.size(),
+			seats.size() - newSeatStatuses.size()
+		);
+	}
+}

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/application/GameSeatStatusInitService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/application/GameSeatStatusInitService.java
@@ -1,6 +1,5 @@
 package com.goti.ticketing.seat.service.application;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -8,39 +7,29 @@ import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.goti.constants.messages.ErrorCode;
-import com.goti.exception.CustomException;
 import com.goti.ticketing.domain.entity.game.GameScheduleEntity;
 import com.goti.ticketing.domain.entity.seat.SeatEntity;
 import com.goti.ticketing.domain.entity.seat.SeatStatusEntity;
-import com.goti.ticketing.game.repository.gameschedule.GameScheduleRepository;
+import com.goti.ticketing.game.service.domain.GameScheduleService;
 import com.goti.ticketing.seat.dto.response.GameSeatStatusInitResponse;
-import com.goti.ticketing.seat.repository.SeatRepository;
-import com.goti.ticketing.seat.repository.SeatStatusRepository;
+import com.goti.ticketing.seat.service.domain.SeatService;
+import com.goti.ticketing.seat.service.domain.SeatStatusService;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class GameSeatStatusInitService {
-	private final GameScheduleRepository gameScheduleRepository;
-	private final SeatRepository seatRepository;
-	private final SeatStatusRepository seatStatusRepository;
+	private final GameScheduleService gameScheduleService;
+	private final SeatService seatService;
+	private final SeatStatusService seatStatusService;
 
 	@Transactional
 	public GameSeatStatusInitResponse init(UUID gameId) {
-		GameScheduleEntity game = gameScheduleRepository.findById(gameId)
-			.orElseThrow(() -> new CustomException(ErrorCode.GAME_NOT_FOUND));
-
-		List<SeatEntity> seats = seatRepository.findAllByStadiumId(game.getStadiumId());
-		Set<UUID> existingSeatIds = new HashSet<>(seatStatusRepository.findSeatIdsByGameId(gameId));
-
-		List<SeatStatusEntity> newSeatStatuses = seats.stream()
-			.filter(seat -> !existingSeatIds.contains(seat.getId()))
-			.map(seat -> SeatStatusEntity.create(game, seat))
-			.toList();
-
-		seatStatusRepository.saveAll(newSeatStatuses);
+		GameScheduleEntity game = gameScheduleService.get(gameId);
+		List<SeatEntity> seats = seatService.getByStadiumId(game.getStadiumId());
+		Set<UUID> existingSeatIds = seatStatusService.getSeatIdsByGameId(gameId);
+		List<SeatStatusEntity> newSeatStatuses = seatStatusService.createMissingStatuses(game, seats, existingSeatIds);
 
 		return new GameSeatStatusInitResponse(
 			gameId,

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatService.java
@@ -3,6 +3,7 @@ package com.goti.ticketing.seat.service.domain;
 import java.util.List;
 import java.util.UUID;
 
+import com.goti.ticketing.domain.entity.seat.SeatEntity;
 import com.goti.ticketing.seat.dto.response.BulkCreateSeatsResponse;
 import com.goti.ticketing.seat.dto.response.SeatResponse;
 
@@ -10,4 +11,6 @@ public interface SeatService {
 	BulkCreateSeatsResponse create(UUID sectionId, String rowName, Integer startSeatNumber, Integer endSeatNumber);
 
 	List<SeatResponse> get(UUID sectionId, UUID userId);
+
+	List<SeatEntity> getByStadiumId(UUID stadiumId);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatServiceImpl.java
@@ -97,4 +97,10 @@ public class SeatServiceImpl implements SeatService {
 			.map(SeatResponse::from)
 			.toList();
 	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<SeatEntity> getByStadiumId(UUID stadiumId) {
+		return seatRepository.findAllByStadiumId(stadiumId);
+	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatStatusService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatStatusService.java
@@ -2,8 +2,11 @@ package com.goti.ticketing.seat.service.domain;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
+import com.goti.ticketing.domain.entity.game.GameScheduleEntity;
+import com.goti.ticketing.domain.entity.seat.SeatEntity;
 import com.goti.ticketing.domain.entity.seat.SeatStatusEntity;
 import com.goti.ticketing.seat.dto.response.GameSeatStatusResponse;
 
@@ -11,6 +14,10 @@ public interface SeatStatusService {
 	List<GameSeatStatusResponse> get(UUID gameId, UUID sectionId, UUID userId);
 
 	Map<UUID, SeatStatusEntity> getByGameIdAndSeatIds(UUID gameId, List<UUID> seatIds);
+
+	Set<UUID> getSeatIdsByGameId(UUID gameId);
+
+	List<SeatStatusEntity> createMissingStatuses(GameScheduleEntity game, List<SeatEntity> seats, Set<UUID> existingSeatIds);
 
 	void release(SeatStatusEntity seatStatus);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatStatusServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatStatusServiceImpl.java
@@ -2,6 +2,7 @@ package com.goti.ticketing.seat.service.domain;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -10,6 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.goti.constants.messages.ErrorCode;
 import com.goti.global.validation.Preconditions;
+import com.goti.ticketing.domain.entity.game.GameScheduleEntity;
+import com.goti.ticketing.domain.entity.seat.SeatEntity;
 import com.goti.ticketing.domain.entity.seat.SeatStatusEntity;
 import com.goti.ticketing.seat.dto.response.GameSeatStatusResponse;
 import com.goti.ticketing.seat.repository.SeatStatusRepository;
@@ -44,6 +47,27 @@ public class SeatStatusServiceImpl implements SeatStatusService {
 		return seatStatusRepository.findAllByGameAndSeatIds(gameId, seatIds)
 			.stream()
 			.collect(Collectors.toMap(seatStatus -> seatStatus.getSeat().getId(), seatStatus -> seatStatus));
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Set<UUID> getSeatIdsByGameId(UUID gameId) {
+		return Set.copyOf(seatStatusRepository.findSeatIdsByGameId(gameId));
+	}
+
+	@Override
+	@Transactional
+	public List<SeatStatusEntity> createMissingStatuses(
+		GameScheduleEntity game,
+		List<SeatEntity> seats,
+		Set<UUID> existingSeatIds
+	) {
+		List<SeatStatusEntity> newSeatStatuses = seats.stream()
+			.filter(seat -> !existingSeatIds.contains(seat.getId()))
+			.map(seat -> SeatStatusEntity.create(game, seat))
+			.toList();
+
+		return seatStatusRepository.saveAll(newSeatStatuses);
 	}
 
 	@Override

--- a/user/src/main/java/com/goti/user/constants/SecurityPathConstants.java
+++ b/user/src/main/java/com/goti/user/constants/SecurityPathConstants.java
@@ -15,6 +15,7 @@ public final class SecurityPathConstants {
 		"/api/v1/seats/bulk",
 		"/api/v1/stadium-seats/seat-sections",
 		"/api/v1/stadium-seats/seat-grades",
+		"/api/v1/game-seats/*/init",
 		"/actuator/health",
 		"/actuator/health/**",
 		"/swagger-ui/**",


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#291 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
경기별 좌석 상태 초기화 API 추가
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
> POST /api/v1/game-seats/{gameId}/init API 추가
특정 경기의 구장에 속한 전체 좌석을 조회해 seat_statuses 초기화 로직 구현
좌석 상태가 없는 좌석만 AVAILABLE 상태로 생성하도록 구현
초기화 결과 응답 DTO 추가

<br/>