### PR TITLE
[FEAT] 티켓팅 부하테스트 모니터링용 로그 추가

### DIFF
--- a/common/src/main/java/com/goti/exception/CustomException.java
+++ b/common/src/main/java/com/goti/exception/CustomException.java
@@ -1,12 +1,18 @@
 package com.goti.exception;
 
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import com.goti.constants.messages.ErrorCode;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class CustomException extends BaseException {
+
+	private final Map<String, Object> context = new LinkedHashMap<>();
 
 	public CustomException(ErrorCode error) {
 		super(error);
@@ -20,5 +26,13 @@ public class CustomException extends BaseException {
 		super(error, cause);
 	}
 
-}
+	public CustomException withContext(String key, Object value) {
+		context.put(key, value);
+		return this;
+	}
 
+	public Map<String, Object> context() {
+		return Collections.unmodifiableMap(context);
+	}
+
+}

--- a/common/src/main/java/com/goti/exception/handler/SystemExceptionHandler.java
+++ b/common/src/main/java/com/goti/exception/handler/SystemExceptionHandler.java
@@ -32,20 +32,22 @@ public class SystemExceptionHandler extends BaseExceptionHandler {
 	@ExceptionHandler(CustomException.class)
 	public ResponseEntity<ApiErrorResponse> handleCustomException(CustomException ex) {
 		ErrorCode error = ex.error();
-		String contextLog = formatContext(ex.context());
-		String tag = contextLog.isEmpty()
-			? String.format("[%s Error]", error.isSystemError() ? "System" : "Business")
-			: contextLog;
-		String message = String.format(
-			"code=%s message=%s",
+		Map<String, Object> context = ex.context();
+		String action = String.valueOf(context.getOrDefault("action", "ERROR_OCCURRED"));
+		String contextLog = formatContext(context);
+
+		String logMessage = String.format(
+			"action=%s errorCode=%s message=%s %s",
+			action,
 			error.name(),
-			ex.getMessage()
-		);
+			ex.getMessage(),
+			contextLog
+		).trim();
 
 		if (error.isSystemError()) {
-			log.error("{} {}", tag, message, ex);
+			log.error(logMessage, ex);
 		} else {
-			log.warn("{} {}", tag, message);
+			log.warn(logMessage);
 		}
 		return toResponse(ex);
 	}
@@ -89,6 +91,7 @@ public class SystemExceptionHandler extends BaseExceptionHandler {
 			return "";
 		}
 		return context.entrySet().stream()
+			.filter(entry -> !"action".equals(entry.getKey()))
 			.map(entry -> entry.getKey() + "=" + entry.getValue())
 			.collect(Collectors.joining(" "));
 	}

