### PR TITLE
[REFACTOR] 좌석 점유 요청 시 예외 처리 로직 개선

### DIFF
--- a/common/src/main/java/com/goti/constants/messages/ErrorCode.java
+++ b/common/src/main/java/com/goti/constants/messages/ErrorCode.java
@@ -76,6 +76,7 @@ public enum ErrorCode {
 	SEAT_SECTION_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 동일한 좌석 구역이 존재합니다."),
 	SEAT_LOCK_ACQUIRE_FAILED(HttpStatus.BAD_REQUEST, "요청이 몰리고 있습니다. 잠시 후 다시 시도해주세요"),
 	SEAT_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "좌석 상태를 확인할 수 없습니다."),
+	SEAT_ALREADY_SELECTED(HttpStatus.BAD_REQUEST, "이미 선택된 좌석입니다."),
 	SEAT_HOLD_NOT_FOUND(HttpStatus.NOT_FOUND, "좌석 점유 정보를 찾을 수 없습니다."),
 	SEAT_HOLD_GAME_MISMATCH(HttpStatus.BAD_REQUEST, "선택한 좌석의 경기 정보가 요청한 경기와 일치하지 않습니다."),
 	SEAT_HOLD_STATUS_INVALID(HttpStatus.BAD_REQUEST, "점유 중인 좌석만 주문할 수 있습니다."),

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldTransactionalService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldTransactionalService.java
@@ -11,6 +11,7 @@ import com.goti.ticketing.domain.entity.seat.SeatHoldEntity;
 import com.goti.ticketing.domain.entity.seat.SeatStatusEntity;
 import com.goti.exception.CustomException;
 import com.goti.ticketing.game.repository.gameschedule.GameScheduleRepository;
+import com.goti.ticketing.constants.SeatStatus;
 import com.goti.global.validation.Preconditions;
 import com.goti.ticketing.seat.config.properties.SeatHoldProperties;
 import com.goti.ticketing.seat.repository.SeatHoldRepository;
@@ -35,6 +36,11 @@ public class SeatHoldTransactionalService {
 				seatRepository.getReferenceById(seatId)
 			)
 			.orElseThrow(() -> new CustomException(ErrorCode.SEAT_STATUS_NOT_FOUND));
+
+		Preconditions.validate(
+			seatStatus.getStatus() == SeatStatus.AVAILABLE,
+			ErrorCode.SEAT_ALREADY_SELECTED
+		);
 
 		seatStatus.hold();
 		seatStatusRepository.save(seatStatus);


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#318
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
좌석 점유 요청 시 이미 선점된 좌석에 대해 전용 에러코드와 명확한 메시지를 반환하도록 예외 처리 로직 개선
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
> 좌석 점유 시도 시 좌석 상태가 AVAILABLE인지 먼저 검증하도록 로직 추가
이미 다른 사용자가 선점했거나 선택 불가 상태인 좌석은 전용 에러코드로 처리하도록 변경
SEAT_ALREADY_SELECTED 에러코드 추가
"이미 선택된 좌석입니다." 메시지로 응답하도록 수정

<br/>