### PR TITLE
[FEAT] 토큰재발급 API 구축 및 테스트

### DIFF
--- a/user/src/main/java/com/goti/user/controller/AuthController.java
+++ b/user/src/main/java/com/goti/user/controller/AuthController.java
@@ -24,6 +24,7 @@ import org.springframework.data.util.Pair;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -75,20 +76,11 @@ public class AuthController {
 	)
 	@PostMapping("/login")
 	public ResponseEntity<ApiSuccessResponse<TokenResponse>> login(
-		@RequestBody @Valid LoginRequest request, HttpServletResponse response
+		@RequestBody @Valid LoginRequest request,
+		HttpServletResponse response
 	) {
-
-		Pair<String, String> tokens = socialAuthService.login(
-			request.socialVerifyToken()
-		);
-
-		String accessToken = tokens.getFirst();
-		String refreshToken = tokens.getSecond();
-
-		ResponseCookie cookie = cookieProvider.createRefreshTokenCookie(refreshToken);
-		response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
-
-		return wrap(new TokenResponse(accessToken));
+		var tokens = socialAuthService.login(request.socialVerifyToken());
+		return handleTokenResponse(tokens, response);
 	}
 
 	@Operation(
@@ -99,7 +91,7 @@ public class AuthController {
 	public ResponseEntity<ApiSuccessResponse<TokenResponse>> signup(
 		@RequestBody @Valid SignupRequest request, HttpServletResponse response
 	) {
-		Pair<String, String> tokens = socialAuthService.signup(
+		var tokens = socialAuthService.signup(
 			request.socialVerifyToken(),
 			request.name(),
 			request.mobile(),
@@ -107,11 +99,7 @@ public class AuthController {
 			request.birthDate(),
 			request.authCode()
 		);
-		String accessToken = tokens.getFirst();
-		String refreshToken = tokens.getSecond();
-		ResponseCookie cookie = cookieProvider.createRefreshTokenCookie(refreshToken);
-		response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
-		return wrap(new TokenResponse(accessToken));
+		return handleTokenResponse(tokens, response);
 	}
 
 	@Operation(
@@ -126,5 +114,30 @@ public class AuthController {
 			request.socialVerifyToken(), request.mobile()
 		);
 		return empty();
+	}
+
+	@Operation(
+		summary = "토큰 재발급",
+		description = "RefreshToken 기반 Access/Refresh Token 재발급 API"
+	)
+	@PostMapping("/reissue")
+	public ResponseEntity<ApiSuccessResponse<TokenResponse>> reissueToken(
+		@CookieValue(name = "refreshToken") String refreshToken,
+		HttpServletResponse response
+	) {
+		var tokens = socialAuthService.reissueToken(refreshToken);
+		return handleTokenResponse(tokens, response);
+	}
+
+	private ResponseEntity<ApiSuccessResponse<TokenResponse>> handleTokenResponse(
+		Pair<String, String> tokens, HttpServletResponse response
+	) {
+		String accessToken = tokens.getFirst();
+		String refreshToken = tokens.getSecond();
+
+		ResponseCookie cookie = cookieProvider.createRefreshTokenCookie(refreshToken);
+		response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+		return wrap(new TokenResponse(accessToken));
 	}
 }

--- a/user/src/main/java/com/goti/user/service/auth/application/SocialAuthService.java
+++ b/user/src/main/java/com/goti/user/service/auth/application/SocialAuthService.java
@@ -27,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.UUID;
@@ -77,6 +78,7 @@ public class SocialAuthService {
 		return SocialVerifyResponse.of(isRegistered, socialVerifyToken);
 	}
 
+	@Transactional
 	public Pair<String, String> login(String socialVerifyToken) {
 		SocialInfo verifiedSocialInfo = getSocialInfoByToken(socialVerifyToken);
 		MemberEntity member = socialProviderService.findMemberBySocialInfo(
@@ -94,6 +96,7 @@ public class SocialAuthService {
 		return authService.issueTokens(member);
 	}
 
+	@Transactional
 	public Pair<String, String> signup(
 		String socialVerifyToken,
 		String name,
@@ -114,8 +117,9 @@ public class SocialAuthService {
 		authService.sendSmsCode(socialVerifyToken, mobile);
 	}
 
+	@Transactional
 	public Pair<String, String> reissueToken(String refreshToken) {
-		UUID memberId = authService.identifyByToken(refreshToken);
+		UUID memberId = authService.validateTokenAndGetMemberId(refreshToken);
 		MemberEntity member = memberService.getById(memberId);
 		return authService.issueTokens(member);
 	}

--- a/user/src/main/java/com/goti/user/service/domain/auth/AuthService.java
+++ b/user/src/main/java/com/goti/user/service/domain/auth/AuthService.java
@@ -10,7 +10,8 @@ public interface AuthService {
 
 	void verifySmsCode(String mobile, String authCode);
 
-	UUID identifyByToken(String token);
+	UUID validateTokenAndGetMemberId(String token);
 
 	Pair<String, String> issueTokens(MemberEntity member);
+
 }

--- a/user/src/main/java/com/goti/user/service/domain/auth/AuthServiceImpl.java
+++ b/user/src/main/java/com/goti/user/service/domain/auth/AuthServiceImpl.java
@@ -53,7 +53,7 @@ public class AuthServiceImpl implements AuthService {
 	}
 
 	@Override
-	public UUID identifyByToken(String token) {
+	public UUID validateTokenAndGetMemberId(String token) {
 		UUID memberId = parseMemberId(token);
 		validateJti(token, memberId);
 		return memberId;

--- a/user/src/test/java/com/goti/api/auth/SocialAuthReissueTokenApiTest.java
+++ b/user/src/test/java/com/goti/api/auth/SocialAuthReissueTokenApiTest.java
@@ -1,0 +1,116 @@
+package com.goti.api.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goti.constants.Gender;
+import com.goti.constants.OAuthProvider;
+import com.goti.infra.cache.RedisCache;
+import com.goti.infra.constants.redis.RedisKey;
+import com.goti.user.GotiUserApplication;
+
+import com.goti.user.config.jwt.JwtTokenProvider;
+
+import com.goti.user.constants.TokenType;
+import com.goti.user.domain.entity.user.MemberEntity;
+
+import com.goti.user.domain.entity.user.SocialProviderEntity;
+
+import com.goti.user.repository.MemberRepository;
+
+import com.goti.user.repository.SocialProviderRepository;
+
+import jakarta.servlet.http.Cookie;
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Slf4j
+@SpringBootTest(classes = GotiUserApplication.class)
+@Transactional
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DisplayName("토큰 재발급 - POST /api/v1/auth/reissue")
+public class SocialAuthReissueTokenApiTest {
+
+	@Autowired MockMvc mockMvc;
+	@Autowired ObjectMapper objectMapper;
+	@Autowired JwtTokenProvider jwtTokenProvider;
+	@Autowired RedisCache redisCache;
+	@Autowired MemberRepository memberRepository;
+	@Autowired SocialProviderRepository socialProviderRepository;
+
+	MemberEntity member;
+	SocialProviderEntity socialProvider;
+
+	@BeforeEach
+	void setup() {
+		saveMember();
+		saveSocialProvider();
+	}
+
+	@Test
+	void 토큰_재발급_성공__200_OK() throws Exception {
+		String loginAccessToken = jwtTokenProvider.create(
+			member.getId(),
+			member.getMobile(),
+			member.getRole(),
+			TokenType.ACCESS
+		);
+		String loginRefreshToken = jwtTokenProvider.create(
+			member.getId(),
+			member.getMobile(),
+			member.getRole(),
+			TokenType.REFRESH
+		);
+
+		log.info("login AccessToken: {}", loginAccessToken);
+		log.info("login RefreshToken: {}", loginRefreshToken);
+
+		String jti = jwtTokenProvider.extractJti(loginRefreshToken);
+		redisCache.set(RedisKey.REFRESH_TOKEN, member.getId(), jti);
+
+		mockMvc.perform(post("/api/v1/auth/reissue")
+				.cookie(new Cookie("refreshToken", loginRefreshToken))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.accessToken").exists())
+			.andExpect(header().exists(HttpHeaders.SET_COOKIE))
+			.andDo(print());
+	}
+
+	private void saveMember() {
+		member = MemberEntity.create(
+			"01012341234",
+			"테스트_회원",
+			Gender.MALE,
+			LocalDate.of(2000,2,10)
+		);
+		memberRepository.save(member);
+	}
+
+	private void saveSocialProvider() {
+		socialProvider = SocialProviderEntity.create(
+			member,
+			OAuthProvider.KAKAO,
+			"existing_kakao_provider_id",
+			"kakao_user@test.com"
+		);
+		socialProviderRepository.save(socialProvider);
+	}
+
+}


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#289 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
토큰재발급 API 구축 및 테스트 (AuthController - ReissueToken)
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- 토큰 재발급(reIssue) API 구축 및 API Test 코드 추가
- reIssue 및 login, signup Cookie set 중복로직 handleTokenResponse Controller 단 통합 응답 Method 정의 및 규격 통일
- login, reissue, signup Service(SocialAuthService) -> 트랜잭션 추가
- AuthService: identifyByToken -> validateTokenAndGetMemberId Method 명 직관적으로 변경
<br/>