### PR TITLE
[CHORE] cd-poc-queue 워크플로우 확장 (multi-module + prod 지원) (#383)

### DIFF
--- a/.github/workflows/cd-poc-queue.yml
+++ b/.github/workflows/cd-poc-queue.yml
@@ -2,7 +2,9 @@
 # [POC] Queue 구현체 비교 테스트용 이미지 빌드
 # ============================================================================
 # 목적: 3개 대기열 구현체(수연/준상/성전)를 각각 ECR에 빌드+푸시
-# 사용법: GitHub Actions > Run workflow > 브랜치 선택 > Run
+# 사용법: GitHub Actions > Run workflow > 옵션 선택 > Run
+#   - build_module=all: queue+ticketing+payment 3모듈 병렬 빌드
+#   - target_env=prod: EKS prod values 자동 업데이트
 # 삭제 시점: 최종 구현체 결정 후 이 워크플로우 삭제
 # ============================================================================
 
@@ -26,49 +28,82 @@ on:
         type: string
         default: "auto"
       build_module:
-        description: "빌드할 모듈 (queue: MSA 큐, ticketing: MSA 티켓팅, api: 모놀리스)"
+        description: "빌드할 모듈 (all: queue+ticketing+payment 병렬)"
         required: true
         type: choice
         options:
+          - all
           - queue
           - ticketing
-          - api
-        default: queue
+          - payment
+        default: all
+      target_env:
+        description: "values 업데이트 대상 환경"
+        required: true
+        type: choice
+        options:
+          - prod
+          - dev
+        default: prod
 
 env:
   AWS_REGION: ap-northeast-2
-  ECR_REPO: goti-queue
 
 jobs:
-  resolve-branches:
+  resolve-matrix:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - name: Set build matrix
+      - name: Build matrix (authors x modules)
         id: set-matrix
         run: |
+          # --- 브랜치 매핑 ---
+          declare -A BRANCHES
+          BRANCHES[suyeon]="poc/queue-waiting-suyeon-cdn-optimized"
+          BRANCHES[junsang]="poc/queue-waiting-junsang"
+          BRANCHES[sungjeon]="poc/queue-waiting-sungjeon"
+
+          # --- 대상 작성자 ---
           if [ "${{ inputs.poc_author }}" = "all" ]; then
-            echo 'matrix={"include":[{"author":"suyeon","branch":"poc/queue-waiting-suyeon-cdn-optimized"},{"author":"junsang","branch":"poc/queue-waiting-junsang"},{"author":"sungjeon","branch":"poc/queue-waiting-sungjeon"}]}' >> "$GITHUB_OUTPUT"
+            AUTHORS="suyeon junsang sungjeon"
           else
-            AUTHOR="${{ inputs.poc_author }}"
+            AUTHORS="${{ inputs.poc_author }}"
+          fi
+
+          # --- 대상 모듈 ---
+          if [ "${{ inputs.build_module }}" = "all" ]; then
+            MODULES="queue ticketing payment"
+          else
+            MODULES="${{ inputs.build_module }}"
+          fi
+
+          # --- 크로스 프로덕트 매트릭스 생성 ---
+          ITEMS="[]"
+          for author in $AUTHORS; do
             if [ "${{ inputs.poc_branch }}" = "auto" ]; then
-              case "$AUTHOR" in
-                suyeon)    BRANCH="poc/queue-waiting-suyeon-cdn-optimized" ;;
-                junsang)   BRANCH="poc/queue-waiting-junsang" ;;
-                sungjeon)  BRANCH="poc/queue-waiting-sungjeon" ;;
-              esac
+              BRANCH="${BRANCHES[$author]}"
             else
               BRANCH="${{ inputs.poc_branch }}"
             fi
-            echo "matrix={\"include\":[{\"author\":\"${AUTHOR}\",\"branch\":\"${BRANCH}\"}]}" >> "$GITHUB_OUTPUT"
-          fi
+            for module in $MODULES; do
+              ITEMS=$(echo "$ITEMS" | jq \
+                --arg a "$author" \
+                --arg b "$BRANCH" \
+                --arg m "$module" \
+                '. + [{"author": $a, "branch": $b, "module": $m}]')
+            done
+          done
+
+          MATRIX=$(echo "$ITEMS" | jq -c '{include: .}')
+          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
+          echo "::notice::Build matrix: ${MATRIX}"
 
   build-and-push:
