### PR TITLE
[REFACTOR] 테스트 유저 중복 생성 시 ERROR 로그 제거 (#316)

### DIFF
--- a/user/src/main/java/com/goti/user/service/test/TestUserPersistenceHelper.java
+++ b/user/src/main/java/com/goti/user/service/test/TestUserPersistenceHelper.java
@@ -1,0 +1,45 @@
+package com.goti.user.service.test;
+
+import java.time.LocalDate;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goti.constants.Gender;
+import com.goti.constants.OAuthProvider;
+import com.goti.user.domain.entity.user.MemberEntity;
+import com.goti.user.service.domain.user.MemberService;
+import com.goti.user.service.domain.user.SocialProviderService;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 테스트 유저 생성 시 REQUIRES_NEW 트랜잭션 격리를 위한 헬퍼.
+ * Self-invocation 문제를 회피하기 위해 별도 Bean으로 분리.
+ *
+ * <p>중복 키(DataIntegrityViolationException) 발생 시
+ * 이 트랜잭션만 롤백되고 호출자 트랜잭션은 영향 없음.</p>
+ */
+@Profile("!prod")
+@Component
+@RequiredArgsConstructor
+public class TestUserPersistenceHelper {
+
+	private final MemberService memberService;
+	private final SocialProviderService socialProviderService;
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public MemberEntity createMember(
+		String name, String mobile, Gender gender, LocalDate birthDate
+	) {
+		MemberEntity member = memberService.save(name, mobile, gender, birthDate);
+		socialProviderService.save(
+			member, OAuthProvider.NAVER,
+			"test-provider-" + mobile,
+			"test-" + mobile + "@test.com"
+		);
+		return member;
+	}
+}

--- a/user/src/main/java/com/goti/user/service/test/TestUserService.java
+++ b/user/src/main/java/com/goti/user/service/test/TestUserService.java
@@ -64,7 +64,8 @@ public class TestUserService {
 					// REQUIRES_NEW 덕분에 외부 트랜잭션은 깨끗한 상태
 					log.debug("테스트 유저 이미 존재 (동시 생성): mobile={}", request.mobile());
 					return memberService.findByMobile(request.mobile())
-						.orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+						.orElseThrow(() -> new CustomException(ErrorCode.INTERNAL_SERVER_ERROR,
+							"중복 생성된 테스트 유저 조회에 실패했습니다."));
 				}
 			});
 	}

--- a/user/src/main/java/com/goti/user/service/test/TestUserService.java
+++ b/user/src/main/java/com/goti/user/service/test/TestUserService.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import com.goti.user.constants.TokenType;
 
 import org.springframework.context.annotation.Profile;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,7 +26,9 @@ import com.goti.user.service.domain.user.MemberService;
 import com.goti.user.service.domain.user.SocialProviderService;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Profile("!prod")
 @Service
 @RequiredArgsConstructor
@@ -33,14 +36,12 @@ public class TestUserService {
 
 	private final MemberService memberService;
 	private final SocialProviderService socialProviderService;
+	private final TestUserPersistenceHelper persistenceHelper;
 	private final JwtTokenProvider jwtTokenProvider;
 
 	@Transactional
 	public TestUserResponse createUser(CreateTestUserRequest request) {
-		MemberEntity member = memberService.findByMobile(request.mobile())
-			.orElseGet(() -> createMemberWithSocialProvider(
-				request.name(), request.mobile(), request.gender(), request.birthDate()
-			));
+		MemberEntity member = findOrCreateMember(request);
 
 		String accessToken = jwtTokenProvider.create(
 			member.getId(), member.getMobile(), UserRole.MEMBER, TokenType.ACCESS
@@ -49,6 +50,23 @@ public class TestUserService {
 		return new TestUserResponse(
 			member.getId(), member.getMobile(), member.getName(), accessToken
 		);
+	}
+
+	private MemberEntity findOrCreateMember(CreateTestUserRequest request) {
+		return memberService.findByMobile(request.mobile())
+			.orElseGet(() -> {
+				try {
+					return persistenceHelper.createMember(
+						request.name(), request.mobile(),
+						request.gender(), request.birthDate()
+					);
+				} catch (DataIntegrityViolationException e) {
+					// REQUIRES_NEW 덕분에 외부 트랜잭션은 깨끗한 상태
+					log.debug("테스트 유저 이미 존재 (동시 생성): mobile={}", request.mobile());
+					return memberService.findByMobile(request.mobile())
+						.orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+				}
+			});
 	}
 
 	/**
@@ -97,7 +115,6 @@ public class TestUserService {
 		String name, String mobile, Gender gender, LocalDate birthDate
 	) {
 		MemberEntity member = memberService.save(name, mobile, gender, birthDate);
-		// 테스트 더미 SocialProvider — providerId는 mobile 기반 고정값 (SecureRandom 불필요)
 		socialProviderService.save(
 			member, OAuthProvider.NAVER,
 			"test-provider-" + mobile,


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #316 

<br/>

## 🔎 개요
K6 부하 테스트 시 `POST /api/v1/test/users` 반복 호출로 인한 `DataIntegrityViolationException` ERROR 로그 노이즈 제거.
기능은 정상(200 반환)이지만, 부하 테스트마다 수백 건의 ERROR 로그가 쌓여 진짜 에러를 놓칠 수 있는 문제 해결.

<br/>


## 📋 작업 내용
- `TestUserPersistenceHelper` 신규 생성 — `@Transactional(REQUIRES_NEW)` 트랜잭션 격리용 별도 Bean
- `TestUserService.findOrCreateMember()` — helper 호출로 self-invocation 문제 해결
  - 기존: 같은 클래스 내 `REQUIRES_NEW` 메서드 호출 → Spring 프록시 미작동 → 외부 트랜잭션 rollback-only 오염
  - 변경: 별도 Bean 호출 → 프록시 정상 작동 → 중복 키 에러 시 helper 트랜잭션만 롤백
- 중복 키 예외 시 `log.error` → `log.debug`로 격하(테스트 유저만)

<br/>