### PR TITLE
[FEAT] JwtToken(AccessToken, RefreshToken) Payload 추가

### DIFF
--- a/user/src/main/java/com/goti/user/config/jwt/JwtTokenProvider.java
+++ b/user/src/main/java/com/goti/user/config/jwt/JwtTokenProvider.java
@@ -45,6 +45,7 @@ public class JwtTokenProvider {
 	private static final String TOKEN_PREFIX = "Bearer ";
 	private static final String ROLE_CLAIM_KEY = "role";
 	private static final String MOBILE_CLAIM_KEY = "mobile";
+	private static final String EMAIL_CLAIM_KEY = "email";
 
 	private static final String PROVIDER_TYPE_KEY = "provider_type";
 	private static final String PROVIDER_ID_KEY = "provider_id";
@@ -79,7 +80,9 @@ public class JwtTokenProvider {
 		}
 	}
 
-	public String create(UUID id, String mobile, UserRole role, TokenType tokenType) {
+	public String create(
+		UUID id, String mobile, UserRole role, String email, TokenType tokenType
+	) {
 		Date issuedAt = new Date();
 		Duration validTime = tokenType == TokenType.ACCESS ?
 			jwtProperties.accessValidTime() : jwtProperties.refreshValidTime();
@@ -92,6 +95,7 @@ public class JwtTokenProvider {
 			.issuer(jwtProperties.issuer())
 			.claim(ROLE_CLAIM_KEY, role.name())
 			.claim(MOBILE_CLAIM_KEY, mobile)
+			.claim(EMAIL_CLAIM_KEY, email)
 			.issuedAt(issuedAt)
 			.expiration(expireAt);
 
@@ -167,6 +171,10 @@ public class JwtTokenProvider {
 
 	public String extractJti(String token) {
 		return getClaims(token).getId();
+	}
+
+	public String extractEmail(String token) {
+		return getClaims(token).get(EMAIL_CLAIM_KEY, String.class);
 	}
 
 	/**

--- a/user/src/main/java/com/goti/user/service/application/auth/SocialAuthService.java
+++ b/user/src/main/java/com/goti/user/service/application/auth/SocialAuthService.java
@@ -92,7 +92,7 @@ public class SocialAuthService {
 				return new CustomException(ErrorCode.MEMBER_NOT_FOUND);
 			}
 		);
-		return authService.issueTokens(member);
+		return authService.issueTokens(member, verifiedSocialInfo.email());
 	}
 
 	@Transactional
@@ -109,7 +109,7 @@ public class SocialAuthService {
 		MemberEntity member = getOrCreateMember(name, mobile, gender, birthDate);
 
 		createSocialProvider(member, verifiedSocialInfo);
-		return authService.issueTokens(member);
+		return authService.issueTokens(member, verifiedSocialInfo.email());
 	}
 
 	public void sendSignupSmsCode(String socialVerifyToken, String mobile) {
@@ -119,8 +119,9 @@ public class SocialAuthService {
 	@Transactional
 	public Pair<String, String> reissueToken(String refreshToken) {
 		UUID memberId = authService.validateTokenAndGetMemberId(refreshToken);
+		String email = jwtTokenProvider.extractEmail(refreshToken);
 		MemberEntity member = memberService.getMember(memberId);
-		return authService.issueTokens(member);
+		return authService.issueTokens(member, email);
 	}
 
 	private void validateState(OAuthProvider provider, String state) {

--- a/user/src/main/java/com/goti/user/service/domain/auth/AuthService.java
+++ b/user/src/main/java/com/goti/user/service/domain/auth/AuthService.java
@@ -12,6 +12,6 @@ public interface AuthService {
 
 	UUID validateTokenAndGetMemberId(String token);
 
-	Pair<String, String> issueTokens(MemberEntity member);
+	Pair<String, String> issueTokens(MemberEntity member, String email);
 
 }

--- a/user/src/main/java/com/goti/user/service/domain/auth/AuthServiceImpl.java
+++ b/user/src/main/java/com/goti/user/service/domain/auth/AuthServiceImpl.java
@@ -60,10 +60,10 @@ public class AuthServiceImpl implements AuthService {
 	}
 
 	@Override
-	public Pair<String, String> issueTokens(MemberEntity member) {
+	public Pair<String, String> issueTokens(MemberEntity member, String email) {
 		deleteCachedTokenId(member.getId());
-		String accessToken = createToken(member, TokenType.ACCESS);
-		String refreshToken = createToken(member, TokenType.REFRESH);
+		String accessToken = createToken(member, email, TokenType.ACCESS);
+		String refreshToken = createToken(member, email, TokenType.REFRESH);
 		saveTokenJti(member.getId(), refreshToken);
 		return Pair.of(accessToken, refreshToken);
 	}
@@ -73,11 +73,14 @@ public class AuthServiceImpl implements AuthService {
 		redisCache.set(RedisKey.REFRESH_TOKEN, memberId, jti);
 	}
 
-	private String createToken(MemberEntity member, TokenType tokenType) {
+	private String createToken(
+		MemberEntity member, String email, TokenType tokenType
+	) {
 		return jwtTokenProvider.create(
 			member.getId(),
 			member.getMobile(),
 			member.getRole(),
+			email,
 			tokenType
 		);
 	}

--- a/user/src/main/java/com/goti/user/service/test/TestUserService.java
+++ b/user/src/main/java/com/goti/user/service/test/TestUserService.java
@@ -39,12 +39,14 @@ public class TestUserService {
 	private final TestUserPersistenceHelper persistenceHelper;
 	private final JwtTokenProvider jwtTokenProvider;
 
+	private static final String EMAIL = "test@test.com";
+
 	@Transactional
 	public TestUserResponse createUser(CreateTestUserRequest request) {
 		MemberEntity member = findOrCreateMember(request);
 
 		String accessToken = jwtTokenProvider.create(
-			member.getId(), member.getMobile(), UserRole.MEMBER, TokenType.ACCESS
+			member.getId(), member.getMobile(), UserRole.MEMBER, EMAIL, TokenType.ACCESS
 		);
 
 		return new TestUserResponse(
@@ -106,7 +108,7 @@ public class TestUserService {
 			.orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
 		String accessToken = jwtTokenProvider.create(
-			member.getId(), member.getMobile(), UserRole.MEMBER, TokenType.ACCESS
+			member.getId(), member.getMobile(), UserRole.MEMBER, EMAIL, TokenType.ACCESS
 		);
 
 		return new TokenResponse(accessToken);

--- a/user/src/test/java/com/goti/api/auth/SocialAuthReissueTokenApiTest.java
+++ b/user/src/test/java/com/goti/api/auth/SocialAuthReissueTokenApiTest.java
@@ -48,19 +48,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class SocialAuthReissueTokenApiTest {
 
 	@Autowired MockMvc mockMvc;
-	@Autowired ObjectMapper objectMapper;
 	@Autowired JwtTokenProvider jwtTokenProvider;
 	@Autowired RedisCache redisCache;
 	@Autowired MemberRepository memberRepository;
 	@Autowired SocialProviderRepository socialProviderRepository;
+	static final String EMAIL = "test@test.com";
 
 	MemberEntity member;
 	SocialProviderEntity socialProvider;
-
+	String email;
 	@BeforeEach
 	void setup() {
 		saveMember();
 		saveSocialProvider();
+
 	}
 
 	@Test
@@ -69,12 +70,14 @@ public class SocialAuthReissueTokenApiTest {
 			member.getId(),
 			member.getMobile(),
 			member.getRole(),
+			EMAIL,
 			TokenType.ACCESS
 		);
 		String loginRefreshToken = jwtTokenProvider.create(
 			member.getId(),
 			member.getMobile(),
 			member.getRole(),
+			EMAIL,
 			TokenType.REFRESH
 		);
 

--- a/user/src/test/java/com/goti/user/config/jwt/JwtTokenProviderRs256Test.java
+++ b/user/src/test/java/com/goti/user/config/jwt/JwtTokenProviderRs256Test.java
@@ -86,7 +86,9 @@ class JwtTokenProviderRs256Test {
 			UUID userId = UUID.randomUUID();
 
 			// When
-			String token = provider.create(userId, "01012345678", UserRole.MEMBER, TokenType.ACCESS);
+			String token = provider.create(
+				userId, "01012345678", UserRole.MEMBER, "test@test.com", TokenType.ACCESS
+			);
 
 			// Then
 			assertThatCode(() -> provider.validateToken(token))
@@ -98,7 +100,9 @@ class JwtTokenProviderRs256Test {
 		void should_extractClaims_when_rs256Token() {
 			// Given
 			UUID userId = UUID.randomUUID();
-			String token = provider.create(userId, "01012345678", UserRole.ADMIN, TokenType.ACCESS);
+			String token = provider.create(
+				userId, "01012345678", UserRole.ADMIN, "test@test.com", TokenType.ACCESS
+			);
 
 			// When
 			String jti = provider.extractJti(token);
@@ -148,7 +152,9 @@ class JwtTokenProviderRs256Test {
 			UUID userId = UUID.randomUUID();
 
 			// When
-			String token = provider.create(userId, "01012345678", UserRole.MEMBER, TokenType.ACCESS);
+			String token = provider.create(
+				userId, "01012345678", UserRole.MEMBER, "test@test.com", TokenType.ACCESS
+			);
 
 			// Then
 			assertThatCode(() -> provider.validateToken(token))
@@ -189,7 +195,9 @@ class JwtTokenProviderRs256Test {
 			expiredProvider.initKeys();
 
 			UUID userId = UUID.randomUUID();
-			String token = expiredProvider.create(userId, "01012345678", UserRole.MEMBER, TokenType.ACCESS);
+			String token = expiredProvider.create(
+				userId, "01012345678", UserRole.MEMBER, "test@test.com", TokenType.ACCESS
+			);
 
 			// When & Then
 			assertThatThrownBy(() -> expiredProvider.validateToken(token))


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#375 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
로그인 및 회원가입, 토큰재발급에서 얻을 수 있는 인증 JwtToken payload 내 로그인 회원의 Email 값 추가 (claims)
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- token (access, refresh) 생성 시 email 인자값 추가 및 Email 키값 생성 (in JwtTokenProvider, 인증 기반으로 발급된 token)
- JwtTokenProvider email 추가 기반하여 AuthService 및 SocialAuthService 일괄 email 추가 로직 구현(테스트코드도 일괄적용),
- token -> extractEmail() 메소드 추가(email value 추출, JwtTokenProvider)
- 상황별 email 추출 및 데이터 전송
  - 로그인 및 회원가입 시 -> socialVerifyToken(소셜 verify 이후 얻은 token 정보) 내 데이터 활용
  - 토큰 재발급 시 (reissue) -> RefreshToken 내 getCaims, Email 키값으로 추출 (extractEmail)
<br/>