### PR TITLE
[FEAT] 회원 주소 엔티티 추가

### DIFF
--- a/user/src/main/java/com/goti/user/domain/entity/user/AddressEntity.java
+++ b/user/src/main/java/com/goti/user/domain/entity/user/AddressEntity.java
@@ -1,0 +1,80 @@
+package com.goti.user.domain.entity.user;
+
+import com.goti.domain.base.ModificationTimestampEntity;
+
+import com.goti.global.validation.Preconditions;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import org.springframework.util.StringUtils;
+
+import static lombok.AccessLevel.*;
+
+@Getter
+@Entity
+@Table(name = "addresses")
+@NoArgsConstructor(access = PROTECTED)
+public class AddressEntity extends ModificationTimestampEntity {
+
+	@Column(nullable = false, length = 10)
+	private String zipCode;
+
+	@Column(nullable = false)
+	private String baseAddress;
+
+	@Column(nullable = false)
+	private String detailAddress;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", unique = true, nullable = false)
+	private MemberEntity member;
+
+	private AddressEntity(
+		String zipCode, String baseAddress, String detailAddress, MemberEntity member
+	) {
+		this.zipCode = zipCode;
+		this.baseAddress = baseAddress;
+		this.detailAddress = detailAddress;
+		this.member = member;
+	}
+
+	public static AddressEntity create(
+		final String zipCode,
+		final String baseAddress,
+		final String detailAddress,
+		final MemberEntity member
+	) {
+		validate(zipCode, baseAddress, detailAddress, member);
+		return new AddressEntity(
+			zipCode, baseAddress, detailAddress, member
+		);
+	}
+
+	private static void validate(
+		String zipCode, String baseAddress, String detailAddress, MemberEntity member
+	) {
+		Preconditions.domainValidate(
+			StringUtils.hasText(zipCode),
+			"우편번호는 비어있을 수 없습니다."
+		);
+		Preconditions.domainValidate(
+			StringUtils.hasText(baseAddress),
+			"기본 주소는 비어있을 수 없습니다."
+		);
+		Preconditions.domainValidate(
+			StringUtils.hasText(detailAddress),
+			"상세 주소는 비어있을 수 없습니다."
+		);
+		Preconditions.domainValidate(
+			member != null,
+			"회원 정보는 비어있을 수 없습니다."
+		);
+	}
+}

--- a/user/src/test/java/domain/account/AccountEntityTest.java
+++ b/user/src/test/java/domain/account/AccountEntityTest.java
@@ -1,4 +1,4 @@
-package account;
+package domain.account;
 
 import com.goti.constants.Gender;
 import com.goti.exception.FieldValidationException;

--- a/user/src/test/java/domain/address/AddressEntityTest.java
+++ b/user/src/test/java/domain/address/AddressEntityTest.java
@@ -5,8 +5,6 @@ import com.goti.exception.FieldValidationException;
 import com.goti.user.domain.entity.user.AddressEntity;
 import com.goti.user.domain.entity.user.MemberEntity;
 
