### PR TITLE
[FEAT] 회원 계좌 정보 엔티티 추가

### DIFF
--- a/user/src/main/java/com/goti/user/domain/entity/user/AccountEntity.java
+++ b/user/src/main/java/com/goti/user/domain/entity/user/AccountEntity.java
@@ -1,0 +1,86 @@
+package com.goti.user.domain.entity.user;
+
+import com.goti.domain.base.ModificationTimestampEntity;
+
+import com.goti.global.validation.Preconditions;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import org.springframework.util.StringUtils;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Entity
+@Table(name = "accounts")
+@NoArgsConstructor(access = PROTECTED)
+public class AccountEntity extends ModificationTimestampEntity {
+
+	@Column(nullable = false)
+	private String accountNumber;
+
+	@Column(nullable = false)
+	private String bankName;
+
+	@Column(nullable = false)
+	private String accountHolder;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", unique = true, nullable = false)
+	private MemberEntity member;
+
+	private AccountEntity(
+		String accountNumber,
+		String bankName,
+		String accountHolder,
+		MemberEntity member
+	) {
+		this.accountNumber = accountNumber;
+		this.bankName = bankName;
+		this.accountHolder = accountHolder;
+		this.member = member;
+	}
+
+	public static AccountEntity create(
+		final String accountNumber,
+		final String bankName,
+		final String accountHolder,
+		final MemberEntity member
+	) {
+		validate(accountNumber, bankName, accountHolder, member);
+		return new AccountEntity(
+			accountNumber, bankName, accountHolder, member
+		);
+	}
+
+	private static void validate(
+		String accountNumber,
+		String bankName,
+		String accountHolder,
+		MemberEntity member
+	) {
+		Preconditions.domainValidate(
+			StringUtils.hasText(accountNumber), "계좌번호는 비어 있을 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			StringUtils.hasText(bankName), "계좌 은행은 비어 있을 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			StringUtils.hasText(accountHolder), "계좌 예금주는 비어 있을 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			member != null, "회원 정보는 비어 있을 수 없습니다."
+		);
+	}
+
+}

--- a/user/src/test/java/account/AccountEntityTest.java
+++ b/user/src/test/java/account/AccountEntityTest.java
@@ -1,17 +1,24 @@
 package account;
 
 import com.goti.constants.Gender;
+import com.goti.exception.FieldValidationException;
 import com.goti.user.domain.entity.user.AccountEntity;
 import com.goti.user.domain.entity.user.MemberEntity;
+
+import com.goti.user.domain.entity.user.SocialProviderEntity;
 
 import lombok.extern.slf4j.Slf4j;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.NullSource;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDate;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 @Slf4j
@@ -26,13 +33,13 @@ public class AccountEntityTest {
 			"01012341234",
 			"테스트회원",
 			Gender.MALE,
-			LocalDate.of(2026, 2, 4)
+			LocalDate.of(2000, 2, 4)
 		);
 		assertNotNull(member);
 	}
 
 	@Test
-	void 회원_계좌_생성() {
+	void 계좌_생성_성공() {
 		AccountEntity accountEntity = AccountEntity.create(
 			"1002-876-543210",
 			"우리은행",
@@ -40,9 +47,73 @@ public class AccountEntityTest {
 			member
 		);
 		assertNotNull(accountEntity);
+		assertEquals("1002-876-543210", accountEntity.getAccountNumber());
+		assertEquals("우리은행", accountEntity.getBankName());
+		assertEquals("테스트예금주", accountEntity.getAccountHolder());
+		assertEquals(member, accountEntity.getMember());
 		log.info("account name:: {}", accountEntity.getAccountNumber());
 		log.info("account holder:: {}", accountEntity.getAccountHolder());
 		log.info("account bankName:: {}", accountEntity.getBankName());
 	}
+
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	void 계좌_생성_실패_account_number_null_또는_공백(String accountNumber) {
+		assertThatThrownBy(
+			() -> AccountEntity.create(
+				accountNumber,
+				"우리은행",
+				"테스트예금주",
+				member
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("계좌번호는 비어 있을 수 없습니다.");
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	void 계좌_생성_실패_bank_name_null_또는_공백(String bankName) {
+		assertThatThrownBy(
+			() -> AccountEntity.create(
+				"1002-876-543210",
+				bankName,
+				"테스트예금주",
+				member
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("계좌 은행은 비어 있을 수 없습니다.");
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	void 계좌_생성_실패_account_holder_null_또는_공백(String accountHolder) {
+		assertThatThrownBy(
+			() -> AccountEntity.create(
+				"1002-876-543210",
+				"우리은행",
+				accountHolder,
+				member
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("계좌 예금주는 비어 있을 수 없습니다.");
+	}
+
+	@Test
+	void 계좌_생성_실패_member_null() {
+		assertThatThrownBy(
+			() -> AccountEntity.create(
+				"1002-876-543210",
+				"우리은행",
+				"테스트예금주",
+				null
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("회원 정보는 비어 있을 수 없습니다.");
+	}
+
+
+
+
 
 }

--- a/user/src/test/java/account/AccountEntityTest.java
+++ b/user/src/test/java/account/AccountEntityTest.java
@@ -1,0 +1,48 @@
+package account;
+
+import com.goti.constants.Gender;
+import com.goti.user.domain.entity.user.AccountEntity;
+import com.goti.user.domain.entity.user.MemberEntity;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+@ActiveProfiles("test")
+public class AccountEntityTest {
+
+	MemberEntity member;
+
+	@BeforeEach
+	void setup() {
+		member = MemberEntity.create(
+			"01012341234",
+			"테스트회원",
+			Gender.MALE,
+			LocalDate.of(2026, 2, 4)
+		);
+		assertNotNull(member);
+	}
+
+	@Test
+	void 회원_계좌_생성() {
+		AccountEntity accountEntity = AccountEntity.create(
+			"1002-876-543210",
+			"우리은행",
+			"테스트예금주",
+			member
+		);
+		assertNotNull(accountEntity);
+		log.info("account name:: {}", accountEntity.getAccountNumber());
+		log.info("account holder:: {}", accountEntity.getAccountHolder());
+		log.info("account bankName:: {}", accountEntity.getBankName());
+	}
+
+}


### PR DESCRIPTION
회원 계좌 엔티티 추가 및 도메인 테스트 코드 추가

<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#335 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
- 회원계좌 (AccountEntity) 엔티티 추가 (회원 (MemberEntity) 과 1:1 (단방향매핑) 되는 엔티티)
- 회원 계좌 도메인 테스트코드 추가 
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->


<br/>