### PR TITLE
[FEAT] Infra: Kafka 및 Zookeeper 인프라 환경 구축

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -14,6 +14,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+    // Kafka
+    implementation 'org.springframework.kafka:spring-kafka'
+
+    // Kafka Test
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
+
     // OpenTelemetry (metrics + traces + logs 자동 설정)
     implementation 'io.opentelemetry.instrumentation:opentelemetry-spring-boot-starter'
 

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -39,6 +39,8 @@ spring:
   config:
     import:
       - optional:file:.env[.properties]
+  kafka:
+    bootstrap-servers: localhost:9092
 
 jwt:
   secret: ${JWT_SECRET_KEY}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -59,10 +59,10 @@ services:
     ports:
       - "9092:9092"
     environment:
-      # 아파치 공식 이미지 설정 (KRaft 모드 겸용 가능하지만 Zookeeper 연결로 유지)
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_BROKER_ID: 1
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
     depends_on:
       - zookeeper

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -42,6 +42,43 @@ services:
           memory: 256M
     restart: unless-stopped
 
+  zookeeper:
+    image: zookeeper:3.9.2
+    platform: ${DOCKER_PLATFORM:-linux/arm64}
+    container_name: goti-zookeeper
+    ports:
+      - "2181:2181"
+    environment:
+      ZOO_MY_ID: 1
+      ZOO_SERVERS: server.1=zookeeper:2888:3888;2181
+
+  kafka:
+    image: apache/kafka:3.7.0
+    platform: ${DOCKER_PLATFORM:-linux/arm64}
+    container_name: goti-kafka
+    ports:
+      - "9092:9092"
+    environment:
+      # 아파치 공식 이미지 설정 (KRaft 모드 겸용 가능하지만 Zookeeper 연결로 유지)
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    depends_on:
+      - zookeeper
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    platform: ${DOCKER_PLATFORM:-linux/arm64}
+    container_name: goti-kafka-ui
+    ports:
+      - "8089:8080"
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092
+    depends_on:
+      - kafka
+
 volumes:
   postgres-data:
   redis-data:


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
서비스 간 비동기 통신과 대규모 트래픽 처리를 위한 메시징 인프라(Kafka) -> 로컬 환경 구축
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- docker-compose에 Kafka 3.7.0 및 Zookeeper 3.9.2 추가
- 실시간 모니터링을 위한 Kafka-UI 설정 (8089 포트)
- platform(arm64) 설정 적용 (개인적인 M2 아키택쳐를 위해)
- 기존 PostgreSQL, Redis와 함께 msa-up 시 자동 실행되도록 구성
<br/>