--- a/common/src/main/java/com/goti/exception/handler/SystemExceptionHandler.java
+++ b/common/src/main/java/com/goti/exception/handler/SystemExceptionHandler.java
@@ -33,18 +33,19 @@ public class SystemExceptionHandler extends BaseExceptionHandler {
 	public ResponseEntity<ApiErrorResponse> handleCustomException(CustomException ex) {
 		ErrorCode error = ex.error();
 		String contextLog = formatContext(ex.context());
+		String tag = contextLog.isEmpty()
+			? String.format("[%s Error]", error.isSystemError() ? "System" : "Business")
+			: contextLog;
+		String message = String.format(
+			"code=%s message=%s",
+			error.name(),
+			ex.getMessage()
+		);
+
 		if (error.isSystemError()) {
-			if (contextLog.isEmpty()) {
-				log.error("[System Error] code={} message={}", error.name(), ex.getMessage(), ex);
-			} else {
-				log.error("{} reason={} message={}", contextLog, error.name(), ex.getMessage(), ex);
-			}
+			log.error("{} {}", tag, message, ex);
 		} else {
-			if (contextLog.isEmpty()) {
-				log.warn("[Business Error] code={} message={}", error.name(), ex.getMessage());
-			} else {
-				log.warn("{} reason={} message={}", contextLog, error.name(), ex.getMessage());
-			}
+			log.warn("{} {}", tag, message);
 		}
 		return toResponse(ex);
 	}

--- a/common/src/main/java/com/goti/exception/handler/SystemExceptionHandler.java
+++ b/common/src/main/java/com/goti/exception/handler/SystemExceptionHandler.java
@@ -1,5 +1,8 @@
 package com.goti.exception.handler;
 
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import com.goti.global.api.ApiErrorResponse;
 import com.goti.constants.messages.ErrorCode;
 import com.goti.exception.CustomException;
@@ -29,10 +32,19 @@ public class SystemExceptionHandler extends BaseExceptionHandler {
 	@ExceptionHandler(CustomException.class)
 	public ResponseEntity<ApiErrorResponse> handleCustomException(CustomException ex) {
 		ErrorCode error = ex.error();
+		String contextLog = formatContext(ex.context());
 		if (error.isSystemError()) {
-			log.error("[System Error] code={} message={}", error.name(), ex.getMessage(), ex);
+			if (contextLog.isEmpty()) {
+				log.error("[System Error] code={} message={}", error.name(), ex.getMessage(), ex);
+			} else {
+				log.error("{} reason={} message={}", contextLog, error.name(), ex.getMessage(), ex);
+			}
 		} else {
-			log.warn("[Business Error] code={} message={}", error.name(), ex.getMessage());
+			if (contextLog.isEmpty()) {
+				log.warn("[Business Error] code={} message={}", error.name(), ex.getMessage());
+			} else {
+				log.warn("{} reason={} message={}", contextLog, error.name(), ex.getMessage());
+			}
 		}
 		return toResponse(ex);
 	}
@@ -70,4 +82,14 @@ public class SystemExceptionHandler extends BaseExceptionHandler {
 		);
 		return toResponse(ErrorCode.AUTH_INVALID);
 	}
+
+	private String formatContext(Map<String, Object> context) {
+		if (context == null || context.isEmpty()) {
+			return "";
+		}
+		return context.entrySet().stream()
+			.map(entry -> entry.getKey() + "=" + entry.getValue())
+			.collect(Collectors.joining(" "));
+	}
+
 }

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderCancelService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderCancelService.java
@@ -37,7 +37,9 @@ import com.goti.ticketing.seat.service.domain.SeatStatusService;
 import com.goti.ticketing.ticket.service.domain.TicketService;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class OrderCancelService {
@@ -129,6 +131,15 @@ public class OrderCancelService {
 		updateOrderStatus(order, orderItems);
 		PaymentCancelResponse paymentData = paymentApiClient.cancelPayment(orderId, cancellation.getId());
 		orderCancellationService.complete(cancellation);
+
+		log.info(
+			"action=ORDER_CANCEL gameId={} userId={} orderId={} cancelledItems={} refundAmount={}",
+			order.getGameSchedule().getId(),
+			memberId,
+			orderId,
+			targetItems.size(),
+			refundAmount.refundAmount()
+		);
 
 		return OrderCancelResponse.from(
 			cancellation,

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderCreateService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderCreateService.java
@@ -79,6 +79,15 @@ public class OrderCreateService {
 
 		createOrderItems(order, pricingResult.pricedHolds());
 
+		log.info(
+			"action=ORDER_CREATE gameId={} userId={} orderId={} quantity={} totalAmount={}",
+			command.gameId(),
+			command.memberId(),
+			order.getId(),
+			order.getTotalQuantity(),
+			order.getTotalAmount()
+		);
+
 		return OrderCreateResponse.from(
 			order.getId(),
 			order.getOrderNumber(),

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderCreateService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderCreateService.java
@@ -6,6 +6,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,6 +33,7 @@ import com.goti.ticketing.seat.repository.SeatHoldRepository;
 
 import lombok.RequiredArgsConstructor;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class OrderCreateService {
@@ -117,10 +120,16 @@ public class OrderCreateService {
 				hold.getStatus() == SeatHoldStatus.HOLDING,
 				ErrorCode.SEAT_HOLD_STATUS_INVALID
 			);
-			Preconditions.validate(
-				hold.getExpiredAt().isAfter(LocalDateTime.now()),
-				ErrorCode.SEAT_HOLD_EXPIRED
-			);
+			if (!hold.getExpiredAt().isAfter(LocalDateTime.now())) {
+				log.info(
+					"action=SESSION_BLOCK gameId={} userId={} stage=ORDER_CREATE holdId={} reason={}",
+					gameId,
+					userId,
+					hold.getId(),
+					ErrorCode.SEAT_HOLD_EXPIRED.name()
+				);
+				throw new CustomException(ErrorCode.SEAT_HOLD_EXPIRED);
+			}
 		}
 	}
 

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderCreateService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderCreateService.java
@@ -6,6 +6,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,6 +33,7 @@ import com.goti.ticketing.seat.repository.SeatHoldRepository;
 
 import lombok.RequiredArgsConstructor;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class OrderCreateService {

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderCreateService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderCreateService.java
@@ -6,8 +6,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 
-import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,7 +31,6 @@ import com.goti.ticketing.seat.repository.SeatHoldRepository;
 
 import lombok.RequiredArgsConstructor;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class OrderCreateService {
@@ -130,14 +127,12 @@ public class OrderCreateService {
 				ErrorCode.SEAT_HOLD_STATUS_INVALID
 			);
 			if (!hold.getExpiredAt().isAfter(LocalDateTime.now())) {
-				log.info(
-					"action=SESSION_BLOCK gameId={} userId={} stage=ORDER_CREATE holdId={} reason={}",
-					gameId,
-					userId,
-					hold.getId(),
-					ErrorCode.SEAT_HOLD_EXPIRED.name()
-				);
-				throw new CustomException(ErrorCode.SEAT_HOLD_EXPIRED);
+				throw new CustomException(ErrorCode.SEAT_HOLD_EXPIRED)
+					.withContext("action", "SESSION_BLOCK")
+					.withContext("stage", "ORDER_CREATE")
+					.withContext("gameId", gameId)
+					.withContext("userId", userId)
+					.withContext("holdId", hold.getId());
 			}
 		}
 	}

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderPaymentConfirmService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderPaymentConfirmService.java
@@ -99,15 +99,13 @@ public class OrderPaymentConfirmService {
 			.isPresent();
 
 		if (!activeHoldExists) {
-			log.info(
-				"action=SESSION_BLOCK gameId={} userId={} stage=PAYMENT_CONFIRM orderId={} seatId={} reason={}",
-				order.getGameSchedule().getId(),
-				order.getMemberId(),
-				order.getId(),
-				orderItem.getSeat().getId(),
-				ErrorCode.SEAT_HOLD_EXPIRED.name()
-			);
-			throw new CustomException(ErrorCode.SEAT_HOLD_EXPIRED);
+			throw new CustomException(ErrorCode.SEAT_HOLD_EXPIRED)
+				.withContext("action", "SESSION_BLOCK")
+				.withContext("stage", "PAYMENT_CONFIRM")
+				.withContext("gameId", order.getGameSchedule().getId())
+				.withContext("userId", order.getMemberId())
+				.withContext("orderId", order.getId())
+				.withContext("seatId", orderItem.getSeat().getId());
 		}
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderPaymentConfirmService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderPaymentConfirmService.java
@@ -43,7 +43,7 @@ public class OrderPaymentConfirmService {
 		String pgTid
 	) {
 		log.info(
-			"주문 결제 완료 처리 시작 - orderId: {}, userId: {}, paymentId: {}, pgTid: {}",
+			"action=PAYMENT_CONFIRM_START orderId={} userId={} paymentId={} pgTid={}",
 			orderId,
 			userId,
 			paymentId,
@@ -71,6 +71,14 @@ public class OrderPaymentConfirmService {
 		}
 
 		List<TicketResponse> tickets = ticketCreateService.create(order);
+
+		log.info(
+			"action=PAYMENT_CONFIRM gameId={} userId={} orderId={} ticketCount={}",
+			order.getGameSchedule().getId(),
+			order.getMemberId(),
+			order.getId(),
+			tickets.size()
+		);
 
 		return OrderPaymentConfirmResponse.from(
 			order.getId(),

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderPaymentConfirmService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderPaymentConfirmService.java
@@ -90,9 +90,16 @@ public class OrderPaymentConfirmService {
 			.filter(seatHold -> seatHold.getExpiredAt().isAfter(LocalDateTime.now()))
 			.isPresent();
 
-		Preconditions.validate(
-			activeHoldExists,
-			ErrorCode.SEAT_HOLD_EXPIRED
-		);
+		if (!activeHoldExists) {
+			log.info(
+				"action=SESSION_BLOCK gameId={} userId={} stage=PAYMENT_CONFIRM orderId={} seatId={} reason={}",
+				order.getGameSchedule().getId(),
+				order.getMemberId(),
+				order.getId(),
+				orderItem.getSeat().getId(),
+				ErrorCode.SEAT_HOLD_EXPIRED.name()
+			);
+			throw new CustomException(ErrorCode.SEAT_HOLD_EXPIRED);
+		}
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldExpiryService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldExpiryService.java
@@ -42,18 +42,18 @@ public class SeatHoldExpiryService {
 
 				failed++;
 				log.debug(
-					"좌석 점유 만료 처리 락 획득 실패로 건너뜀. holdId={}, gameId={}, seatId={}",
-					seatHold.getId(),
+					"action=LOCK_TIMEOUT operation=SEAT_HOLD_EXPIRY gameId={} seatId={} holdId={}",
 					seatHold.getGameSchedule().getId(),
-					seatHold.getSeat().getId()
+					seatHold.getSeat().getId(),
+					seatHold.getId()
 				);
 			} catch (Exception e) {
 				failed++;
 				log.warn(
-					"좌석 점유 만료 처리 실패. holdId={}, gameId={}, seatId={}, reason={}",
-					seatHold.getId(),
+					"action=HOLD_RELEASE_FAILED gameId={} seatId={} holdId={} reason={}",
 					seatHold.getGameSchedule().getId(),
 					seatHold.getSeat().getId(),
+					seatHold.getId(),
 					e.getMessage()
 				);
 			}

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldTransactionalService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldTransactionalService.java
@@ -34,49 +34,39 @@ public class SeatHoldTransactionalService {
 
 	@Transactional
 	public UUID hold(UUID gameId, UUID seatId, UUID userId, String queueTokenJti) {
-		try {
-			SeatStatusEntity seatStatus = seatStatusRepository.findByGameAndSeat(
-					gameScheduleRepository.getReferenceById(gameId),
-					seatRepository.getReferenceById(seatId)
-				)
-				.orElseThrow(() -> new CustomException(ErrorCode.SEAT_STATUS_NOT_FOUND));
+		SeatStatusEntity seatStatus = seatStatusRepository.findByGameAndSeat(
+				gameScheduleRepository.getReferenceById(gameId),
+				seatRepository.getReferenceById(seatId)
+			)
+			.orElseThrow(() -> blocked(gameId, userId, seatId, ErrorCode.SEAT_STATUS_NOT_FOUND));
 
-			Preconditions.validate(
-				seatStatus.getStatus() == SeatStatus.AVAILABLE,
-				ErrorCode.SEAT_ALREADY_SELECTED
-			);
-
-			seatStatus.hold();
-			seatStatusRepository.save(seatStatus);
-
-			// TODO: 좌석 점유 시 game_seat_inventories 카운트 반영
-			SeatHoldEntity seatHold = SeatHoldEntity.create(
-				seatStatus.getSeat(),
-				seatStatus.getGame(),
-				userId,
-				queueTokenJti,
-				LocalDateTime.now().plus(seatHoldProperties.ttl())
-			);
-
-			UUID holdId = seatHoldRepository.save(seatHold).getId();
-			log.info(
-				"action=SEAT_HOLD gameId={} userId={} seatId={} holdId={}",
-				gameId,
-				userId,
-				seatId,
-				holdId
-			);
-			return holdId;
-		} catch (CustomException e) {
-			log.info(
-				"action=SEAT_HOLD_BLOCKED gameId={} userId={} seatId={} reason={}",
-				gameId,
-				userId,
-				seatId,
-				e.error().name()
-			);
-			throw e;
+		if (seatStatus.getStatus() != SeatStatus.AVAILABLE) {
+			throw blocked(gameId, userId, seatId, ErrorCode.SEAT_ALREADY_SELECTED);
 		}
+
+		seatStatus.hold();
+		seatStatusRepository.save(seatStatus);
+
+		// TODO: 좌석 점유 시 game_seat_inventories 카운트 반영
+		SeatHoldEntity seatHold = SeatHoldEntity.create(
+			seatStatus.getSeat(),
+			seatStatus.getGame(),
+			userId,
+			queueTokenJti,
+			LocalDateTime.now().plus(seatHoldProperties.ttl())
+		);
+
+		UUID holdId = seatHoldRepository.save(seatHold).getId();
+		log.info("action=SEAT_HOLD gameId={} userId={} seatId={} holdId={}", gameId, userId, seatId, holdId);
+		return holdId;
+	}
+
+	private CustomException blocked(UUID gameId, UUID userId, UUID seatId, ErrorCode errorCode) {
+		return new CustomException(errorCode)
+			.withContext("action", "SEAT_HOLD_BLOCKED")
+			.withContext("gameId", gameId)
+			.withContext("userId", userId)
+			.withContext("seatId", seatId);
 	}
 
 	@Transactional

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldTransactionalService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldTransactionalService.java
@@ -3,6 +3,8 @@ package com.goti.ticketing.seat.service.application;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +22,7 @@ import com.goti.ticketing.seat.repository.SeatStatusRepository;
 
 import lombok.RequiredArgsConstructor;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SeatHoldTransactionalService {
@@ -31,30 +34,49 @@ public class SeatHoldTransactionalService {
 
 	@Transactional
 	public UUID hold(UUID gameId, UUID seatId, UUID userId, String queueTokenJti) {
-		SeatStatusEntity seatStatus = seatStatusRepository.findByGameAndSeat(
-				gameScheduleRepository.getReferenceById(gameId),
-				seatRepository.getReferenceById(seatId)
-			)
-			.orElseThrow(() -> new CustomException(ErrorCode.SEAT_STATUS_NOT_FOUND));
+		try {
+			SeatStatusEntity seatStatus = seatStatusRepository.findByGameAndSeat(
+					gameScheduleRepository.getReferenceById(gameId),
+					seatRepository.getReferenceById(seatId)
+				)
+				.orElseThrow(() -> new CustomException(ErrorCode.SEAT_STATUS_NOT_FOUND));
 
-		Preconditions.validate(
-			seatStatus.getStatus() == SeatStatus.AVAILABLE,
-			ErrorCode.SEAT_ALREADY_SELECTED
-		);
+			Preconditions.validate(
+				seatStatus.getStatus() == SeatStatus.AVAILABLE,
+				ErrorCode.SEAT_ALREADY_SELECTED
+			);
 
-		seatStatus.hold();
-		seatStatusRepository.save(seatStatus);
+			seatStatus.hold();
+			seatStatusRepository.save(seatStatus);
 
-		// TODO: 좌석 점유 시 game_seat_inventories 카운트 반영
-		SeatHoldEntity seatHold = SeatHoldEntity.create(
-			seatStatus.getSeat(),
-			seatStatus.getGame(),
-			userId,
-			queueTokenJti,
-			LocalDateTime.now().plus(seatHoldProperties.ttl())
-		);
+			// TODO: 좌석 점유 시 game_seat_inventories 카운트 반영
+			SeatHoldEntity seatHold = SeatHoldEntity.create(
+				seatStatus.getSeat(),
+				seatStatus.getGame(),
+				userId,
+				queueTokenJti,
+				LocalDateTime.now().plus(seatHoldProperties.ttl())
+			);
 
-		return seatHoldRepository.save(seatHold).getId();
+			UUID holdId = seatHoldRepository.save(seatHold).getId();
+			log.info(
+				"action=SEAT_HOLD gameId={} userId={} seatId={} holdId={}",
+				gameId,
+				userId,
+				seatId,
+				holdId
+			);
+			return holdId;
+		} catch (CustomException e) {
+			log.info(
+				"action=SEAT_HOLD_BLOCKED gameId={} userId={} seatId={} reason={}",
+				gameId,
+				userId,
+				seatId,
+				e.error().name()
+			);
+			throw e;
+		}
 	}
 
 	@Transactional

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatStatusServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatStatusServiceImpl.java
@@ -6,6 +6,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import lombok.extern.slf4j.Slf4j;
+
 import com.goti.exception.CustomException;
 
 import org.springframework.stereotype.Service;
@@ -16,11 +18,13 @@ import com.goti.global.validation.Preconditions;
 import com.goti.ticketing.domain.entity.game.GameScheduleEntity;
 import com.goti.ticketing.domain.entity.seat.SeatEntity;
 import com.goti.ticketing.domain.entity.seat.SeatStatusEntity;
+import com.goti.ticketing.constants.SeatStatus;
 import com.goti.ticketing.seat.dto.response.GameSeatStatusResponse;
 import com.goti.ticketing.seat.repository.SeatStatusRepository;
 
 import lombok.RequiredArgsConstructor;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SeatStatusServiceImpl implements SeatStatusService {
@@ -38,9 +42,37 @@ public class SeatStatusServiceImpl implements SeatStatusService {
 			ErrorCode.AUTH_INVALID
 		);
 
-		return seatStatusRepository.findSeatStatuses(gameId, sectionId).stream()
+		List<GameSeatStatusResponse> seatStatuses = seatStatusRepository.findSeatStatuses(gameId, sectionId).stream()
 			.map(GameSeatStatusResponse::from)
 			.toList();
+
+		long total = seatStatuses.size();
+		long availableCount = seatStatuses.stream()
+			.filter(seatStatus -> seatStatus.status() == SeatStatus.AVAILABLE)
+			.count();
+		long heldCount = seatStatuses.stream()
+			.filter(seatStatus -> seatStatus.status() == SeatStatus.HELD)
+			.count();
+		long soldCount = seatStatuses.stream()
+			.filter(seatStatus -> seatStatus.status() == SeatStatus.SOLD)
+			.count();
+		long blockedCount = seatStatuses.stream()
+			.filter(seatStatus -> seatStatus.status() == SeatStatus.BLOCKED)
+			.count();
+
+		log.info(
+			"action=SEAT_STATUS gameId={} userId={} sectionId={} total={} available={} held={} sold={} blocked={}",
+			gameId,
+			userId,
+			sectionId,
+			total,
+			availableCount,
+			heldCount,
+			soldCount,
+			blockedCount
+		);
+
+		return seatStatuses;
 	}
 
 	@Override

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatStatusServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatStatusServiceImpl.java
@@ -46,30 +46,19 @@ public class SeatStatusServiceImpl implements SeatStatusService {
 			.map(GameSeatStatusResponse::from)
 			.toList();
 
-		long total = seatStatuses.size();
-		long availableCount = seatStatuses.stream()
-			.filter(seatStatus -> seatStatus.status() == SeatStatus.AVAILABLE)
-			.count();
-		long heldCount = seatStatuses.stream()
-			.filter(seatStatus -> seatStatus.status() == SeatStatus.HELD)
-			.count();
-		long soldCount = seatStatuses.stream()
-			.filter(seatStatus -> seatStatus.status() == SeatStatus.SOLD)
-			.count();
-		long blockedCount = seatStatuses.stream()
-			.filter(seatStatus -> seatStatus.status() == SeatStatus.BLOCKED)
-			.count();
+		Map<SeatStatus, Long> counts = seatStatuses.stream()
+			.collect(Collectors.groupingBy(GameSeatStatusResponse::status, Collectors.counting()));
 
 		log.info(
 			"action=SEAT_STATUS gameId={} userId={} sectionId={} total={} available={} held={} sold={} blocked={}",
 			gameId,
 			userId,
 			sectionId,
-			total,
-			availableCount,
-			heldCount,
-			soldCount,
-			blockedCount
+			seatStatuses.size(),
+			counts.getOrDefault(SeatStatus.AVAILABLE, 0L),
+			counts.getOrDefault(SeatStatus.HELD, 0L),
+			counts.getOrDefault(SeatStatus.SOLD, 0L),
+			counts.getOrDefault(SeatStatus.BLOCKED, 0L)
 		);
 
 		return seatStatuses;

--- a/ticketing/src/main/java/com/goti/ticketing/seat/utils/SeatHoldExpiryScheduler.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/utils/SeatHoldExpiryScheduler.java
@@ -37,7 +37,7 @@ public class SeatHoldExpiryScheduler {
 
 				if (result.attempted() > 0) {
 					log.info(
-						"좌석 점유 만료 처리 완료. attempted={}, succeeded={}, failed={}",
+						"action=HOLD_RELEASE_BATCH attempted={} succeeded={} failed={}",
 						result.attempted(),
 						result.succeeded(),
 						result.failed()
@@ -46,7 +46,7 @@ public class SeatHoldExpiryScheduler {
 
 				if (result.failed() > 0) {
 					log.warn(
-						"좌석 점유 만료 처리 중 실패 발생. attempted={}, succeeded={}, failed={}",
+						"action=HOLD_RELEASE_BATCH attempted={} succeeded={} failed={}",
 						result.attempted(),
 						result.succeeded(),
 						result.failed()
@@ -56,7 +56,7 @@ public class SeatHoldExpiryScheduler {
 		);
 
 		if (!acquired) {
-			log.debug("좌석 만료 스케줄러 락을 획득하지 못해 이번 실행을 건너뜁니다.");
+			log.debug("action=LOCK_TIMEOUT operation=SEAT_HOLD_EXPIRY_JOB");
 		}
 	}
 }


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#321 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
티켓팅 부하테스트 모니터링용 로그 추가
 좌석 점유/해제 관련 로그 포맷 통일
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
> 주문 생성 단계에서 좌석 hold 만료로 차단되는 경우 SESSION_BLOCK 로그 추가
결제 확정 직전 active hold 만료로 차단되는 경우 SESSION_BLOCK 로그 추가

> 좌석 점유 성공 시 SEAT_HOLD 로그 추가
좌석 점유 실패 시 SEAT_HOLD_BLOCKED 로그 추가
경기 좌석 상태 조회 시 SEAT_STATUS 로그 추가

> 좌석 점유 만료 배치 처리 로그를 HOLD_RELEASE_BATCH 포맷으로 통일
좌석 점유 만료 처리 중 개별 락 획득 실패 로그를 LOCK_TIMEOUT 포맷으로 통일
좌석 점유 만료 처리 실패 로그를 HOLD_RELEASE_FAILED 포맷으로 통일

<br/>