-    needs: resolve-branches
+    needs: resolve-matrix
     runs-on: ubuntu-latest
     strategy:
-      matrix: ${{ fromJson(needs.resolve-branches.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.resolve-matrix.outputs.matrix) }}
       fail-fast: false
     permissions:
       id-token: write
@@ -86,9 +121,9 @@ jobs:
           distribution: temurin
           java-version: 21
 
-      - name: Build ${{ inputs.build_module || 'queue' }} bootJar
+      - name: Build ${{ matrix.module }} bootJar
         run: |
-          MODULE="${{ inputs.build_module || 'queue' }}"
+          MODULE="${{ matrix.module }}"
           if [ "$MODULE" = "api" ]; then
             ./gradlew :api:bootJar --no-daemon -x test
           else
@@ -115,9 +150,12 @@ jobs:
           SEQ="${{ github.run_number }}"
           TAG="poc-${{ matrix.author }}-${SEQ}-${SHA7}"
           REGISTRY="${{ steps.ecr-login.outputs.registry }}"
+          # 모듈별 ECR 레포 결정
+          ECR_REPO="goti-${{ matrix.module }}"
           IMAGE="${REGISTRY}/${ECR_REPO}:${TAG}"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+          echo "ecr_repo=${ECR_REPO}" >> "$GITHUB_OUTPUT"
           echo "::notice::📦 Image: ${IMAGE}"
 
       - name: Build and push to ECR
@@ -125,47 +163,57 @@ jobs:
         with:
           context: .
           push: true
-          build-args: MODULE=${{ inputs.build_module || 'queue' }}
+          build-args: MODULE=${{ matrix.module }}
           tags: ${{ steps.tag.outputs.image }}
-          cache-from: type=gha,scope=poc-queue-${{ matrix.author }}
-          cache-to: type=gha,mode=max,scope=poc-queue-${{ matrix.author }}
+          cache-from: type=gha,scope=poc-${{ matrix.module }}-${{ matrix.author }}
+          cache-to: type=gha,mode=max,scope=poc-${{ matrix.module }}-${{ matrix.author }}
 
       - name: Update Goti-k8s values.yaml
         env:
           GH_TOKEN: ${{ secrets.GOTI_K8S_DISPATCH_TOKEN }}
         run: |
           AUTHOR="${{ matrix.author }}"
+          MODULE="${{ matrix.module }}"
           TAG="${{ steps.tag.outputs.tag }}"
+          ECR_REPO="${{ steps.tag.outputs.ecr_repo }}"
+          REGISTRY="${{ steps.ecr-login.outputs.registry }}"
+          ENV="${{ inputs.target_env }}"
 
-          # 구현체별 values.yaml 경로 매핑
-          case "$AUTHOR" in
-            suyeon)    FILE_PATH="environments/dev/goti-queue/values.yaml" ;;
-            junsang)   FILE_PATH="environments/dev/goti-queue-junsang/values.yaml" ;;
-            sungjeon)  FILE_PATH="environments/dev/goti-queue-sungjeon/values.yaml" ;;
-          esac
+          # --- values.yaml 경로 결정 ---
+          if [ "$ENV" = "prod" ]; then
+            # prod: 모든 서비스가 명시적 이름
+            FILE_PATH="environments/prod/goti-${MODULE}-${AUTHOR}/values.yaml"
+          else
+            # dev: 수연 queue는 기본 슬롯, 나머지는 명시적
+            if [ "$MODULE" = "queue" ] && [ "$AUTHOR" = "suyeon" ]; then
+              FILE_PATH="environments/dev/goti-queue/values.yaml"
+            else
+              FILE_PATH="environments/dev/goti-${MODULE}-${AUTHOR}/values.yaml"
+            fi
+          fi
 
