### PR TITLE
[BUG]  예매 세션 새로 진입/재진입 구분 및 Redis 역직렬화 처리 개선

### DIFF
--- a/integration/src/main/java/com/goti/infra/cache/RedisCache.java
+++ b/integration/src/main/java/com/goti/infra/cache/RedisCache.java
@@ -1,5 +1,7 @@
 package com.goti.infra.cache;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
@@ -14,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class RedisCache {
 	private final RedisTemplate<String, Object> redisTemplate;
+	private final ObjectMapper objectMapper;
 
 	public <T> void set(String key, T value) {
 		redisTemplate.opsForValue().set(key, value);
@@ -29,7 +32,13 @@ public class RedisCache {
 
 	public <T> T get(String key, Class<T> clazz) {
 		Object value = redisTemplate.opsForValue().get(key);
-		return value != null ? clazz.cast(value) : null;
+		if (value == null) {
+			return null;
+		}
+		if (clazz.isInstance(value)) {
+			return clazz.cast(value);
+		}
+		return objectMapper.convertValue(value, clazz);
 	}
 
 	public boolean delete(String key) {

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderExpiryService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderExpiryService.java
@@ -16,7 +16,7 @@ import com.goti.ticketing.domain.entity.seat.SeatHoldEntity;
 import com.goti.ticketing.domain.entity.seat.SeatStatusEntity;
 import com.goti.ticketing.order.service.domain.OrderItemService;
 import com.goti.ticketing.order.service.domain.OrderService;
-import com.goti.ticketing.seat.service.domain.SeatHoldExpiryService;
+import com.goti.ticketing.seat.service.domain.SeatHoldService;
 import com.goti.ticketing.seat.service.domain.SeatStatusService;
 
 import lombok.RequiredArgsConstructor;
@@ -26,7 +26,7 @@ import lombok.RequiredArgsConstructor;
 public class OrderExpiryService {
 	private final OrderService orderService;
 	private final OrderItemService orderItemService;
-	private final SeatHoldExpiryService seatHoldExpiryService;
+	private final SeatHoldService seatHoldService;
 	private final SeatStatusService seatStatusService;
 
 	@Transactional
@@ -42,7 +42,7 @@ public class OrderExpiryService {
 			.map(orderItem -> orderItem.getSeat().getId())
 			.toList();
 
-		Map<UUID, SeatHoldEntity> seatHoldMap = seatHoldExpiryService.getByIds(holdIds);
+		Map<UUID, SeatHoldEntity> seatHoldMap = seatHoldService.getByIds(holdIds);
 		Map<UUID, SeatStatusEntity> seatStatusMap = seatStatusService.getByGameIdAndSeatIds(
 			order.getGameSchedule().getId(),
 			seatIds
@@ -61,7 +61,7 @@ public class OrderExpiryService {
 				ErrorCode.SEAT_STATUS_NOT_FOUND
 			);
 
-			seatHoldExpiryService.expire(seatStatus, seatHold, LocalDateTime.now());
+			seatHoldService.expire(seatStatus, seatHold, LocalDateTime.now());
 			orderItemService.expire(orderItem);
 		}
 	}

--- a/ticketing/src/main/java/com/goti/ticketing/seat/controller/SeatReservationController.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/controller/SeatReservationController.java
@@ -41,14 +41,13 @@ public class SeatReservationController {
 		@Valid @RequestBody HoldSeatRequest request
 	) {
 		// TODO: 대기열 구현 완료 후 queueTokenJti를 요청값이 아닌 queue token claim(jti)에서 추출하도록 변경
-		HoldSeatResponse response = HoldSeatResponse.from(
-			seatHoldManageService.hold(
-				request.gameId(),
-				seatId,
-				memberId,
-				request.queueTokenJti()
-			)
+		UUID holdId = seatHoldManageService.hold(
+			request.gameId(),
+			seatId,
+			memberId,
+			request.queueTokenJti()
 		);
+		HoldSeatResponse response = HoldSeatResponse.from(holdId);
 		return wrap(response);
 	}
 
@@ -61,9 +60,8 @@ public class SeatReservationController {
 		@PathVariable UUID holdId,
 		@AuthenticationPrincipal(expression = "id") UUID memberId
 	) {
-		ReleaseSeatResponse response = ReleaseSeatResponse.from(
-			seatHoldManageService.release(holdId, memberId)
-		);
+		UUID releasedHoldId = seatHoldManageService.release(holdId, memberId);
+		ReleaseSeatResponse response = ReleaseSeatResponse.from(releasedHoldId);
 		return wrap(response);
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/controller/SeatReservationController.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/controller/SeatReservationController.java
@@ -16,7 +16,7 @@ import com.goti.global.api.ApiSuccessResponse;
 import com.goti.ticketing.seat.dto.request.HoldSeatRequest;
 import com.goti.ticketing.seat.dto.response.HoldSeatResponse;
 import com.goti.ticketing.seat.dto.response.ReleaseSeatResponse;
-import com.goti.ticketing.seat.service.application.SeatHoldService;
+import com.goti.ticketing.seat.service.application.SeatHoldManageService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -28,7 +28,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/seat-reservations")
 public class SeatReservationController {
-	private final SeatHoldService seatHoldService;
+	private final SeatHoldManageService seatHoldManageService;
 
 	@Operation(
 		summary = "좌석 점유",
@@ -42,7 +42,7 @@ public class SeatReservationController {
 	) {
 		// TODO: 대기열 구현 완료 후 queueTokenJti를 요청값이 아닌 queue token claim(jti)에서 추출하도록 변경
 		HoldSeatResponse response = HoldSeatResponse.from(
-			seatHoldService.hold(
+			seatHoldManageService.hold(
 				request.gameId(),
 				seatId,
 				memberId,
@@ -62,7 +62,7 @@ public class SeatReservationController {
 		@AuthenticationPrincipal(expression = "id") UUID memberId
 	) {
 		ReleaseSeatResponse response = ReleaseSeatResponse.from(
-			seatHoldService.release(holdId, memberId)
+			seatHoldManageService.release(holdId, memberId)
 		);
 		return wrap(response);
 	}

--- a/ticketing/src/main/java/com/goti/ticketing/seat/controller/StadiumSeatController.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/controller/StadiumSeatController.java
@@ -64,9 +64,10 @@ public class StadiumSeatController {
 	public ResponseEntity<ApiSuccessResponse<SeatGradeSearchResultResponse>> getSeatGrades(
 		@AuthenticationPrincipal(expression = "id") UUID userId,
 		@PathVariable UUID stadiumId,
-		@PathVariable UUID gameId
+		@PathVariable UUID gameId,
+		@RequestParam(defaultValue = "false") boolean forceNewSession
 	) {
-		return wrap(seatGradeService.get(stadiumId, gameId, userId));
+		return wrap(seatGradeService.get(stadiumId, gameId, userId, forceNewSession));
 	}
 
 	@Operation(

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldExpiryTransactionalService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldExpiryTransactionalService.java
@@ -12,7 +12,7 @@ import com.goti.ticketing.domain.entity.seat.SeatStatusEntity;
 import com.goti.exception.CustomException;
 import com.goti.ticketing.seat.repository.SeatHoldRepository;
 import com.goti.ticketing.seat.repository.SeatStatusRepository;
-import com.goti.ticketing.seat.service.domain.SeatHoldExpiryService;
+import com.goti.ticketing.seat.service.domain.SeatHoldService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -21,7 +21,7 @@ import lombok.RequiredArgsConstructor;
 public class SeatHoldExpiryTransactionalService {
 	private final SeatHoldRepository seatHoldRepository;
 	private final SeatStatusRepository seatStatusRepository;
-	private final SeatHoldExpiryService seatHoldExpiryService;
+	private final SeatHoldService seatHoldService;
 
 	@Transactional
 	public void expire(UUID holdId, LocalDateTime now) {
@@ -34,7 +34,7 @@ public class SeatHoldExpiryTransactionalService {
 		)
 			.orElseThrow(() -> new CustomException(ErrorCode.SEAT_STATUS_NOT_FOUND));
 
-		seatHoldExpiryService.expire(seatStatus, seatHold, now);
+		seatHoldService.expire(seatStatus, seatHold, now);
 		seatStatusRepository.save(seatStatus);
 		seatHoldRepository.save(seatHold);
 	}

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldManageService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldManageService.java
@@ -6,18 +6,17 @@ import org.springframework.stereotype.Service;
 
 import com.goti.constants.messages.ErrorCode;
 import com.goti.ticketing.domain.entity.seat.SeatHoldEntity;
-import com.goti.exception.CustomException;
 import com.goti.infra.lock.DistributedLockManager;
 import com.goti.global.validation.Preconditions;
-import com.goti.ticketing.seat.repository.SeatHoldRepository;
+import com.goti.ticketing.seat.service.domain.SeatHoldService;
 import com.goti.ticketing.session.service.application.ReservationSessionService;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-public class SeatHoldService {
-	private final SeatHoldRepository seatHoldRepository;
+public class SeatHoldManageService {
+	private final SeatHoldService seatHoldService;
 	private final DistributedLockManager distributedLockManager;
 	private final SeatHoldTransactionalService seatHoldTransactionalService;
 	private final ReservationSessionService reservationSessionService;
@@ -33,16 +32,14 @@ public class SeatHoldService {
 	}
 
 	public UUID release(UUID holdId, UUID userId) {
-		SeatHoldEntity seatHold = seatHoldRepository.findById(holdId)
-			.orElseThrow(() -> new CustomException(ErrorCode.SEAT_HOLD_NOT_FOUND));
+		SeatHoldEntity seatHold = seatHoldService.get(holdId);
 
 		String lockKey = buildLockKey(seatHold.getGameSchedule().getId(), seatHold.getSeat().getId());
 		return distributedLockManager.withLock(lockKey, () -> seatHoldTransactionalService.release(holdId, userId));
 	}
 
 	public UUID release(UUID gameId, UUID holdId, UUID userId) {
-		SeatHoldEntity seatHold = seatHoldRepository.findById(holdId)
-			.orElseThrow(() -> new CustomException(ErrorCode.SEAT_HOLD_NOT_FOUND));
+		SeatHoldEntity seatHold = seatHoldService.get(holdId);
 
 		Preconditions.validate(
 			seatHold.getGameSchedule().getId().equals(gameId),

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldManageService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldManageService.java
@@ -32,14 +32,14 @@ public class SeatHoldManageService {
 	}
 
 	public UUID release(UUID holdId, UUID userId) {
-		SeatHoldEntity seatHold = seatHoldService.get(holdId);
+		SeatHoldEntity seatHold = seatHoldService.findSeatHold(holdId);
 
 		String lockKey = buildLockKey(seatHold.getGameSchedule().getId(), seatHold.getSeat().getId());
 		return distributedLockManager.withLock(lockKey, () -> seatHoldTransactionalService.release(holdId, userId));
 	}
 
 	public UUID release(UUID gameId, UUID holdId, UUID userId) {
-		SeatHoldEntity seatHold = seatHoldService.get(holdId);
+		SeatHoldEntity seatHold = seatHoldService.findSeatHold(holdId);
 
 		Preconditions.validate(
 			seatHold.getGameSchedule().getId().equals(gameId),

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatGradeService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatGradeService.java
@@ -10,5 +10,5 @@ import com.goti.ticketing.seat.dto.response.SeatGradeSearchResultResponse;
 public interface SeatGradeService {
 	SeatGradeRegisterResponse create(UUID stadiumId, String name, String displayColorHex);
 
-	SeatGradeSearchResultResponse get(UUID stadiumId, UUID gameId, UUID userId);
+	SeatGradeSearchResultResponse get(UUID stadiumId, UUID gameId, UUID userId, boolean forceNewSession);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatGradeServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatGradeServiceImpl.java
@@ -45,13 +45,19 @@ public class SeatGradeServiceImpl implements SeatGradeService {
 
 	@Override
 	@Transactional(readOnly = true)
-	public SeatGradeSearchResultResponse get(UUID stadiumId, UUID gameId, UUID userId) {
+	public SeatGradeSearchResultResponse get(
+		UUID stadiumId,
+		UUID gameId,
+		UUID userId,
+		boolean forceNewSession
+	) {
 		Preconditions.validate(
 			userId != null,
 			ErrorCode.AUTH_INVALID
 		);
 
-		ReservationSessionCache reservationSession = reservationSessionService.getOrCreate(userId, gameId);
+		ReservationSessionCache reservationSession = reservationSessionService
+			.getOrCreate(userId, gameId, forceNewSession);
 
 		List<SeatGradeEntity> seatGrades = seatGradeRepository.findAllByStadiumId(stadiumId);
 		List<UUID> seatGradeIds = seatGrades.stream()

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatHoldService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatHoldService.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import java.util.UUID;
 
 public interface SeatHoldService {
-	SeatHoldEntity get(UUID holdId);
+	SeatHoldEntity findSeatHold(UUID holdId);
 
 	List<SeatHoldEntity> getHoldingSeats(UUID gameId, UUID userId);
 

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatHoldService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatHoldService.java
@@ -8,7 +8,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-public interface SeatHoldExpiryService {
+public interface SeatHoldService {
+	SeatHoldEntity get(UUID holdId);
+
+	List<SeatHoldEntity> getHoldingSeats(UUID gameId, UUID userId);
+
 	Map<UUID, SeatHoldEntity> getByIds(List<UUID> holdIds);
 
 	void expire(

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatHoldServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatHoldServiceImpl.java
@@ -25,7 +25,7 @@ public class SeatHoldServiceImpl implements SeatHoldService {
 
 	@Override
 	@Transactional(readOnly = true)
-	public SeatHoldEntity get(UUID holdId) {
+	public SeatHoldEntity findSeatHold(UUID holdId) {
 		return seatHoldRepository.findById(holdId)
 			.orElseThrow(() -> new CustomException(ErrorCode.SEAT_HOLD_NOT_FOUND));
 	}

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatHoldServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatHoldServiceImpl.java
@@ -1,7 +1,9 @@
 package com.goti.ticketing.seat.service.domain;
 
+import com.goti.constants.messages.ErrorCode;
 import com.goti.ticketing.domain.entity.seat.SeatHoldEntity;
 import com.goti.ticketing.domain.entity.seat.SeatStatusEntity;
+import com.goti.exception.CustomException;
 import com.goti.global.validation.Preconditions;
 import com.goti.ticketing.seat.repository.SeatHoldRepository;
 import org.springframework.stereotype.Service;
@@ -14,12 +16,28 @@ import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.transaction.annotation.Transactional;
+
 @Service
 @RequiredArgsConstructor
-public class SeatHoldExpiryServiceImpl implements SeatHoldExpiryService {
+public class SeatHoldServiceImpl implements SeatHoldService {
 	private final SeatHoldRepository seatHoldRepository;
 
 	@Override
+	@Transactional(readOnly = true)
+	public SeatHoldEntity get(UUID holdId) {
+		return seatHoldRepository.findById(holdId)
+			.orElseThrow(() -> new CustomException(ErrorCode.SEAT_HOLD_NOT_FOUND));
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<SeatHoldEntity> getHoldingSeats(UUID gameId, UUID userId) {
+		return seatHoldRepository.findAllHoldingSeats(gameId, userId);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
 	public Map<UUID, SeatHoldEntity> getByIds(List<UUID> holdIds) {
 		return seatHoldRepository.findAllWithDetailsByIdIn(holdIds).stream()
 			.collect(Collectors.toMap(SeatHoldEntity::getId, seatHold -> seatHold));

--- a/ticketing/src/main/java/com/goti/ticketing/session/service/application/ReservationSessionService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/session/service/application/ReservationSessionService.java
@@ -33,7 +33,8 @@ public class ReservationSessionService {
 
 	public ReservationSessionCache getOrCreate(
 		UUID memberId,
-		UUID gameId
+		UUID gameId,
+		boolean forceNewSession
 	) {
 		Preconditions.validate(
 			memberId != null,
@@ -44,8 +45,20 @@ public class ReservationSessionService {
 			ErrorCode.BAD_REQUEST
 		);
 
+		if (forceNewSession) {
+			releaseHeldSeats(memberId, gameId);
+			delete(memberId, gameId);
+			return create(memberId, gameId);
+		}
+
 		ReservationSessionCache reservationSession = findReservationSession(memberId, gameId)
-			.orElseGet(() -> create(memberId, gameId));
+			.orElseThrow(() -> new CustomException(ErrorCode.RESERVATION_SESSION_EXPIRED));
+
+		if (reservationSession.expiresAt().isBefore(LocalDateTime.now())) {
+			releaseHeldSeats(memberId, gameId);
+			delete(memberId, gameId);
+			throw new CustomException(ErrorCode.RESERVATION_SESSION_EXPIRED);
+		}
 
 		return reservationSession;
 	}

--- a/ticketing/src/main/java/com/goti/ticketing/session/service/application/ReservationSessionService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/session/service/application/ReservationSessionService.java
@@ -16,9 +16,9 @@ import com.goti.infra.cache.RedisCache;
 import com.goti.infra.constants.redis.RedisKey;
 import com.goti.ticketing.domain.entity.seat.SeatHoldEntity;
 import com.goti.ticketing.domain.entity.seat.SeatStatusEntity;
+import com.goti.ticketing.seat.service.domain.SeatHoldService;
 import com.goti.ticketing.seat.service.domain.SeatStatusService;
 import com.goti.ticketing.session.model.ReservationSessionCache;
-import com.goti.ticketing.seat.repository.SeatHoldRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -28,7 +28,7 @@ public class ReservationSessionService {
 	private static final String KEY_DELIMITER = ":";
 
 	private final RedisCache redisCache;
-	private final SeatHoldRepository seatHoldRepository;
+	private final SeatHoldService seatHoldService;
 	private final SeatStatusService seatStatusService;
 
 	public ReservationSessionCache getOrCreate(
@@ -116,7 +116,7 @@ public class ReservationSessionService {
 	}
 
 	private void releaseHeldSeats(UUID memberId, UUID gameId) {
-		List<SeatHoldEntity> seatHolds = seatHoldRepository.findAllHoldingSeats(gameId, memberId);
+		List<SeatHoldEntity> seatHolds = seatHoldService.getHoldingSeats(gameId, memberId);
 		if (seatHolds.isEmpty()) {
 			return;
 		}


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#356
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
예매 세션 재진입 정책을 정리하여 새 진입 시에만 세션을 새로 생성하고, 기존 세션이 없거나 만료된 경우에는 만료 에러를 반환하도록 수정

<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
> 좌석 등급 조회 API에 forceNewSession 파라미터 추가
> forceNewSession=true일 때 기존 HOLD 좌석 해제 후 기존 세션 삭제 및 새 세션 생성 로직 추가
> forceNewSession=false일 때는 기존 세션이 있을 경우에만 재사용하도록 변경
> Redis 조회 시 역직렬화된 LinkedHashMap을 대상 타입으로 변환하도록 RedisCache 로직 보완

<br/>