### PR TITLE
[FEAT] 인증 토큰 내 소셜 제공자 식별자(providerId) 추가 및 Principal 확장

### DIFF
--- a/common/src/main/java/com/goti/constants/messages/ErrorCode.java
+++ b/common/src/main/java/com/goti/constants/messages/ErrorCode.java
@@ -105,6 +105,7 @@ public enum ErrorCode {
 	ORDER_SEAT_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 주문된 좌석이 포함되어 있습니다."),
 
 	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
+	SOCIAL_PROVIDER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 소셜 계정은 존재하지 않습니다."),
 	SOCIAL_PROVIDER_ALREADY_LINKED(HttpStatus.BAD_REQUEST, "해당 소셜 계정은 이미 다른 회원과 연동되어 있습니다."),
 	BASEBALL_TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 야구 구단(팀)입니다."),
 	STADIUM_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 구장입니다."),

--- a/user/src/main/java/com/goti/user/config/jwt/JwtTokenProvider.java
+++ b/user/src/main/java/com/goti/user/config/jwt/JwtTokenProvider.java
@@ -157,8 +157,9 @@ public class JwtTokenProvider {
 	}
 
 	public Authentication getAuthentication(String token) {
-		String userId = extractSubject(token);
-		String providerId = extractProviderId(token);
+		Claims claims = getClaims(token);
+		String userId = claims.getSubject();
+		String providerId = claims.get(PROVIDER_ID_KEY, String.class);
 		UserDetails userDetails = userDetailsService.loadUserById(userId, providerId);
 		return UsernamePasswordAuthenticationToken.authenticated(
 			userDetails,

--- a/user/src/main/java/com/goti/user/config/jwt/JwtTokenProvider.java
+++ b/user/src/main/java/com/goti/user/config/jwt/JwtTokenProvider.java
@@ -29,6 +29,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
+import java.security.Provider;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.time.Duration;
@@ -79,7 +80,7 @@ public class JwtTokenProvider {
 		}
 	}
 
-	public String create(UUID id, String mobile, UserRole role, TokenType tokenType) {
+	public String create(UUID id, UserRole role, String providerId, TokenType tokenType) {
 		Date issuedAt = new Date();
 		Duration validTime = tokenType == TokenType.ACCESS ?
 			jwtProperties.accessValidTime() : jwtProperties.refreshValidTime();
@@ -91,7 +92,7 @@ public class JwtTokenProvider {
 			.id(jwtId)
 			.issuer(jwtProperties.issuer())
 			.claim(ROLE_CLAIM_KEY, role.name())
-			.claim(MOBILE_CLAIM_KEY, mobile)
+			.claim(PROVIDER_ID_KEY, providerId)
 			.issuedAt(issuedAt)
 			.expiration(expireAt);
 
@@ -156,8 +157,9 @@ public class JwtTokenProvider {
 	}
 
 	public Authentication getAuthentication(String token) {
-		String userId = getClaims(token).getSubject();
-		UserDetails userDetails = userDetailsService.loadUserById(userId);
+		String userId = extractSubject(token);
+		String providerId = extractProviderId(token);
+		UserDetails userDetails = userDetailsService.loadUserById(userId, providerId);
 		return UsernamePasswordAuthenticationToken.authenticated(
 			userDetails,
 			null,
@@ -167,6 +169,10 @@ public class JwtTokenProvider {
 
 	public String extractJti(String token) {
 		return getClaims(token).getId();
+	}
+
+	public String extractProviderId(String token) {
+		return getClaims(token).get(PROVIDER_ID_KEY, String.class);
 	}
 
 	/**

--- a/user/src/main/java/com/goti/user/repository/SocialProviderRepository.java
+++ b/user/src/main/java/com/goti/user/repository/SocialProviderRepository.java
@@ -1,6 +1,8 @@
 package com.goti.user.repository;
 
 import com.goti.constants.OAuthProvider;
+import com.goti.constants.messages.ErrorCode;
+import com.goti.exception.CustomException;
 import com.goti.user.domain.entity.user.SocialProviderEntity;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,12 +16,18 @@ import java.util.UUID;
 @Repository
 public interface SocialProviderRepository extends JpaRepository<SocialProviderEntity, UUID> {
 
+	default SocialProviderEntity findSocialProviderOrThrow(String providerId, OAuthProvider provider) {
+		return findSocialProvider(providerId, provider).orElseThrow(
+			() -> new CustomException(ErrorCode.SOCIAL_PROVIDER_NOT_FOUND)
+		);
+	}
+
 	@Query("SELECT s " +
 					 "FROM SocialProviderEntity s " +
 		 "JOIN FETCH s.member " +
 					"WHERE s.providerId = :providerId " +
 		 				"AND s.provider = :provider")
-	Optional<SocialProviderEntity> findByProviderIdAndProvider(
+	Optional<SocialProviderEntity> findSocialProvider(
 		@Param("providerId") String providerId,
 		@Param("provider") OAuthProvider provider
 	);

--- a/user/src/main/java/com/goti/user/security/ExtendedUserDetails.java
+++ b/user/src/main/java/com/goti/user/security/ExtendedUserDetails.java
@@ -14,10 +14,12 @@ import java.util.UUID;
 @EqualsAndHashCode(callSuper = true)
 public class ExtendedUserDetails extends User {
 	private final UUID id;
+	private final String providerId;
 
-	public ExtendedUserDetails(UUID id, String mobile, UserRole role) {
-		super(mobile, "", AuthorityUtils.createAuthorityList("ROLE_" + role.name()));
+	public ExtendedUserDetails(UUID id, UserRole role, String providerId) {
+		super(String.valueOf(id), "", AuthorityUtils.createAuthorityList("ROLE_" + role.name()));
 		this.id = id;
+		this.providerId = providerId;
 	}
 
 }

--- a/user/src/main/java/com/goti/user/security/ExtendedUserDetailsService.java
+++ b/user/src/main/java/com/goti/user/security/ExtendedUserDetailsService.java
@@ -6,5 +6,5 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 public interface ExtendedUserDetailsService extends UserDetailsService {
 
-	UserDetails loadUserById(String userId) throws UsernameNotFoundException;
+	UserDetails loadUserById(String userId, String providerId) throws UsernameNotFoundException;
 }

--- a/user/src/main/java/com/goti/user/security/ExtendedUserDetailsServiceImpl.java
+++ b/user/src/main/java/com/goti/user/security/ExtendedUserDetailsServiceImpl.java
@@ -11,7 +11,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -23,24 +22,27 @@ public class ExtendedUserDetailsServiceImpl implements ExtendedUserDetailsServic
 
 	@Override
 	public UserDetails loadUserByUsername(String mobile) throws UsernameNotFoundException {
-		return userService.findUserByMobile(mobile).map(this::convert).orElseThrow(
-			() -> new UsernameNotFoundException(mobile + " 번호로 등록된 사용자 정보를 찾을 수 없습니다.")
-		);
+		UserEntity user = userService.findUserByMobile(mobile)
+			.orElseThrow(
+				() -> new UsernameNotFoundException("사용자 정보를 찾을 수 없습니다.")
+			);
+		return convert(user, null);
 	}
 
 	@Override
-	public UserDetails loadUserById(String userId) throws UsernameNotFoundException {
-		Optional<UserEntity> user = userService.findUserById(UUID.fromString(userId));
-		return user.map(this::convert).orElseThrow(
-			() -> new UsernameNotFoundException("사용자 정보를 찾을 수 없습니다.")
-		);
+	public UserDetails loadUserById(String userId, String providerId) throws UsernameNotFoundException {
+		UserEntity user = userService.findUserById(UUID.fromString(userId))
+			.orElseThrow(
+				() -> new UsernameNotFoundException("사용자 정보를 찾을 수 없습니다.")
+			);
+		return convert(user, providerId);
 	}
 
-	private UserDetails convert(UserEntity user) {
+	private UserDetails convert(UserEntity user, String providerId) {
 		return new ExtendedUserDetails(
 			user.getId(),
-			user.getMobile(),
-			user.getRole()
+			user.getRole(),
+			providerId
 		);
 	}
 }

--- a/user/src/main/java/com/goti/user/service/application/auth/SocialAuthService.java
+++ b/user/src/main/java/com/goti/user/service/application/auth/SocialAuthService.java
@@ -5,6 +5,7 @@ import com.goti.constants.Gender;
 import com.goti.constants.OAuthProvider;
 import com.goti.constants.messages.ErrorCode;
 import com.goti.user.domain.entity.user.MemberEntity;
+import com.goti.user.domain.entity.user.SocialProviderEntity;
 import com.goti.user.dto.response.SocialVerifyResponse;
 import com.goti.exception.CustomException;
 import com.goti.infra.api.client.SocialApiClient;
@@ -67,7 +68,7 @@ public class SocialAuthService {
 		SocialUserInfoResponse socialUserInfo = apiClient.getSocialUserInfo(socialAccessToken);
 		String email = socialUserInfo.email();
 		String providerId = socialUserInfo.providerId();
-		boolean isRegistered = socialProviderService.findByProviderIdAndProvider(
+		boolean isRegistered = socialProviderService.findSocialProvider(
 			providerId, provider
 		).isPresent();
 
@@ -79,20 +80,12 @@ public class SocialAuthService {
 
 	@Transactional
 	public Pair<String, String> login(String socialVerifyToken) {
-		SocialInfo verifiedSocialInfo = getSocialInfoByToken(socialVerifyToken);
-		MemberEntity member = socialProviderService.findMemberBySocialInfo(
-			verifiedSocialInfo.providerId,
-			verifiedSocialInfo.provider
-		).orElseThrow(
-			() ->{
-				log.error(
-					"Member not found after social verify - providerId: {}, provider: {}",
-					verifiedSocialInfo.providerId, verifiedSocialInfo.provider
-				);
-				return new CustomException(ErrorCode.MEMBER_NOT_FOUND);
-			}
+		SocialInfo verifiedSocialInfo = getSocialInfo(socialVerifyToken);
+		SocialProviderEntity socialProvider = socialProviderService.getSocialProvider(
+			verifiedSocialInfo.providerId(), verifiedSocialInfo.provider()
 		);
-		return authService.issueTokens(member);
+		MemberEntity member = socialProvider.getMember();
+		return authService.issueTokens(member, verifiedSocialInfo.providerId());
 	}
 
 	@Transactional
@@ -104,12 +97,13 @@ public class SocialAuthService {
 		LocalDate birthDate,
 		String authCode
 	) {
-		SocialInfo verifiedSocialInfo = getSocialInfoByToken(socialVerifyToken);
+		SocialInfo verifiedSocialInfo = getSocialInfo(socialVerifyToken);
+
 		authService.verifySmsCode(mobile, authCode);
 		MemberEntity member = getOrCreateMember(name, mobile, gender, birthDate);
 
 		createSocialProvider(member, verifiedSocialInfo);
-		return authService.issueTokens(member);
+		return authService.issueTokens(member, verifiedSocialInfo.providerId());
 	}
 
 	public void sendSignupSmsCode(String socialVerifyToken, String mobile) {
@@ -120,7 +114,8 @@ public class SocialAuthService {
 	public Pair<String, String> reissueToken(String refreshToken) {
 		UUID memberId = authService.validateTokenAndGetMemberId(refreshToken);
 		MemberEntity member = memberService.getMember(memberId);
-		return authService.issueTokens(member);
+		String providerId = jwtTokenProvider.extractProviderId(refreshToken);
+		return authService.issueTokens(member, providerId);
 	}
 
 	private void validateState(OAuthProvider provider, String state) {
@@ -138,14 +133,17 @@ public class SocialAuthService {
 
 	private record SocialInfo(String providerId, OAuthProvider provider, String email) {}
 
-	private SocialInfo getSocialInfoByToken(String socialVerifyToken) {
+	private SocialInfo getSocialInfo(String socialVerifyToken) {
 		Claims claims = jwtTokenProvider.getSocialVerifyClaims(socialVerifyToken);
 
-		return new SocialInfo(
-			claims.get(PROVIDER_ID_KEY, String.class),
-			OAuthProvider.valueOf(claims.get(PROVIDER_TYPE_KEY, String.class)),
-			claims.get(PROVIDER_EMAIL_KEY, String.class)
+		String providerId = claims.get(PROVIDER_ID_KEY, String.class);
+
+		OAuthProvider provider = OAuthProvider.valueOf(
+			claims.get(PROVIDER_TYPE_KEY, String.class)
 		);
+		String email = claims.get(PROVIDER_EMAIL_KEY, String.class);
+
+		return new SocialInfo(providerId, provider, email);
 	}
 
 	private MemberEntity getOrCreateMember(
@@ -166,7 +164,7 @@ public class SocialAuthService {
 	private void createSocialProvider(
 		MemberEntity member, SocialInfo socialInfo
 	) {
-		socialProviderService.findByProviderIdAndProvider(
+		socialProviderService.findSocialProvider(
 			socialInfo.providerId(),
 			socialInfo.provider
 		).ifPresentOrElse(

--- a/user/src/main/java/com/goti/user/service/domain/auth/AuthService.java
+++ b/user/src/main/java/com/goti/user/service/domain/auth/AuthService.java
@@ -12,6 +12,6 @@ public interface AuthService {
 
 	UUID validateTokenAndGetMemberId(String token);
 
-	Pair<String, String> issueTokens(MemberEntity member);
+	Pair<String, String> issueTokens(MemberEntity member, String providerId);
 
 }

--- a/user/src/main/java/com/goti/user/service/domain/auth/AuthServiceImpl.java
+++ b/user/src/main/java/com/goti/user/service/domain/auth/AuthServiceImpl.java
@@ -60,10 +60,12 @@ public class AuthServiceImpl implements AuthService {
 	}
 
 	@Override
-	public Pair<String, String> issueTokens(MemberEntity member) {
+	public Pair<String, String> issueTokens(MemberEntity member, String providerId) {
 		deleteCachedTokenId(member.getId());
-		String accessToken = createToken(member, TokenType.ACCESS);
-		String refreshToken = createToken(member, TokenType.REFRESH);
+
+		String accessToken = createToken(member, providerId, TokenType.ACCESS);
+		String refreshToken = createToken(member, providerId, TokenType.REFRESH);
+
 		saveTokenJti(member.getId(), refreshToken);
 		return Pair.of(accessToken, refreshToken);
 	}
@@ -73,11 +75,13 @@ public class AuthServiceImpl implements AuthService {
 		redisCache.set(RedisKey.REFRESH_TOKEN, memberId, jti);
 	}
 
-	private String createToken(MemberEntity member, TokenType tokenType) {
+	private String createToken(
+		MemberEntity member, String providerId, TokenType tokenType
+	) {
 		return jwtTokenProvider.create(
 			member.getId(),
-			member.getMobile(),
 			member.getRole(),
+			providerId,
 			tokenType
 		);
 	}

--- a/user/src/main/java/com/goti/user/service/domain/user/SocialProviderService.java
+++ b/user/src/main/java/com/goti/user/service/domain/user/SocialProviderService.java
@@ -12,7 +12,7 @@ public interface SocialProviderService {
 		MemberEntity member, OAuthProvider provider, String providerId, String email
 	);
 
-	Optional<MemberEntity> findMemberBySocialInfo(String providerId, OAuthProvider provider);
+	Optional<SocialProviderEntity> findSocialProvider(String providerId, OAuthProvider provider);
 
-	Optional<SocialProviderEntity> findByProviderIdAndProvider(String providerId, OAuthProvider provider);
+	SocialProviderEntity getSocialProvider(String providerId, OAuthProvider provider);
 }

--- a/user/src/main/java/com/goti/user/service/domain/user/SocialProviderServiceImpl.java
+++ b/user/src/main/java/com/goti/user/service/domain/user/SocialProviderServiceImpl.java
@@ -32,14 +32,19 @@ public class SocialProviderServiceImpl implements SocialProviderService {
 	}
 
 	@Override
-	public Optional<MemberEntity> findMemberBySocialInfo(String providerId, OAuthProvider provider) {
-		return findByProviderIdAndProvider(providerId, provider)
-			.map(SocialProviderEntity::getMember);
+	public Optional<SocialProviderEntity> findSocialProvider(
+		String providerId, OAuthProvider provider
+	) {
+		return socialProviderRepository.findSocialProvider(
+			providerId, provider
+		);
 	}
 
 	@Override
-	public Optional<SocialProviderEntity> findByProviderIdAndProvider(String providerId, OAuthProvider provider) {
-		return socialProviderRepository.findByProviderIdAndProvider(
+	public SocialProviderEntity getSocialProvider(
+		String providerId, OAuthProvider provider
+	) {
+		return socialProviderRepository.findSocialProviderOrThrow(
 			providerId, provider
 		);
 	}

--- a/user/src/main/java/com/goti/user/service/test/TestUserService.java
+++ b/user/src/main/java/com/goti/user/service/test/TestUserService.java
@@ -14,7 +14,6 @@ import com.goti.constants.OAuthProvider;
 import com.goti.constants.messages.ErrorCode;
 import com.goti.exception.CustomException;
 import com.goti.user.config.jwt.JwtTokenProvider;
-import com.goti.user.constants.UserRole;
 import com.goti.user.domain.entity.user.MemberEntity;
 import com.goti.user.dto.request.BulkCreateTestUserRequest;
 import com.goti.user.dto.request.CreateTestUserRequest;
@@ -42,9 +41,9 @@ public class TestUserService {
 	@Transactional
 	public TestUserResponse createUser(CreateTestUserRequest request) {
 		MemberEntity member = findOrCreateMember(request);
-
+		String providerId = "test_provider_id";
 		String accessToken = jwtTokenProvider.create(
-			member.getId(), member.getMobile(), UserRole.MEMBER, TokenType.ACCESS
+			member.getId(), member.getRole(), providerId, TokenType.ACCESS
 		);
 
 		return new TestUserResponse(
@@ -104,9 +103,9 @@ public class TestUserService {
 	public TokenResponse login(TestLoginRequest request) {
 		MemberEntity member = memberService.findByMobile(request.mobile())
 			.orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-
+		String providerId = "test_provider_id";
 		String accessToken = jwtTokenProvider.create(
-			member.getId(), member.getMobile(), UserRole.MEMBER, TokenType.ACCESS
+			member.getId(), member.getRole(), providerId, TokenType.ACCESS
 		);
 
 		return new TokenResponse(accessToken);

--- a/user/src/test/java/com/goti/api/address/AddressRegisterApiTest.java
+++ b/user/src/test/java/com/goti/api/address/AddressRegisterApiTest.java
@@ -47,6 +47,7 @@ class AddressRegisterApiTest {
 
 	MemberEntity member;
 	ExtendedUserDetails authenticator;
+	private final static String PROVIDER_ID = "test_provider_id";
 
 	@BeforeEach
 	void setup() {
@@ -60,8 +61,8 @@ class AddressRegisterApiTest {
 
 		authenticator = new ExtendedUserDetails(
 			member.getId(),
-			member.getMobile(),
-			member.getRole()
+			member.getRole(),
+			PROVIDER_ID
 		);
 	}
 

--- a/user/src/test/java/com/goti/api/auth/SocialAuthReissueTokenApiTest.java
+++ b/user/src/test/java/com/goti/api/auth/SocialAuthReissueTokenApiTest.java
@@ -56,7 +56,7 @@ public class SocialAuthReissueTokenApiTest {
 
 	MemberEntity member;
 	SocialProviderEntity socialProvider;
-
+	private final static String PROVIDER_ID = "test_provider_id";
 	@BeforeEach
 	void setup() {
 		saveMember();
@@ -67,14 +67,14 @@ public class SocialAuthReissueTokenApiTest {
 	void 토큰_재발급_성공__200_OK() throws Exception {
 		String loginAccessToken = jwtTokenProvider.create(
 			member.getId(),
-			member.getMobile(),
 			member.getRole(),
+			PROVIDER_ID,
 			TokenType.ACCESS
 		);
 		String loginRefreshToken = jwtTokenProvider.create(
 			member.getId(),
-			member.getMobile(),
 			member.getRole(),
+			PROVIDER_ID,
 			TokenType.REFRESH
 		);
 

--- a/user/src/test/java/com/goti/api/member/AccountRegisterApiTest.java
+++ b/user/src/test/java/com/goti/api/member/AccountRegisterApiTest.java
@@ -50,6 +50,7 @@ public class AccountRegisterApiTest {
 
 	MemberEntity member;
 	ExtendedUserDetails authenticator;
+	static final String PROVIDER_ID = "test_provider_id";
 
 	@BeforeEach
 	void setup() {
@@ -63,8 +64,8 @@ public class AccountRegisterApiTest {
 
 		authenticator = new ExtendedUserDetails(
 			member.getId(),
-			member.getMobile(),
-			member.getRole()
+			member.getRole(),
+			PROVIDER_ID
 		);
 	}
 

--- a/user/src/test/java/com/goti/user/config/jwt/JwtTokenProviderRs256Test.java
+++ b/user/src/test/java/com/goti/user/config/jwt/JwtTokenProviderRs256Test.java
@@ -56,7 +56,7 @@ class JwtTokenProviderRs256Test {
 		);
 		ExtendedUserDetailsService mockService = new ExtendedUserDetailsService() {
 			@Override
-			public UserDetails loadUserById(String userId) throws UsernameNotFoundException {
+			public UserDetails loadUserById(String userId, String providerId) throws UsernameNotFoundException {
 				return null;
 			}
 
@@ -84,9 +84,10 @@ class JwtTokenProviderRs256Test {
 		void should_createAndValidate_when_rs256Enabled() {
 			// Given
 			UUID userId = UUID.randomUUID();
+			String providerId = "test_provider_id";
 
 			// When
-			String token = provider.create(userId, "01012345678", UserRole.MEMBER, TokenType.ACCESS);
+			String token = provider.create(userId, UserRole.MEMBER, providerId, TokenType.ACCESS);
 
 			// Then
 			assertThatCode(() -> provider.validateToken(token))
@@ -98,7 +99,9 @@ class JwtTokenProviderRs256Test {
 		void should_extractClaims_when_rs256Token() {
 			// Given
 			UUID userId = UUID.randomUUID();
-			String token = provider.create(userId, "01012345678", UserRole.ADMIN, TokenType.ACCESS);
+			String providerId = "test_provider_id";
+
+			String token = provider.create(userId, UserRole.ADMIN, providerId, TokenType.ACCESS);
 
 			// When
 			String jti = provider.extractJti(token);
@@ -146,9 +149,10 @@ class JwtTokenProviderRs256Test {
 		void should_createAndValidate_when_hs512Only() {
 			// Given
 			UUID userId = UUID.randomUUID();
+			String providerId = "test_provider_id";
 
 			// When
-			String token = provider.create(userId, "01012345678", UserRole.MEMBER, TokenType.ACCESS);
+			String token = provider.create(userId, UserRole.MEMBER, providerId, TokenType.ACCESS);
 
 			// Then
 			assertThatCode(() -> provider.validateToken(token))
@@ -169,6 +173,8 @@ class JwtTokenProviderRs256Test {
 		@Test
 		@DisplayName("만료된 토큰은 fallback 없이 즉시 실패한다")
 		void should_throwExpired_when_tokenExpired() {
+			String providerId = "test_provider_id";
+
 			// Given: 이미 만료된 토큰을 생성하기 위해 유효시간 0인 provider
 			JwtProperties properties = new JwtProperties(
 				HMAC_SECRET, rsaPrivateKeyPem, rsaPublicKeyPem, "goti-user-service",
@@ -176,7 +182,7 @@ class JwtTokenProviderRs256Test {
 			);
 			ExtendedUserDetailsService mockService = new ExtendedUserDetailsService() {
 				@Override
-				public UserDetails loadUserById(String userId) throws UsernameNotFoundException {
+				public UserDetails loadUserById(String userId, String providerId) throws UsernameNotFoundException {
 					return null;
 				}
 
@@ -189,7 +195,7 @@ class JwtTokenProviderRs256Test {
 			expiredProvider.initKeys();
 
 			UUID userId = UUID.randomUUID();
-			String token = expiredProvider.create(userId, "01012345678", UserRole.MEMBER, TokenType.ACCESS);
+			String token = expiredProvider.create(userId, UserRole.MEMBER, providerId, TokenType.ACCESS);
 
 			// When & Then
 			assertThatThrownBy(() -> expiredProvider.validateToken(token))


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#388 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
소셜 계정 멀티 연동 구조(1:N)에서 현재 로그인된 구체적인 소셜 계정을 식별하기 위해, JWT 페이로드 및 SecurityContext Principal 구조 확장
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- 로그인 및 회원가입, 토큰 재발급 로직 -> providerId (토큰 생성 시) Parameter 추가
- SocialProviderRepository -> findByProviderIdAndProvider method name 변경 (findByProviderIdAndProvider -> findSocialProvider)
- SocialProviderRepository -> findSocialProviderOrThrow() 추가 (Repository 단 에러 처리)

- SocialProviderService 변경
  - findMemberBySocialInfo 제거 및 findSocialProvider 추가
  - findByProviderIdAndProvider -> getSocialProvider 메서드명 변경
  - SocialProviderService -> socialProvider Get method 추가

- SocialAuthService(SocialApplicationService): getSocialInfoByToken 메소드명 변경 및 로직 개선 (getSocialInfoByToken -> getSocialInfo)
- AuthService(Auth 도메인 서비스): issueTokens -> providerId 인자 값 추가 및 token 생성 시 providerId 인자전달 추가,
- Auth 및 User 관련 테스트 로직 -> ProviderId 값 추가
- JwtTokenProvider -> create providerId 인자 추가 및 jwt payload(claims) providerId 추가
- ExtendedUserDetails -> providerId 필드 추가 및 생성자 인자에 추가 (Principal ProviderId 추가 및 확장)
- UserDetailsService 구현체(ExtendedUserDetailsService: loadUserById) -> String providerId Parameter 추가
- ErrorCode -> SOCIAL_PROVIDER_NOT_FOUND (소셜 provider 미존재 에러) 추가

<br/>