-          echo "📝 Updating ${FILE_PATH} → tag: ${TAG}"
+          echo "📝 Updating ${FILE_PATH} → ${ECR_REPO}:${TAG}"
 
           # 현재 파일 조회
           RESPONSE=$(gh api "repos/Team-Ikujo/Goti-k8s/contents/${FILE_PATH}?ref=main" \
-            --jq '{sha: .sha, content: .content}')
+            --jq '{sha: .sha, content: .content}') || {
+            echo "⚠️ File not found: ${FILE_PATH} — skipping values update"
+            exit 0
+          }
 
           FILE_SHA=$(echo "$RESPONSE" | jq -r '.sha')
           CURRENT=$(echo "$RESPONSE" | jq -r '.content' | base64 -d)
 
-          # 현재 태그 추출
-          CURRENT_TAG=$(echo "$CURRENT" | grep -oP 'tag:\s*"\K[^"]+')
-          echo "  Current tag: ${CURRENT_TAG}"
-          echo "  New tag:     ${TAG}"
-
-          # 태그 교체
-          UPDATED=$(echo "$CURRENT" | sed "s|tag: \"${CURRENT_TAG}\"|tag: \"${TAG}\"|")
+          # 이미지 태그 + 레포 교체
+          UPDATED=$(echo "$CURRENT" | sed \
+            -e "s|tag: \"[^\"]*\"|tag: \"${TAG}\"|" \
+            -e "s|repository: \"[^\"]*\"|repository: \"${REGISTRY}/${ECR_REPO}\"|")
           NEW_B64=$(echo "$UPDATED" | base64 -w 0)
 
           # Goti-k8s main 브랜치에 커밋
           gh api "repos/Team-Ikujo/Goti-k8s/contents/${FILE_PATH}" \
             -X PUT \
-            -f message="[CHORE] goti-queue-${AUTHOR} POC 이미지 태그 업데이트: ${TAG}" \
+            -f message="[CHORE] ${ENV} goti-${MODULE}-${AUTHOR} POC 이미지 태그 업데이트: ${TAG}" \
             -f content="${NEW_B64}" \
             -f sha="${FILE_SHA}" \
             -f branch="main"
@@ -174,12 +222,14 @@ jobs:
 
       - name: Summary
         run: |
-          echo "## 🏗️ POC Queue Build — ${{ matrix.author }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "## 🏗️ POC Build — ${{ matrix.author }} / ${{ matrix.module }}" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| 항목 | 값 |" >> "$GITHUB_STEP_SUMMARY"
           echo "|------|-----|" >> "$GITHUB_STEP_SUMMARY"
           echo "| 구현체 | ${{ matrix.author }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| 브랜치 | \`${{ matrix.branch }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| 빌드 모듈 | \`${{ inputs.build_module || 'queue' }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| 빌드 모듈 | \`${{ matrix.module }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| ECR 레포 | \`${{ steps.tag.outputs.ecr_repo }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| 이미지 태그 | \`${{ steps.tag.outputs.tag }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| 전체 이미지 | \`${{ steps.tag.outputs.image }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| 대상 환경 | \`${{ inputs.target_env }}\` |" >> "$GITHUB_STEP_SUMMARY"

--- a/api/src/main/resources/application-prod.yml
+++ b/api/src/main/resources/application-prod.yml
@@ -1,4 +1,10 @@
 # EKS 환경 전용 — SPRING_PROFILES_ACTIVE=prod 로 활성화
+springdoc:
+  swagger-ui:
+    enabled: false
+  api-docs:
+    enabled: false
+
 spring:
   jpa:
     hibernate:


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #383


<br/>

## 🔎 개요
POC Queue 부하테스트를 EKS prod에서 진행하기 위해 `cd-poc-queue.yml` 워크플로우를 확장합니다.
1회 실행으로 queue+ticketing+payment 3모듈을 병렬 빌드하고 prod values를 자동 업데이트합니다.

<br/>


## 📋 작업 내용
- `build_module`에 `payment`, `all`(3모듈 병렬) 옵션 추가
- `target_env` 입력 추가 (`prod` / `dev` values 업데이트 분기)
- ECR 레포 하드코딩(`goti-queue`) 제거 → 모듈별 동적 결정 (`goti-queue` / `goti-ticketing` / `goti-payment`)
- 크로스 프로덕트 매트릭스 (authors × modules) 병렬 빌드
- values 업데이트 시 `repository` + `tag` 모두 교체
- 사용법: `poc_author=suyeon, build_module=all, target_env=prod` → 1회 실행으로 3pod 배포


<br/>