### PR TITLE
[BUG] ticketing 모듈 내 경기 일정 조회 시 타 도메인(Stadium 모듈) 엔티티(Stadium, Team) 참조 에러

### DIFF
--- a/integration/src/main/java/com/goti/infra/api/base/BaseRestClient.java
+++ b/integration/src/main/java/com/goti/infra/api/base/BaseRestClient.java
@@ -1,5 +1,8 @@
 package com.goti.infra.api.base;
 
+import com.goti.global.api.ApiSuccessResponse;
+
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.MediaType;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -61,6 +64,37 @@ public abstract class BaseRestClient {
 			})
 			.retrieve()
 			.body(responseType);
+	}
+
+	protected <T> T get(
+		String uri,
+		Map<String, String> headers,
+		Map<String, ?> queryParams,
+		ParameterizedTypeReference<T> responseType
+	) {
+		return restClient.get()
+			.uri(uriBuilder -> {
+				UriBuilder builder = getActualUriBuilder(uri, uriBuilder);
+				if (queryParams != null) {
+					builder.queryParams(toParams(queryParams));
+				}
+				return builder.build();
+			})
+			.headers(header -> {
+				if (headers != null) headers.forEach(header::add);
+			})
+			.retrieve()
+			.body(responseType);
+	}
+
+	protected <T> T getGotiResponse(
+		String uri,
+		Map<String, String> headers,
+		Map<String, ?> queryParams,
+		ParameterizedTypeReference<ApiSuccessResponse<T>> responseType
+	) {
+		ApiSuccessResponse<T> response = get(uri, headers, queryParams, responseType);
+		return response.getData();
 	}
 
 	protected <T> T post(

--- a/stadium/src/main/java/com/goti/stadium/controller/BaseballTeamController.java
+++ b/stadium/src/main/java/com/goti/stadium/controller/BaseballTeamController.java
@@ -2,9 +2,12 @@ package com.goti.stadium.controller;
 
 import static com.goti.global.api.ApiSuccessResponse.*;
 
+import java.util.List;
 import java.util.UUID;
 
 import com.goti.stadium.domain.entity.team.BaseballTeamEntity;
+
+import com.goti.stadium.dto.response.internal.BaseballTeamDisplayNameResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 
@@ -14,6 +17,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.goti.stadium.dto.request.BaseballTeamCreateRequest;
@@ -76,6 +80,15 @@ public class BaseballTeamController {
 			homeStadiumManagementService.assignHomeStadium(
 				teamId, request.stadiumId(), request.type()
 			)
+		);
+	}
+
+	@GetMapping
+	public ResponseEntity<ApiSuccessResponse<List<BaseballTeamDisplayNameResponse>>> getDisplayNamesByIds(
+		@RequestParam List<UUID> teamIds
+	) {
+		return wrap(
+			baseballTeamService.getDisplayNamesByIds(teamIds)
 		);
 	}
 

--- a/stadium/src/main/java/com/goti/stadium/controller/StadiumController.java
+++ b/stadium/src/main/java/com/goti/stadium/controller/StadiumController.java
@@ -4,6 +4,7 @@ import com.goti.stadium.domain.entity.stadium.StadiumEntity;
 import com.goti.stadium.dto.request.StadiumCreateRequest;
 import com.goti.stadium.dto.response.StadiumCreateResponse;
 import com.goti.global.api.ApiSuccessResponse;
+import com.goti.stadium.dto.response.internal.StadiumLocationResponse;
 import com.goti.stadium.service.domain.stadium.StadiumService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,8 +18,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
 import java.util.UUID;
 
 import static com.goti.global.api.ApiSuccessResponse.wrap;
@@ -63,5 +66,14 @@ public class StadiumController {
 		@PathVariable UUID stadiumId
 	) {
 		return wrap(stadiumService.getById(stadiumId));
+	}
+
+	@GetMapping
+	public ResponseEntity<ApiSuccessResponse<List<StadiumLocationResponse>>> getLocationsByIds(
+		@RequestParam List<UUID> stadiumIds
+	) {
+		return wrap(
+			stadiumService.getLocationsByIds(stadiumIds)
+		);
 	}
 }

