### PR TITLE
[REFACTOR] 좌석 등급 조회 API 경로를 경기 기준으로 정리

### DIFF
--- a/ticketing/src/main/java/com/goti/ticketing/infra/api/TicketPaymentApiClient.java
+++ b/ticketing/src/main/java/com/goti/ticketing/infra/api/TicketPaymentApiClient.java
@@ -13,11 +13,11 @@ import com.goti.ticketing.infra.api.dto.response.PaymentCancelResponse;
 import com.goti.ticketing.order.dto.request.OrderPaymentCancelRequest;
 
 @Component
-public class PaymentApiClient extends BaseRestClient {
+public class TicketPaymentApiClient extends BaseRestClient {
 	private static final String PAYMENT_CANCEL_API = "/api/v1/payments/orders";
 	private static final String PATH_SEPARATOR = "/";
 
-	public PaymentApiClient(RestClient.Builder builder, ApiEndpointProperties properties) {
+	public TicketPaymentApiClient(RestClient.Builder builder, ApiEndpointProperties properties) {
 		super(builder, properties.payment());
 	}
 

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderCancelService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderCancelService.java
@@ -26,7 +26,7 @@ import com.goti.ticketing.domain.entity.order.OrderEntity;
 import com.goti.ticketing.domain.entity.order.OrderItemEntity;
 import com.goti.ticketing.domain.entity.ticket.TicketEntity;
 import com.goti.ticketing.game.repository.GameStatusRepository;
-import com.goti.ticketing.infra.api.PaymentApiClient;
+import com.goti.ticketing.infra.api.TicketPaymentApiClient;
 import com.goti.ticketing.order.dto.request.OrderCancelRequest;
 import com.goti.ticketing.order.dto.response.OrderCancelResponse;
 import com.goti.ticketing.order.service.domain.OrderCancellationItemService;
@@ -55,7 +55,7 @@ public class OrderCancelService {
 	private final TicketService ticketService;
 	private final TicketFreezeService ticketFreezeService;
 	private final SeatStatusService seatStatusService;
-	private final PaymentApiClient paymentApiClient;
+	private final TicketPaymentApiClient ticketPaymentApiClient;
 	private final GameStatusRepository gameStatusRepository;
 
 	@Transactional
@@ -132,7 +132,7 @@ public class OrderCancelService {
 		}
 
 		updateOrderStatus(order, orderItems);
-		PaymentCancelResponse paymentData = paymentApiClient.cancelPayment(orderId, cancellation.getId());
+		PaymentCancelResponse paymentData = ticketPaymentApiClient.cancelPayment(orderId, cancellation.getId());
 		orderCancellationService.complete(cancellation);
 
 		log.info(

--- a/ticketing/src/main/java/com/goti/ticketing/seat/controller/StadiumSeatController.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/controller/StadiumSeatController.java
@@ -64,7 +64,7 @@ public class StadiumSeatController {
 		@PathVariable UUID gameId,
 		@RequestParam(defaultValue = "false") boolean forceNewSession
 	) {
-		return wrap(seatGradeService.get(gameId, userId, forceNewSession));
+		return wrap(seatGradeService.findSeatGrades(gameId, userId, forceNewSession));
 	}
 
 	@Operation(

--- a/ticketing/src/main/java/com/goti/ticketing/seat/controller/StadiumSeatController.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/controller/StadiumSeatController.java
@@ -60,13 +60,12 @@ public class StadiumSeatController {
 		summary = "좌석 등급 조회",
 		description = "구장별 좌석 등급 조회 API"
 	)
-	@GetMapping("/stadiums/{stadiumId}/games/{gameId}/seat-grades")
+	@GetMapping("/games/{gameId}/seat-grades")
 	public ResponseEntity<ApiSuccessResponse<SeatGradeSearchResultResponse>> getSeatGrades(
 		@AuthenticationPrincipal(expression = "id") UUID userId,
-		@PathVariable UUID stadiumId,
 		@PathVariable UUID gameId
 	) {
-		return wrap(seatGradeService.get(stadiumId, gameId, userId));
+		return wrap(seatGradeService.get(gameId, userId));
 	}
 
 	@Operation(

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatGradeService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatGradeService.java
@@ -10,5 +10,5 @@ import com.goti.ticketing.seat.dto.response.SeatGradeSearchResultResponse;
 public interface SeatGradeService {
 	SeatGradeRegisterResponse create(UUID stadiumId, String name, String displayColorHex);
 
-	SeatGradeSearchResultResponse get(UUID stadiumId, UUID gameId, UUID userId);
+	SeatGradeSearchResultResponse get(UUID gameId, UUID userId);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatGradeService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatGradeService.java
@@ -8,5 +8,5 @@ import com.goti.ticketing.seat.dto.response.SeatGradeSearchResultResponse;
 public interface SeatGradeService {
 	SeatGradeRegisterResponse create(UUID stadiumId, String name, String displayColorHex);
 
-	SeatGradeSearchResultResponse get(UUID stadiumId, UUID gameId, UUID userId, boolean forceNewSession);
+	SeatGradeSearchResultResponse findSeatGrades(UUID gameId, UUID userId, boolean forceNewSession);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatGradeServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatGradeServiceImpl.java
@@ -11,7 +11,9 @@ import org.springframework.transaction.annotation.Transactional;
 import com.goti.constants.messages.ErrorCode;
 import com.goti.global.validation.Preconditions;
 import com.goti.ticketing.constants.SeatStatus;
+import com.goti.ticketing.domain.entity.game.GameScheduleEntity;
 import com.goti.ticketing.domain.entity.seat.SeatGradeEntity;
+import com.goti.ticketing.game.service.domain.GameScheduleService;
 import com.goti.ticketing.session.model.ReservationSessionCache;
 import com.goti.ticketing.session.service.application.ReservationSessionService;
 import com.goti.ticketing.seat.dto.response.SeatGradeRegisterResponse;
@@ -29,6 +31,7 @@ public class SeatGradeServiceImpl implements SeatGradeService {
 	private final SeatGradeRepository seatGradeRepository;
 	private final SeatStatusRepository seatStatusRepository;
 	private final ReservationSessionService reservationSessionService;
+	private final GameScheduleService gameScheduleService;
 
 	@Override
 	@Transactional
@@ -45,15 +48,16 @@ public class SeatGradeServiceImpl implements SeatGradeService {
 
 	@Override
 	@Transactional(readOnly = true)
-	public SeatGradeSearchResultResponse get(UUID stadiumId, UUID gameId, UUID userId) {
+	public SeatGradeSearchResultResponse get(UUID gameId, UUID userId) {
 		Preconditions.validate(
 			userId != null,
 			ErrorCode.AUTH_INVALID
 		);
 
+		GameScheduleEntity gameSchedule = gameScheduleService.get(gameId);
 		ReservationSessionCache reservationSession = reservationSessionService.getOrCreate(userId, gameId);
 
-		List<SeatGradeEntity> seatGrades = seatGradeRepository.findAllByStadiumId(stadiumId);
+		List<SeatGradeEntity> seatGrades = seatGradeRepository.findAllByStadiumId(gameSchedule.getStadiumId());
 		List<UUID> seatGradeIds = seatGrades.stream()
 			.map(SeatGradeEntity::getId)
 			.toList();

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatGradeServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatGradeServiceImpl.java
@@ -48,7 +48,7 @@ public class SeatGradeServiceImpl implements SeatGradeService {
 
 	@Override
 	@Transactional(readOnly = true)
-	public SeatGradeSearchResultResponse get(UUID gameId, UUID userId, boolean forceNewSession) {
+	public SeatGradeSearchResultResponse findSeatGrades(UUID gameId, UUID userId, boolean forceNewSession) {
 		Preconditions.validate(
 			userId != null,
 			ErrorCode.AUTH_INVALID


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#360 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
좌석 등급 조회 시 -> stadiumId 경로 제거 및 기존 gameId 기반 조회 로직 처리 (Refactory)
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
> 좌석 등급 조회 API 경로를 gameId 기준으로 변경
> 좌석 등급 조회 시 GameScheduleService를 통해 경기의 stadiumId를 조회하도록 수정
<br/>