### PR TITLE
[BUG] payment → ticketing 내부 API 호출 시 401 수정 (#296)

### DIFF
--- a/ticketing/src/main/java/com/goti/ticketing/constants/SecurityPathConstants.java
+++ b/ticketing/src/main/java/com/goti/ticketing/constants/SecurityPathConstants.java
@@ -8,5 +8,7 @@ public final class SecurityPathConstants {
 
 	public static final String[] PUBLIC_URLS = {
 		"/api/v1/games/**",
+		"/api/v1/orders/*/payment-order",        // 내부용: payment → ticketing (mTLS로 보호)
+		"/api/v1/orders/*/payment-confirmations", // 내부용: payment → ticketing (결제 확인 콜백)
 	};
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #296 

<br/>

## 🔎 개요
goti-payment에서 goti-ticketing 내부 API 호출 시 Spring Security가 401을 반환하는 문제 수정.
서비스 간 호출(mTLS)은 JWT/X-User-Id 없이 이루어지므로, 내부용 API를 PUBLIC_URLS에 등록하여 인증 우회 처리.

<br/>


## 📋 작업 내용
- `SecurityPathConstants.PUBLIC_URLS`에 내부용 경로 2건 추가
  - `/api/v1/orders/*/payment-order` — 결제 정보 조회 (payment → ticketing)
  - `/api/v1/orders/*/payment-confirmations` — 결제 확인 콜백 (payment → ticketing)


<br/>