### PR TITLE
[CHORE] CD 워크플로우에 queue 모듈 빌드 추가 (#323)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Detect changed modules
         id: detect
         run: |
-          MSA_MODULES="user stadium ticketing payment resale"
+          MSA_MODULES="user stadium ticketing payment resale queue"
           SHARED_MODULES="common integration core"
 
           CHANGED=$(git diff --name-only HEAD~1 HEAD | grep -oP '^[^/]+' | sort -u)


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #323 

<br/>

## 🔎 개요
CD 워크플로우의 MSA 모듈 목록에 `queue`를 추가하여, queue 모듈 변경 시 Docker 이미지 자동 빌드·배포가 동작하도록 합니다.

<br/>


## 📋 작업 내용
- `cd.yml`의 `MSA_MODULES`에 `queue` 추가
  - Before: `"user stadium ticketing payment resale"`
  - After: `"user stadium ticketing payment resale queue"`
- ECR `goti-queue` 레포 및 K8s ApplicationSet은 별도 레포에서 준비 완료

<br/>