--- a/stadium/src/main/java/com/goti/stadium/dto/response/internal/BaseballTeamDisplayNameResponse.java
+++ b/stadium/src/main/java/com/goti/stadium/dto/response/internal/BaseballTeamDisplayNameResponse.java
@@ -1,0 +1,20 @@
+package com.goti.stadium.dto.response.internal;
+
+import com.goti.stadium.domain.entity.team.BaseballTeamEntity;
+
+import java.util.UUID;
+
+public record BaseballTeamDisplayNameResponse(
+	UUID teamId,
+	String teamDisplayName
+) {
+
+	public static BaseballTeamDisplayNameResponse from(
+		BaseballTeamEntity baseballTeam
+	) {
+		return new BaseballTeamDisplayNameResponse(
+			baseballTeam.getId(),
+			baseballTeam.getDisplayName()
+		);
+	}
+}

--- a/stadium/src/main/java/com/goti/stadium/dto/response/internal/StadiumLocationResponse.java
+++ b/stadium/src/main/java/com/goti/stadium/dto/response/internal/StadiumLocationResponse.java
@@ -1,0 +1,16 @@
+package com.goti.stadium.dto.response.internal;
+
+import com.goti.stadium.domain.entity.stadium.StadiumEntity;
+
+import java.util.UUID;
+
+public record StadiumLocationResponse(
+	UUID stadiumId,
+	String stadiumLocation
+) {
+	public static StadiumLocationResponse from(StadiumEntity stadium) {
+		return new StadiumLocationResponse(
+			stadium.getId(), stadium.getLocation()
+		);
+	}
+}

--- a/stadium/src/main/java/com/goti/stadium/repository/BaseballTeamRepository.java
+++ b/stadium/src/main/java/com/goti/stadium/repository/BaseballTeamRepository.java
@@ -8,6 +8,7 @@ import com.goti.exception.CustomException;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
@@ -18,4 +19,6 @@ public interface BaseballTeamRepository extends JpaRepository<BaseballTeamEntity
 			() -> new CustomException(ErrorCode.BASEBALL_TEAM_NOT_FOUND)
 		);
 	}
+
+	List<BaseballTeamEntity> findAllByIdIn(List<UUID> ids);
 }

--- a/stadium/src/main/java/com/goti/stadium/repository/StadiumRepository.java
+++ b/stadium/src/main/java/com/goti/stadium/repository/StadiumRepository.java
@@ -8,6 +8,7 @@ import com.goti.exception.CustomException;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
@@ -18,4 +19,6 @@ public interface StadiumRepository extends JpaRepository<StadiumEntity, UUID> {
 			() -> new CustomException(ErrorCode.STADIUM_NOT_FOUND)
 		);
 	}
+
+	List<StadiumEntity> findAllByIdIn(List<UUID> stadiumIds);
 }

--- a/stadium/src/main/java/com/goti/stadium/service/domain/baseballteam/BaseballTeamService.java
+++ b/stadium/src/main/java/com/goti/stadium/service/domain/baseballteam/BaseballTeamService.java
@@ -2,8 +2,10 @@ package com.goti.stadium.service.domain.baseballteam;
 
 import com.goti.stadium.domain.entity.team.BaseballTeamEntity;
 import com.goti.stadium.dto.response.BaseballTeamCreateResponse;
+import com.goti.stadium.dto.response.internal.BaseballTeamDisplayNameResponse;
 import com.goti.stadium.service.domain.baseballteam.command.BaseballTeamCreateCommand;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface BaseballTeamService {
@@ -11,4 +13,6 @@ public interface BaseballTeamService {
 	BaseballTeamCreateResponse create(BaseballTeamCreateCommand command);
 
 	BaseballTeamEntity getById(UUID teamId);
+
+	List<BaseballTeamDisplayNameResponse> getDisplayNamesByIds(List<UUID> teamIds);
 }

--- a/stadium/src/main/java/com/goti/stadium/service/domain/baseballteam/BaseballTeamServiceImpl.java
+++ b/stadium/src/main/java/com/goti/stadium/service/domain/baseballteam/BaseballTeamServiceImpl.java
@@ -3,6 +3,7 @@ package com.goti.stadium.service.domain.baseballteam;
 import com.goti.stadium.domain.entity.team.BaseballTeamEntity;
 import com.goti.stadium.dto.response.BaseballTeamCreateResponse;
 
+import com.goti.stadium.dto.response.internal.BaseballTeamDisplayNameResponse;
 import com.goti.stadium.repository.BaseballTeamRepository;
 
 import com.goti.stadium.service.domain.baseballteam.command.BaseballTeamCreateCommand;
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -57,6 +59,14 @@ public class BaseballTeamServiceImpl implements BaseballTeamService {
 	@Override
 	public BaseballTeamEntity getById(UUID teamId) {
 		return baseballTeamRepository.findByIdOrThrow(teamId);
+	}
+
+	@Override
+	public List<BaseballTeamDisplayNameResponse> getDisplayNamesByIds(List<UUID> teamIds) {
+		return baseballTeamRepository.findAllByIdIn(teamIds)
+			.stream()
+			.map(BaseballTeamDisplayNameResponse::from)
+			.toList();
 	}
 }
 

--- a/stadium/src/main/java/com/goti/stadium/service/domain/stadium/StadiumService.java
+++ b/stadium/src/main/java/com/goti/stadium/service/domain/stadium/StadiumService.java
@@ -2,8 +2,10 @@ package com.goti.stadium.service.domain.stadium;
 
 import com.goti.stadium.domain.entity.stadium.StadiumEntity;
 import com.goti.stadium.dto.response.StadiumCreateResponse;
+import com.goti.stadium.dto.response.internal.StadiumLocationResponse;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -22,5 +24,7 @@ public interface StadiumService {
 	);
 
 	StadiumEntity getById(UUID stadiumId);
+
+	List<StadiumLocationResponse> getLocationsByIds(List<UUID> stadiumIds);
 
 }