-import lombok.extern.slf4j.Slf4j;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -18,7 +16,6 @@ import java.time.LocalDate;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-@Slf4j
 @ActiveProfiles("test")
 public class AddressEntityTest {
 	MemberEntity member;
@@ -47,9 +44,6 @@ public class AddressEntityTest {
 		assertEquals("서울특별시 강남구 학동로 343", address.getBaseAddress());
 		assertEquals("(논현동, 포바강남타워) 4층, 15층", address.getDetailAddress());
 		assertEquals(member, address.getMember());
-		log.info("address zipCode : {}", address.getZipCode());
-		log.info("address baseAddress : {}", address.getBaseAddress());
-		log.info("address detailAddress : {}", address.getDetailAddress());
 	}
 
 	@ParameterizedTest

--- a/user/src/test/java/domain/address/AddressEntityTest.java
+++ b/user/src/test/java/domain/address/AddressEntityTest.java
@@ -2,7 +2,6 @@ package domain.address;
 
 import com.goti.constants.Gender;
 import com.goti.exception.FieldValidationException;
-import com.goti.user.domain.entity.user.AccountEntity;
 import com.goti.user.domain.entity.user.AddressEntity;
 import com.goti.user.domain.entity.user.MemberEntity;
 

--- a/user/src/test/java/domain/address/AddressEntityTest.java
+++ b/user/src/test/java/domain/address/AddressEntityTest.java
@@ -1,0 +1,111 @@
+package domain.address;
+
+import com.goti.constants.Gender;
+import com.goti.exception.FieldValidationException;
+import com.goti.user.domain.entity.user.AccountEntity;
+import com.goti.user.domain.entity.user.AddressEntity;
+import com.goti.user.domain.entity.user.MemberEntity;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+@ActiveProfiles("test")
+public class AddressEntityTest {
+	MemberEntity member;
+
+	@BeforeEach
+	void setup() {
+		member = MemberEntity.create(
+			"01012341234",
+			"테스트회원",
+			Gender.MALE,
+			LocalDate.of(2000, 2, 4)
+		);
+		assertNotNull(member);
+	}
+
+	@Test
+	void 주소_정보_생성_성공() {
+		AddressEntity address = AddressEntity.create(
+			"06111",
+			"서울특별시 강남구 학동로 343",
+			"(논현동, 포바강남타워) 4층, 15층",
+			member
+		);
+		assertNotNull(address);
+		assertEquals("06111", address.getZipCode());
+		assertEquals("서울특별시 강남구 학동로 343", address.getBaseAddress());
+		assertEquals("(논현동, 포바강남타워) 4층, 15층", address.getDetailAddress());
+		assertEquals(member, address.getMember());
+		log.info("address zipCode : {}", address.getZipCode());
+		log.info("address baseAddress : {}", address.getBaseAddress());
+		log.info("address detailAddress : {}", address.getDetailAddress());
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	void 주소_생성_실패_zipCode_null_또는_공백(String zipCode) {
+		assertThatThrownBy(
+			() -> AddressEntity.create(
+				zipCode,
+				"서울특별시 강남구 학동로 343",
+				"(논현동, 포바강남타워) 4층, 15층",
+				member
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("우편번호는 비어있을 수 없습니다.");
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	void 주소_생성_실패_baseAddress_null_또는_공백(String baseAddress) {
+		assertThatThrownBy(
+			() -> AddressEntity.create(
+				"06111",
+				baseAddress,
+				"(논현동, 포바강남타워) 4층, 15층",
+				member
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("기본 주소는 비어있을 수 없습니다.");
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	void 주소_생성_실패_detailAddress_null_또는_공백(String detailAddress) {
+		assertThatThrownBy(
+			() -> AddressEntity.create(
+				"06111",
+				"서울특별시 강남구 학동로 343",
+				detailAddress,
+				member
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("상세 주소는 비어있을 수 없습니다.");
+	}
+
+	@Test
+	void 주소_생성_실패_member_null() {
+		assertThatThrownBy(
+			() -> AddressEntity.create(
+				"06111",
+				"서울특별시 강남구 학동로 343",
+				"(논현동, 포바강남타워) 4층, 15층",
+				null
+			)
+		).isInstanceOf(FieldValidationException.class)
+			.hasMessageContaining("회원 정보는 비어있을 수 없습니다.");
+	}
+
+}

--- a/user/src/test/java/domain/user/MemberEntityTest.java
+++ b/user/src/test/java/domain/user/MemberEntityTest.java
@@ -1,4 +1,4 @@
-package user;
+package domain.user;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;

--- a/user/src/test/java/domain/user/SocialProviderEntityTest.java
+++ b/user/src/test/java/domain/user/SocialProviderEntityTest.java
@@ -1,4 +1,4 @@
-package user;
+package domain.user;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#344 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
회원(MemberEntity) 와 1:1 매핑되는 주소 (AddressEntity) 도메인 엔티티 추가 및 도메인 엔티티 테스트
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- 회원(MemberEntity) 와 1:1 매핑되는 주소 (AddressEntity) 도메인 엔티티
- 주소 (AddressEntity) 도메인 엔티티 테스트 (AddressEntityTest)
- User 모듈 내 도메인 엔티티 테스트 파일 -> 패키지 생성 및 각 패키지 밑으로 이동 (test -> domain/account, user, address 생성)
<br/>