### PR TITLE
[BUG] 결제 완료 후 SeatHold 정합성 및 만료 처리 보강

### DIFF
--- a/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderPaymentConfirmService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderPaymentConfirmService.java
@@ -20,8 +20,8 @@ import com.goti.global.validation.Preconditions;
 import com.goti.ticketing.order.dto.response.OrderPaymentConfirmResponse;
 import com.goti.ticketing.order.repository.OrderItemRepository;
 import com.goti.ticketing.order.repository.OrderRepository;
-import com.goti.ticketing.seat.repository.SeatHoldRepository;
 import com.goti.ticketing.seat.repository.SeatStatusRepository;
+import com.goti.ticketing.seat.service.domain.SeatHoldService;
 import com.goti.ticketing.ticket.dto.response.TicketResponse;
 import com.goti.ticketing.ticket.service.application.TicketCreateService;
 
@@ -34,8 +34,8 @@ import lombok.extern.slf4j.Slf4j;
 public class OrderPaymentConfirmService {
 	private final OrderRepository orderRepository;
 	private final OrderItemRepository orderItemRepository;
-	private final SeatHoldRepository seatHoldRepository;
 	private final SeatStatusRepository seatStatusRepository;
+	private final SeatHoldService seatHoldService;
 	private final TicketCreateService ticketCreateService;
 
 	@Transactional
@@ -96,20 +96,36 @@ public class OrderPaymentConfirmService {
 	}
 
 	private SeatHoldEntity getValidActiveHold(OrderEntity order, OrderItemEntity orderItem) {
-		return seatHoldRepository
-			.findLatestActiveHold(
-				order.getGameSchedule(),
-				orderItem.getSeat(),
-				order.getMemberId(),
-				SeatHoldStatus.HOLDING
-			)
-			.filter(seatHold -> seatHold.getExpiredAt().isAfter(LocalDateTime.now()))
-			.orElseThrow(() -> new CustomException(ErrorCode.SEAT_HOLD_EXPIRED)
+		SeatHoldEntity seatHold = seatHoldService.findSeatHold(orderItem.getHoldId());
+
+		Preconditions.validate(
+			seatHold.getGameSchedule().getId().equals(order.getGameSchedule().getId()),
+			ErrorCode.SEAT_HOLD_GAME_MISMATCH
+		);
+		Preconditions.validate(
+			seatHold.getSeat().getId().equals(orderItem.getSeat().getId()),
+			ErrorCode.SEAT_HOLD_NOT_FOUND
+		);
+		Preconditions.validate(
+			seatHold.getUserId().equals(order.getMemberId()),
+			ErrorCode.AUTH_PERMISSION_DENIED
+		);
+		Preconditions.validate(
+			seatHold.getStatus() == SeatHoldStatus.HOLDING,
+			ErrorCode.SEAT_HOLD_STATUS_INVALID
+		);
+
+		if (!seatHold.getExpiredAt().isAfter(LocalDateTime.now())) {
+			throw new CustomException(ErrorCode.SEAT_HOLD_EXPIRED)
 				.withContext("action", "SESSION_BLOCK")
 				.withContext("stage", "PAYMENT_CONFIRM")
 				.withContext("gameId", order.getGameSchedule().getId())
 				.withContext("userId", order.getMemberId())
 				.withContext("orderId", order.getId())
-				.withContext("seatId", orderItem.getSeat().getId()));
+				.withContext("seatId", orderItem.getSeat().getId())
+				.withContext("holdId", seatHold.getId());
+		}
+
+		return seatHold;
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatHoldServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatHoldServiceImpl.java
@@ -1,6 +1,7 @@
 package com.goti.ticketing.seat.service.domain;
 
 import com.goti.constants.messages.ErrorCode;
+import com.goti.ticketing.constants.SeatStatus;
 import com.goti.ticketing.domain.entity.seat.SeatHoldEntity;
 import com.goti.ticketing.domain.entity.seat.SeatStatusEntity;
 import com.goti.exception.CustomException;
@@ -57,7 +58,9 @@ public class SeatHoldServiceImpl implements SeatHoldService {
 			"만료되지 않은 점유는 해제할 수 없습니다."
 		);
 
-		seatStatus.release();
+		if (seatStatus.getStatus() == SeatStatus.HELD) {
+			seatStatus.release();
+		}
 		seatHold.release();
 	}
 }


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#378 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
결제 완료 후에도 SeatHold가 HOLDING 상태로 남아 스케줄러가 이미 정리된 좌석을 다시 해제하려는 문제 수정 
stale hold(이미 정리됐어야 하는데 HOLDING 상태로 남아 있는 오래된 좌석 점유)에 대한 만료 처리 로직을 보강
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
> 결제 완료 시 OrderItem에 저장된 holdId로 SeatHold를 조회하도록 수정
> 결제 확정 시 주문에 연결된 SeatHold만 정리되도록 hold 검증 로직 보강
> 만료 스케줄러 처리 시 seatStatus == HELD인 경우에만 좌석 상태를 AVAILABLE로 변경하도록 수정
> 좌석 상태가 이미 SOLD 또는 AVAILABLE인 경우에는 SeatHold만 RELEASED로 정리하도록 수정

> 로컬 환경에서 seatStatus = SOLD, seatHold = HOLDING 상태의 만료 데이터로 스케줄러 정상 동작 확인

<br/>