--- a/stadium/src/main/java/com/goti/stadium/service/domain/stadium/StadiumServiceImpl.java
+++ b/stadium/src/main/java/com/goti/stadium/service/domain/stadium/StadiumServiceImpl.java
@@ -2,6 +2,7 @@ package com.goti.stadium.service.domain.stadium;
 
 import com.goti.stadium.domain.entity.stadium.StadiumEntity;
 import com.goti.stadium.dto.response.StadiumCreateResponse;
+import com.goti.stadium.dto.response.internal.StadiumLocationResponse;
 import com.goti.stadium.repository.StadiumRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -51,5 +53,13 @@ public class StadiumServiceImpl implements StadiumService {
 	@Override
 	public StadiumEntity getById(UUID stadiumId) {
 		return stadiumRepository.findByIdOrThrow(stadiumId);
+	}
+
+	@Override
+	public List<StadiumLocationResponse> getLocationsByIds(List<UUID> stadiumIds) {
+		return stadiumRepository.findAllByIdIn(stadiumIds)
+			.stream()
+			.map(StadiumLocationResponse::from)
+			.toList();
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/game/dto/response/GameScheduleSearchResponse.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/dto/response/GameScheduleSearchResponse.java
@@ -105,4 +105,18 @@ public record GameScheduleSearchResponse(
 			ticketing.getTicketingEndAt()
 		);
 	}
+
+	public GameScheduleSearchResponse withExternalInfo(
+		String homeTeamName,
+		String awayTeamName,
+		String stadiumLocation
+	) {
+		return new GameScheduleSearchResponse(
+			gameId, startAt, leagueType,
+			homeTeamId, awayTeamId, stadiumId,
+			homeTeamName, awayTeamName, stadiumLocation,
+			gameStatus, homeTeamScore, awayTeamScore, gameResult,
+			ticketingStatus, ticketingOpenedAt, ticketingEndAt
+		);
+	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/game/repository/gameschedule/GameScheduleRepositoryImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/repository/gameschedule/GameScheduleRepositoryImpl.java
@@ -1,7 +1,5 @@
 package com.goti.ticketing.game.repository.gameschedule;
 
-import com.goti.stadium.domain.entity.stadium.QStadiumEntity;
-import com.goti.stadium.domain.entity.team.QBaseballTeamEntity;
 import com.goti.ticketing.domain.entity.game.QGameScheduleEntity;
 import com.goti.ticketing.domain.entity.game.QGameStatusEntity;
 import com.goti.ticketing.domain.entity.game.QGameTicketingStatusEntity;
@@ -9,6 +7,7 @@ import com.goti.ticketing.game.dto.request.GameScheduleSearchCondition;
 import com.goti.ticketing.game.dto.response.GameScheduleSearchResponse;
 import com.goti.ticketing.game.dto.response.QGameScheduleSearchResponse;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -51,11 +50,6 @@ public class GameScheduleRepositoryImpl implements GameScheduleRepositoryCustom 
 
 	@Override
 	public List<GameScheduleSearchResponse> searchSchedules(GameScheduleSearchCondition condition) {
-
-		QBaseballTeamEntity homeTeam = new QBaseballTeamEntity("homeTeam");
-		QBaseballTeamEntity awayTeam = new QBaseballTeamEntity("awayTeam");
-		QStadiumEntity stadium = QStadiumEntity.stadiumEntity;
-
 		return jpaQueryFactory
 			.select(
 				new QGameScheduleSearchResponse(
@@ -65,9 +59,9 @@ public class GameScheduleRepositoryImpl implements GameScheduleRepositoryCustom 
 					gameSchedule.homeTeamId,
 					gameSchedule.awayTeamId,
 					gameSchedule.stadiumId,
-					homeTeam.displayName,
-					awayTeam.displayName,
-					stadium.location,
+					Expressions.nullExpression(String.class), // homeTeam DisplayName
+					Expressions.nullExpression(String.class), // awayTeamName DisplayName
+					Expressions.nullExpression(String.class), // stadiumLocation
 					gameStatus.gameStatus,
 					gameStatus.homeTeamScore,
 					gameStatus.awayTeamScore,
@@ -80,9 +74,6 @@ public class GameScheduleRepositoryImpl implements GameScheduleRepositoryCustom 
 			.from(gameSchedule)
 			.leftJoin(gameStatus).on(gameStatus.gameSchedule.eq(gameSchedule))
 			.leftJoin(ticketingStatus).on(ticketingStatus.gameSchedule.eq(gameSchedule))
-			.leftJoin(homeTeam).on(homeTeam.id.eq(gameSchedule.homeTeamId))
-			.leftJoin(awayTeam).on(awayTeam.id.eq(gameSchedule.awayTeamId))
-			.leftJoin(stadium).on(stadium.id.eq(gameSchedule.stadiumId))
 			.where(
 				teamIdEq(gameSchedule, condition.teamId()),
 				dateFilter(gameSchedule, condition)

--- a/ticketing/src/main/java/com/goti/ticketing/game/service/application/GameScheduleSearchService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/service/application/GameScheduleSearchService.java
@@ -4,21 +4,75 @@ import com.goti.ticketing.game.dto.request.GameScheduleSearchCondition;
 import com.goti.ticketing.game.dto.response.GameScheduleSearchResponse;
 import com.goti.ticketing.game.repository.gameschedule.GameScheduleRepository;
 
+import com.goti.ticketing.infra.api.StadiumApiClient;
+
+import com.goti.ticketing.infra.api.dto.response.BaseballTeamDisplayNameResponse;
+
+import com.goti.ticketing.infra.api.dto.response.StadiumLocationResponse;
+
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
 public class GameScheduleSearchService {
 	private final GameScheduleRepository gameScheduleRepository;
+	private final StadiumApiClient stadiumApiClient;
 
 	@Transactional(readOnly = true)
 	public List<GameScheduleSearchResponse> searchSchedules(GameScheduleSearchCondition condition) {
-		return gameScheduleRepository.searchSchedules(condition);
+		List<GameScheduleSearchResponse> schedules = gameScheduleRepository.searchSchedules(condition);
+
+		if (schedules.isEmpty()) return schedules;
+
+		Set<UUID> teamIds = schedules.stream()
+			.flatMap(s -> Stream.of(s.homeTeamId(), s.awayTeamId()))
+			.collect(Collectors.toSet());
+
+		Set<UUID> stadiumIds = schedules.stream()
+			.map(GameScheduleSearchResponse::stadiumId)
+			.collect(Collectors.toSet());
+
+		Map<UUID, String> teamDisplayNameMap = getBaseballTeamDisplayNamesMap(teamIds);
+		Map<UUID, String> stadiumLocationMap = getStadiumLocationsMap(stadiumIds);
+
+		return schedules.stream().map(
+			schedule -> schedule.withExternalInfo(
+				teamDisplayNameMap.get(schedule.homeTeamId()),
+				teamDisplayNameMap.get(schedule.awayTeamId()),
+				stadiumLocationMap.get(schedule.stadiumId())
+			)
+		).toList();
+	}
+
+	private Map<UUID, String> getBaseballTeamDisplayNamesMap(Set<UUID> teamIds) {
+		return stadiumApiClient
+			.getBaseballTeamDisplayNames(new ArrayList<>(teamIds))
+			.stream()
+			.collect(Collectors.toMap(
+				BaseballTeamDisplayNameResponse::teamId,
+				BaseballTeamDisplayNameResponse::teamDisplayName
+			));
+	}
+
+	private Map<UUID, String> getStadiumLocationsMap(Set<UUID> stadiumIds) {
+		return stadiumApiClient
+			.getStadiumLocations(new ArrayList<>(stadiumIds))
+			.stream()
+			.collect(Collectors.toMap(
+				StadiumLocationResponse::stadiumId,
+				StadiumLocationResponse::stadiumLocation
+			));
 	}
 
 }

--- a/ticketing/src/main/java/com/goti/ticketing/game/service/application/GameScheduleSearchService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/service/application/GameScheduleSearchService.java
@@ -37,10 +37,12 @@ public class GameScheduleSearchService {
 
 		Set<UUID> teamIds = schedules.stream()
 			.flatMap(s -> Stream.of(s.homeTeamId(), s.awayTeamId()))
+			.filter(java.util.Objects::nonNull)
 			.collect(Collectors.toSet());
 
 		Set<UUID> stadiumIds = schedules.stream()
 			.map(GameScheduleSearchResponse::stadiumId)
+			.filter(java.util.Objects::nonNull)
 			.collect(Collectors.toSet());
 
 		Map<UUID, String> teamDisplayNameMap = getBaseballTeamDisplayNamesMap(teamIds);

--- a/ticketing/src/main/java/com/goti/ticketing/infra/api/StadiumApiClient.java
+++ b/ticketing/src/main/java/com/goti/ticketing/infra/api/StadiumApiClient.java
@@ -11,6 +11,7 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -47,12 +48,13 @@ public class StadiumApiClient extends BaseRestClient implements StadiumClient {
 				.collect(Collectors.joining(","))
 		);
 
-		return getGotiResponse(
+		var response = getGotiResponse(
 			BASEBALL_TEAM_GET_API,
 			null,
 			queryParams,
 			new ParameterizedTypeReference<ApiSuccessResponse<List<BaseballTeamDisplayNameResponse>>>() {}
 		);
+		return response != null ? response : Collections.emptyList();
 	}
 
 	@Override
@@ -62,11 +64,12 @@ public class StadiumApiClient extends BaseRestClient implements StadiumClient {
 				.map(UUID::toString)
 				.collect(Collectors.joining(","))
 		);
-		return getGotiResponse(
+		var response = getGotiResponse(
 			STADIUM_GET_API,
 			null,
 			queryParams,
 			new ParameterizedTypeReference<ApiSuccessResponse<List<StadiumLocationResponse>>>() {}
 		);
+		return response != null ? response : Collections.emptyList();
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/infra/api/StadiumApiClient.java
+++ b/ticketing/src/main/java/com/goti/ticketing/infra/api/StadiumApiClient.java
@@ -1,18 +1,27 @@
 package com.goti.ticketing.infra.api;
 
 import com.goti.config.properties.ApiEndpointProperties;
+import com.goti.global.api.ApiSuccessResponse;
 import com.goti.infra.api.base.BaseRestClient;
 
+import com.goti.ticketing.infra.api.dto.response.StadiumLocationResponse;
+import com.goti.ticketing.infra.api.dto.response.BaseballTeamDisplayNameResponse;
+
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Component
 public class StadiumApiClient extends BaseRestClient implements StadiumClient {
 
-	private final static String BASEBALL_TEAM_GET_API = "/api/v1/baseball-teams/";
-	private final static String STADIUM_GET_API = "/api/v1/stadiums/";
+	private final static String BASEBALL_TEAM_GET_API = "/api/v1/baseball-teams";
+	private final static String STADIUM_GET_API = "/api/v1/stadiums";
+	private final static String PATH_SEPARATOR = "/";
 
 	public StadiumApiClient(RestClient.Builder builder, ApiEndpointProperties properties) {
 		super(builder, properties.stadium());
@@ -20,13 +29,44 @@ public class StadiumApiClient extends BaseRestClient implements StadiumClient {
 
 	@Override
 	public void validateBaseballTeam(UUID teamId) {
-		String uri = BASEBALL_TEAM_GET_API + teamId;
+		String uri = BASEBALL_TEAM_GET_API + PATH_SEPARATOR + teamId;
 		getVoid(uri, null, null);
 	}
 
 	@Override
 	public void validateStadium(UUID stadiumId) {
-		String uri = STADIUM_GET_API + stadiumId;
+		String uri = STADIUM_GET_API + PATH_SEPARATOR + stadiumId;
 		getVoid(uri, null, null);
+	}
+
+	@Override
+	public List<BaseballTeamDisplayNameResponse> getBaseballTeamDisplayNames(List<UUID> teamIds) {
+		Map<String, Object> queryParams = Map.of(
+			"teamIds", teamIds.stream()
+				.map(UUID::toString)
+				.collect(Collectors.joining(","))
+		);
+
+		return getGotiResponse(
+			BASEBALL_TEAM_GET_API,
+			null,
+			queryParams,
+			new ParameterizedTypeReference<ApiSuccessResponse<List<BaseballTeamDisplayNameResponse>>>() {}
+		);
+	}
+
+	@Override
+	public List<StadiumLocationResponse> getStadiumLocations(List<UUID> stadiumIds) {
+		Map<String, Object> queryParams = Map.of(
+			"stadiumIds", stadiumIds.stream()
+				.map(UUID::toString)
+				.collect(Collectors.joining(","))
+		);
+		return getGotiResponse(
+			STADIUM_GET_API,
+			null,
+			queryParams,
+			new ParameterizedTypeReference<ApiSuccessResponse<List<StadiumLocationResponse>>>() {}
+		);
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/infra/api/StadiumClient.java
+++ b/ticketing/src/main/java/com/goti/ticketing/infra/api/StadiumClient.java
@@ -1,8 +1,14 @@
 package com.goti.ticketing.infra.api;
 
+import com.goti.ticketing.infra.api.dto.response.StadiumLocationResponse;
+import com.goti.ticketing.infra.api.dto.response.BaseballTeamDisplayNameResponse;
+
+import java.util.List;
 import java.util.UUID;
 
 public interface StadiumClient {
 	void validateBaseballTeam(UUID teamId);
 	void validateStadium(UUID stadiumId);
+	List<BaseballTeamDisplayNameResponse> getBaseballTeamDisplayNames(List<UUID> teamIds);
+	List<StadiumLocationResponse> getStadiumLocations(List<UUID> stadiumIds);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/infra/api/dto/response/BaseballTeamDisplayNameResponse.java
+++ b/ticketing/src/main/java/com/goti/ticketing/infra/api/dto/response/BaseballTeamDisplayNameResponse.java
@@ -1,0 +1,9 @@
+package com.goti.ticketing.infra.api.dto.response;
+
+import java.util.UUID;
+
+public record BaseballTeamDisplayNameResponse(
+	UUID teamId,
+	String teamDisplayName
+) {
+}

--- a/ticketing/src/main/java/com/goti/ticketing/infra/api/dto/response/StadiumLocationResponse.java
+++ b/ticketing/src/main/java/com/goti/ticketing/infra/api/dto/response/StadiumLocationResponse.java
@@ -1,0 +1,9 @@
+package com.goti.ticketing.infra.api.dto.response;
+
+import java.util.UUID;
+
+public record StadiumLocationResponse(
+	UUID stadiumId,
+	String stadiumLocation
+) {
+}

--- a/ticketing/src/test/java/com/goti/ticketing/game/api/game/GameSchedulesSearchApiTest.java
+++ b/ticketing/src/test/java/com/goti/ticketing/game/api/game/GameSchedulesSearchApiTest.java
@@ -1,6 +1,5 @@
 package com.goti.ticketing.game.api.game;
 
-import com.github.tomakehurst.wiremock.client.WireMock;
 import com.goti.ticketing.GotiTicketingApplication;
 import com.goti.stadium.constants.TeamCode;
 import com.goti.stadium.domain.entity.stadium.StadiumEntity;
@@ -9,6 +8,11 @@ import com.goti.ticketing.constants.LeagueType;
 import com.goti.ticketing.game.service.application.GameManagementService;
 import com.goti.stadium.repository.BaseballTeamRepository;
 import com.goti.stadium.repository.StadiumRepository;
+
+import com.goti.ticketing.infra.api.StadiumApiClient;
+
+import com.goti.ticketing.infra.api.dto.response.BaseballTeamDisplayNameResponse;
+import com.goti.ticketing.infra.api.dto.response.StadiumLocationResponse;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -20,22 +24,23 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
 
+import static org.mockito.BDDMockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
 
 @Slf4j
 @SpringBootTest(classes = GotiTicketingApplication.class)
@@ -48,6 +53,9 @@ public class GameSchedulesSearchApiTest {
 
 	@Autowired
 	MockMvc mockMvc;
+
+	@MockitoBean
+	private StadiumApiClient stadiumApiClient;
 
 	@Autowired
 	GameManagementService gameManagementService;
@@ -72,64 +80,16 @@ public class GameSchedulesSearchApiTest {
 		saveSamsung();
 		saveStadium();
 
-		stubFor(
-			WireMock.get(urlPathMatching("/api/v1/baseball-teams/.*"))
-				.willReturn(aResponse().withStatus(200))
-		);
+		given(stadiumApiClient.getBaseballTeamDisplayNames(any()))
+			.willReturn(List.of(
+				new BaseballTeamDisplayNameResponse(kia.getId(), "KIA"),
+				new BaseballTeamDisplayNameResponse(samsung.getId(), "삼성")
+			));
 
-		stubFor(
-			WireMock.get(urlPathMatching("/api/v1/stadiums/.*"))
-				.willReturn(aResponse().withStatus(200))
-		);
-
-		stubFor(
-			WireMock.get(urlPathEqualTo(BASEBALL_GET_API_URI))
-				.withQueryParam("teamIds", matching(".*"))
-				.willReturn(aResponse()
-					.withStatus(200)
-					.withHeader("Content-Type", "application/json")
-					.withBody("""
-                {
-                    "code": "200",
-                    "message": "성공",
-                    "data": [
-                        {"teamId": "%s", "teamDisplayName": "KIA"},
-                        {"teamId": "%s", "teamDisplayName": "삼성"}
-                    ]
-                }
-                """.formatted(kia.getId(), samsung.getId()))
-				)
-		);
-
-		stubFor(
-			WireMock.get(urlPathEqualTo(STADIUM_GET_API_URI))
-				.withQueryParam("stadiumIds", matching(".*"))
-				.willReturn(aResponse()
-					.withStatus(200)
-					.withHeader("Content-Type", "application/json")
-					.withBody("""
-                {
-                    "code": "200",
-                    "message": "성공",
-                    "data": [
-                        {"stadiumId": "%s", "stadiumLocation": "광주"}
-                    ]
-                }
-                """.formatted(stadium.getId()))
-				)
-		);
-
-		gameManagementService.register(
-			kia.getId(), samsung.getId(), stadium.getId(),
-			LocalDateTime.now().plusDays(10).withHour(18).withMinute(30).withSecond(0).withNano(0),
-			LeagueType.REGULAR
-		);
-
-		gameManagementService.register(
-			samsung.getId(), kia.getId(), stadium.getId(),
-			LocalDateTime.now().plusDays(11).withHour(14).withMinute(0).withSecond(0).withNano(0),
-			LeagueType.REGULAR
-		);
+		given(stadiumApiClient.getStadiumLocations(any()))
+			.willReturn(List.of(
+				new StadiumLocationResponse(stadium.getId(), "광주")
+			));
 	}
 
 	@Test

--- a/ticketing/src/test/java/com/goti/ticketing/game/api/game/GameSchedulesSearchApiTest.java
+++ b/ticketing/src/test/java/com/goti/ticketing/game/api/game/GameSchedulesSearchApiTest.java
@@ -30,12 +30,12 @@ import java.util.Map;
 
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 
 @Slf4j
 @SpringBootTest(classes = GotiTicketingApplication.class)
@@ -62,32 +62,61 @@ public class GameSchedulesSearchApiTest {
 	BaseballTeamEntity samsung;
 	StadiumEntity stadium;
 
-	private static final String BASEBALL_GET_API_URI = "/api/v1/baseball-teams/";
-	private static final String STADIUM_GET_API_URI = "/api/v1/stadiums/";
+	private static final String BASEBALL_GET_API_URI = "/api/v1/baseball-teams";
+	private static final String STADIUM_GET_API_URI = "/api/v1/stadiums";
+
 
 	@BeforeEach
 	void setup() {
-
 		saveKia();
 		saveSamsung();
 		saveStadium();
 
 		stubFor(
-			WireMock.get(
-				urlEqualTo(BASEBALL_GET_API_URI + kia.getId())
-			).willReturn(aResponse().withStatus(200))
+			WireMock.get(urlPathMatching("/api/v1/baseball-teams/.*"))
+				.willReturn(aResponse().withStatus(200))
 		);
 
 		stubFor(
-			WireMock.get(
-				urlEqualTo(BASEBALL_GET_API_URI + samsung.getId())
-			).willReturn(aResponse().withStatus(200))
+			WireMock.get(urlPathMatching("/api/v1/stadiums/.*"))
+				.willReturn(aResponse().withStatus(200))
 		);
 
 		stubFor(
-			WireMock.get(
-				urlEqualTo(STADIUM_GET_API_URI + stadium.getId())
-			).willReturn(aResponse().withStatus(200))
+			WireMock.get(urlPathEqualTo(BASEBALL_GET_API_URI))
+				.withQueryParam("teamIds", matching(".*"))
+				.willReturn(aResponse()
+					.withStatus(200)
+					.withHeader("Content-Type", "application/json")
+					.withBody("""
+                {
+                    "code": "200",
+                    "message": "성공",
+                    "data": [
+                        {"teamId": "%s", "teamDisplayName": "KIA"},
+                        {"teamId": "%s", "teamDisplayName": "삼성"}
+                    ]
+                }
+                """.formatted(kia.getId(), samsung.getId()))
+				)
+		);
+
+		stubFor(
+			WireMock.get(urlPathEqualTo(STADIUM_GET_API_URI))
+				.withQueryParam("stadiumIds", matching(".*"))
+				.willReturn(aResponse()
+					.withStatus(200)
+					.withHeader("Content-Type", "application/json")
+					.withBody("""
+                {
+                    "code": "200",
+                    "message": "성공",
+                    "data": [
+                        {"stadiumId": "%s", "stadiumLocation": "광주"}
+                    ]
+                }
+                """.formatted(stadium.getId()))
+				)
 		);
 
 		gameManagementService.register(

--- a/ticketing/src/test/java/com/goti/ticketing/game/service/GameManagementServiceTest.java
+++ b/ticketing/src/test/java/com/goti/ticketing/game/service/GameManagementServiceTest.java
@@ -14,7 +14,7 @@ import com.goti.stadium.repository.BaseballTeamRepository;
 
 import com.goti.stadium.repository.StadiumRepository;
 
-import com.goti.ticketing.infra.api.StadiumClient;
+import com.goti.ticketing.infra.api.StadiumApiClient;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -51,7 +51,7 @@ public class GameManagementServiceTest {
 	StadiumRepository stadiumRepository;
 
 	@MockitoBean
-	private StadiumClient stadiumClient;
+	private StadiumApiClient StadiumApiClient;
 
 	BaseballTeamEntity homeTeam;
 	BaseballTeamEntity awayTeam;

--- a/ticketing/src/test/java/com/goti/ticketing/game/service/GameScheduleSearchServiceTest.java
+++ b/ticketing/src/test/java/com/goti/ticketing/game/service/GameScheduleSearchServiceTest.java
@@ -12,7 +12,7 @@ import com.goti.ticketing.game.service.application.GameScheduleSearchService;
 import com.goti.stadium.repository.BaseballTeamRepository;
 import com.goti.stadium.repository.StadiumRepository;
 
-import com.goti.ticketing.infra.api.StadiumClient;
+import com.goti.ticketing.infra.api.StadiumApiClient;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -49,7 +49,7 @@ public class GameScheduleSearchServiceTest {
 	StadiumRepository stadiumRepository;
 
 	@MockitoBean
-	private StadiumClient stadiumClient;
+	private StadiumApiClient StadiumApiClient;
 
 	private BaseballTeamEntity kia;
 	private BaseballTeamEntity samsung;


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#301 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
게임 일정 조회 시 타 도메인 호출 및 참조 이슈 해결
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- 기존 게임일정 데이터 조회시 -> 외부 도메인 엔티티 Join 제거 및 Expressions.nullExpression 적용(GameScheduleRepository)
- 외부 API 연동을(Stadium Domain API) 통한 경기 일정 데이터 조립(In-Memory Join) 구현 (GameScheduleSearchService에서 조회된 일정 데이터에 팀명 및 구장 위치 정보를 결합하는 로직 추가) 
- Stadium 도메인 모듈 -> BaseballTeam 및 Stadium 데이터 호출 내부 API 구축 및 id list를 인자를 받은 List Data 응답 로직 구현 (BaseballService, StadiumService)
- 팀 및 구장 정보 벌크 조회를 위한 내부 API 호출 로직 구현(StadiumApiClient) - (StadiumClient 인터페이스에 getBaseballTeamDisplayNames 및 getStadiumLocations 메서드 추가)
- BaseRestClient 내 공통 응답 처리 및 제네릭 GET 메서드 추가
- ParameterizedTypeReference를 지원 공통 get 메서드 구현 -> 유연한 타입 캐스팅 지원
- Goti-server의 표준 응답 규격(ApiSuccessResponse)을 자동으로 언래핑(Unwrapping)하는 getGotiResponse 메서드 추가
- 도메인 간 결합도 해소를 위한 Internal DTO 분리 및 미러링
- stadium 모듈과 ticketing 모듈 간의 DTO 공유를 제거하여 모듈 독립성 강화 -> 각 도메인 패키지 내에 전용 Response Record(StadiumLocationResponse, BaseballTeamDisplayNameResponse)
- 기존 게임일정 데이터 조회 API Test 수정 -> WireMock 도입 및 외부 API 연동 기반 경기 일정 조회 테스트 리팩터링
<br/>