### PR TITLE
[CHORE] POC CD 워크플로우에 ticketing 모듈 빌드 옵션 추가 (#338)

### DIFF
--- a/.github/workflows/cd-poc-queue.yml
+++ b/.github/workflows/cd-poc-queue.yml
@@ -26,11 +26,12 @@ on:
         type: string
         default: "auto"
       build_module:
-        description: "빌드할 모듈 (queue: MSA 큐 모듈, api: 모놀리스 전체)"
+        description: "빌드할 모듈 (queue: MSA 큐, ticketing: MSA 티켓팅, api: 모놀리스)"
         required: true
         type: choice
         options:
           - queue
+          - ticketing
           - api
         default: queue
 
@@ -88,10 +89,10 @@ jobs:
       - name: Build ${{ inputs.build_module || 'queue' }} bootJar
         run: |
           MODULE="${{ inputs.build_module || 'queue' }}"
-          if [ "$MODULE" = "queue" ]; then
-            ./gradlew :queue:bootJar -Pmsa --no-daemon -x test
+          if [ "$MODULE" = "api" ]; then
+            ./gradlew :api:bootJar --no-daemon -x test
           else
-            ./gradlew :${MODULE}:bootJar --no-daemon -x test
+            ./gradlew :${MODULE}:bootJar -Pmsa --no-daemon -x test
           fi
 
       - name: Configure AWS credentials (OIDC)


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #338 

<br/>

## 🔎 개요
POC 부하테스트에서 ticketing MSA 모듈을 별도 pod으로 배포하기 위해,
`cd-poc-queue.yml`의 `build_module` 옵션에 `ticketing`을 추가합니다.

<br/>


## 📋 작업 내용
- `build_module` choice에 `ticketing` 옵션 추가 (queue / ticketing / api)

<br/>