### PR TITLE
[BUG] 게임 예매 상태 값 변경 로직 누락 이슈 해결

### DIFF
--- a/ticketing/src/main/java/com/goti/ticketing/domain/entity/game/GameTicketingStatusEntity.java
+++ b/ticketing/src/main/java/com/goti/ticketing/domain/entity/game/GameTicketingStatusEntity.java
@@ -40,6 +40,10 @@ public class GameTicketingStatusEntity extends ModificationTimestampEntity {
 	@Column(nullable = false)
 	private TicketingStatus status;
 
+	public void updateStatus(TicketingStatus status) {
+		this.status = status;
+	}
+
 	private GameTicketingStatusEntity(
 		GameScheduleEntity gameSchedule,
 		LocalDateTime ticketingOpenedAt,

--- a/ticketing/src/main/java/com/goti/ticketing/game/repository/GameTicketingStatusRepository.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/repository/GameTicketingStatusRepository.java
@@ -1,12 +1,26 @@
 package com.goti.ticketing.game.repository;
 
+import com.goti.ticketing.constants.TicketingStatus;
 import com.goti.ticketing.domain.entity.game.GameTicketingStatusEntity;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface GameTicketingStatusRepository extends JpaRepository<GameTicketingStatusEntity, UUID> {
+
+	@Query("SELECT ticketing_status " +
+		  		 "FROM GameTicketingStatusEntity ticketing_status " +
+					"WHERE ticketing_status.status = :status " +
+						"AND ticketing_status.ticketingOpenedAt <= :now")
+	List<GameTicketingStatusEntity> findOpenableSchedules(
+		@Param("status") TicketingStatus status,
+		@Param("now") LocalDateTime now
+	);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/game/repository/GameTicketingStatusRepository.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/repository/GameTicketingStatusRepository.java
@@ -15,12 +15,23 @@ import java.util.UUID;
 @Repository
 public interface GameTicketingStatusRepository extends JpaRepository<GameTicketingStatusEntity, UUID> {
 
-	@Query("SELECT ticketing_status " +
-		  		 "FROM GameTicketingStatusEntity ticketing_status " +
-					"WHERE ticketing_status.status = :status " +
-						"AND ticketing_status.ticketingOpenedAt <= :now")
+	@Query(
+		"SELECT ticketing_status " +
+			"FROM GameTicketingStatusEntity ticketing_status " +
+		 "WHERE ticketing_status.status = :status " +
+			 "AND ticketing_status.ticketingOpenedAt <= :now"
+	)
 	List<GameTicketingStatusEntity> findOpenableSchedules(
 		@Param("status") TicketingStatus status,
 		@Param("now") LocalDateTime now
 	);
+
+	@Query(
+		"SELECT ticketing_status " +
+			"FROM GameTicketingStatusEntity ticketing_status " +
+		 "WHERE ticketing_status.status " +
+			  "IN (com.goti.ticketing.constants.TicketingStatus.AVAILABLE, " +
+						"com.goti.ticketing.constants.TicketingStatus.EXHAUSTED) " +
+			 "AND ticketing_status.ticketingEndAt <= :now ")
+	List<GameTicketingStatusEntity> findTerminatableSchedules(@Param("now") LocalDateTime now);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/game/repository/GameTicketingStatusRepository.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/repository/GameTicketingStatusRepository.java
@@ -30,8 +30,10 @@ public interface GameTicketingStatusRepository extends JpaRepository<GameTicketi
 		"SELECT ticketing_status " +
 			"FROM GameTicketingStatusEntity ticketing_status " +
 		 "WHERE ticketing_status.status " +
-			  "IN (com.goti.ticketing.constants.TicketingStatus.AVAILABLE, " +
-						"com.goti.ticketing.constants.TicketingStatus.EXHAUSTED) " +
+			  "IN :statuses " +
 			 "AND ticketing_status.ticketingEndAt <= :now ")
-	List<GameTicketingStatusEntity> findTerminatableSchedules(@Param("now") LocalDateTime now);
+	List<GameTicketingStatusEntity> findTerminatableSchedules(
+		@Param("statuses") List<TicketingStatus> statuses,
+		@Param("now") LocalDateTime now
+	);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/game/scheduler/GameTicketingStatusScheduler.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/scheduler/GameTicketingStatusScheduler.java
@@ -22,7 +22,7 @@ public class GameTicketingStatusScheduler {
 
 	@Transactional
 	@Scheduled(cron = "0 0 11 * * *")
-	public void updateTicketingStatus() {
+	public void openScheduledTicketing() {
 		List<GameTicketingStatusEntity> list = ticketingStatusRepository.findOpenableSchedules(
 			TicketingStatus.SCHEDULED,
 			LocalDateTime.now()
@@ -31,8 +31,20 @@ public class GameTicketingStatusScheduler {
 		list.forEach(
 			ticketingStatus -> ticketingStatus.updateStatus(TicketingStatus.AVAILABLE)
 		);
-
 	}
 
+	@Transactional
+	@Scheduled(cron = "0 0 14,15,18 * * *")
+	@Scheduled(cron = "0 30 19 * * *")
+	public void terminateExpiredTicketing() {
+		LocalDateTime now = LocalDateTime.now();
+		List<GameTicketingStatusEntity> list =
+			ticketingStatusRepository.findTerminatableSchedules(now);
+
+		list.forEach(
+			ticketingStatus -> ticketingStatus.updateStatus(TicketingStatus.TERMINATED)
+		);
+
+	}
 
 }

--- a/ticketing/src/main/java/com/goti/ticketing/game/scheduler/GameTicketingStatusScheduler.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/scheduler/GameTicketingStatusScheduler.java
@@ -37,13 +37,19 @@ public class GameTicketingStatusScheduler {
 	@Scheduled(cron = "0 0 14,15,18 * * *")
 	@Scheduled(cron = "0 30 19 * * *")
 	public void terminateExpiredTicketing() {
+		List<TicketingStatus> statuses = List.of(
+			TicketingStatus.AVAILABLE, TicketingStatus.EXHAUSTED
+		);
 		LocalDateTime now = LocalDateTime.now();
 		List<GameTicketingStatusEntity> list =
-			ticketingStatusRepository.findTerminatableSchedules(now);
+			ticketingStatusRepository.findTerminatableSchedules(statuses, now);
 
-		list.forEach(
-			ticketingStatus -> ticketingStatus.updateStatus(TicketingStatus.TERMINATED)
-		);
+		if (!list.isEmpty()) {
+			list.forEach(
+				ticketingStatus -> ticketingStatus.updateStatus(TicketingStatus.TERMINATED)
+			);
+		}
+
 
 	}
 

--- a/ticketing/src/main/java/com/goti/ticketing/game/scheduler/GameTicketingStatusScheduler.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/scheduler/GameTicketingStatusScheduler.java
@@ -1,0 +1,38 @@
+package com.goti.ticketing.game.scheduler;
+
+import com.goti.ticketing.constants.TicketingStatus;
+import com.goti.ticketing.domain.entity.game.GameTicketingStatusEntity;
+import com.goti.ticketing.game.repository.GameTicketingStatusRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class GameTicketingStatusScheduler {
+
+
+	private final GameTicketingStatusRepository ticketingStatusRepository;
+
+	@Transactional
+	@Scheduled(cron = "0 0 11 * * *")
+	public void updateTicketingStatus() {
+		List<GameTicketingStatusEntity> list = ticketingStatusRepository.findOpenableSchedules(
+			TicketingStatus.SCHEDULED,
+			LocalDateTime.now()
+		);
+
+		list.forEach(
+			ticketingStatus -> ticketingStatus.updateStatus(TicketingStatus.AVAILABLE)
+		);
+
+	}
+
+
+}


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#348
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
경기 예매 (Ticketing) 상태 값 변경 로직 추가 (Scheduler)
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- 야구경기(게임) 예매 상태 값(GameTicketingStatus - status) 변경 로직 누락 이슈 -> Scheduler 추가 (매일 오전 11시 해당 날짜에 포함되는 건에 한해 예매 상태값: 판매예정(SCHEDULED) -> 구매가능 (AVAILABLE))
- 경기 예매 마감 시 -> 경기예매상태 값: 매진 or 구매가능 -> 판매종료 변경 스케쥴러 로직 구현 및 추가 (in GameTicketingStatusScheduler)
<br/>