### PR TITLE
[FEAT] 회원 정보 조회(마이페이지) 서비스 구현 및 테스트 추가

### DIFF
--- a/user/src/main/java/com/goti/user/config/jwt/JwtTokenProvider.java
+++ b/user/src/main/java/com/goti/user/config/jwt/JwtTokenProvider.java
@@ -29,7 +29,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
-import java.security.Provider;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.time.Duration;
@@ -45,7 +44,6 @@ public class JwtTokenProvider {
 
 	private static final String TOKEN_PREFIX = "Bearer ";
 	private static final String ROLE_CLAIM_KEY = "role";
-	private static final String MOBILE_CLAIM_KEY = "mobile";
 
 	private static final String PROVIDER_TYPE_KEY = "provider_type";
 	private static final String PROVIDER_ID_KEY = "provider_id";
@@ -80,7 +78,9 @@ public class JwtTokenProvider {
 		}
 	}
 
-	public String create(UUID id, UserRole role, String providerId, TokenType tokenType) {
+	public String create(
+		UUID id, UserRole role, String providerId, OAuthProvider provider, TokenType tokenType
+	) {
 		Date issuedAt = new Date();
 		Duration validTime = tokenType == TokenType.ACCESS ?
 			jwtProperties.accessValidTime() : jwtProperties.refreshValidTime();
@@ -93,6 +93,7 @@ public class JwtTokenProvider {
 			.issuer(jwtProperties.issuer())
 			.claim(ROLE_CLAIM_KEY, role.name())
 			.claim(PROVIDER_ID_KEY, providerId)
+			.claim(PROVIDER_TYPE_KEY, provider)
 			.issuedAt(issuedAt)
 			.expiration(expireAt);
 
@@ -160,7 +161,8 @@ public class JwtTokenProvider {
 		Claims claims = getClaims(token);
 		String userId = claims.getSubject();
 		String providerId = claims.get(PROVIDER_ID_KEY, String.class);
-		UserDetails userDetails = userDetailsService.loadUserById(userId, providerId);
+		OAuthProvider provider = claims.get(PROVIDER_TYPE_KEY, OAuthProvider.class);
+		UserDetails userDetails = userDetailsService.loadUserById(userId, providerId, provider);
 		return UsernamePasswordAuthenticationToken.authenticated(
 			userDetails,
 			null,
@@ -187,7 +189,7 @@ public class JwtTokenProvider {
 		return getClaims(token).getSubject();
 	}
 
-	private Claims getClaims(String token) {
+	public Claims getClaims(String token) {
 		return parseClaimsDualVerify(token).getPayload();
 	}
 

--- a/user/src/main/java/com/goti/user/domain/entity/user/MemberEntity.java
+++ b/user/src/main/java/com/goti/user/domain/entity/user/MemberEntity.java
@@ -3,7 +3,11 @@ package com.goti.user.domain.entity.user;
 import static lombok.AccessLevel.*;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
+import jakarta.persistence.FetchType;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
 import org.springframework.util.StringUtils;
@@ -23,6 +27,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PROTECTED)
 @DiscriminatorValue("MEMBER")
 public class MemberEntity extends UserEntity {
+
+	@OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
+	private List<SocialProviderEntity> socialProviders = new ArrayList<>();
+
 	private MemberEntity(
 		String mobile,
 		String name,

--- a/user/src/main/java/com/goti/user/dto/response/MemberDetailResponse.java
+++ b/user/src/main/java/com/goti/user/dto/response/MemberDetailResponse.java
@@ -76,6 +76,8 @@ public record MemberDetailResponse(
 				.map(SocialProviderEntity::getProvider)
 				.collect(Collectors.toSet());
 
+			connectedProviders.add(currentProvider);
+
 			return new SocialConnection(
 				connectedProviders.contains(OAuthProvider.GOOGLE),
 				connectedProviders.contains(OAuthProvider.KAKAO),

--- a/user/src/main/java/com/goti/user/dto/response/MemberDetailResponse.java
+++ b/user/src/main/java/com/goti/user/dto/response/MemberDetailResponse.java
@@ -77,9 +77,9 @@ public record MemberDetailResponse(
 				.collect(Collectors.toSet());
 
 			return new SocialConnection(
-				currentProvider == OAuthProvider.GOOGLE || connectedProviders.contains(OAuthProvider.GOOGLE),
-				currentProvider == OAuthProvider.KAKAO || connectedProviders.contains(OAuthProvider.KAKAO),
-				currentProvider == OAuthProvider.NAVER || connectedProviders.contains(OAuthProvider.NAVER)
+				connectedProviders.contains(OAuthProvider.GOOGLE),
+				connectedProviders.contains(OAuthProvider.KAKAO),
+				connectedProviders.contains(OAuthProvider.NAVER)
 			);
 		}
 	}

--- a/user/src/main/java/com/goti/user/dto/response/MemberDetailResponse.java
+++ b/user/src/main/java/com/goti/user/dto/response/MemberDetailResponse.java
@@ -1,16 +1,26 @@
 package com.goti.user.dto.response;
 
+import com.goti.constants.OAuthProvider;
 import com.goti.user.domain.entity.user.AccountEntity;
 import com.goti.user.domain.entity.user.AddressEntity;
 import com.goti.user.domain.entity.user.MemberEntity;
 
+import com.goti.user.domain.entity.user.SocialProviderEntity;
+
 import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Schema(description = "회원 본인 상세조회 응답")
 public record MemberDetailResponse(
 
 	@Schema(description = "이메일", example = "email@google.com")
 	String email,
+
+	@Schema(description = "소셜 제공자 타입", example = "GOOGLE")
+	OAuthProvider oAuthProvider,
 
 	@Schema(description = "이름", example = "홍길동")
 	String name,
@@ -60,29 +70,48 @@ public record MemberDetailResponse(
 		@Schema(description = "네이버 연결 여부", example = "false")
 		boolean isNaverConnected
 	) {
+		public static SocialConnection of(List<SocialProviderEntity> connections, OAuthProvider currentProvider) {
+
+			Set<OAuthProvider> connectedProviders = connections.stream()
+				.map(SocialProviderEntity::getProvider)
+				.collect(Collectors.toSet());
+
+			return new SocialConnection(
+				currentProvider == OAuthProvider.GOOGLE || connectedProviders.contains(OAuthProvider.GOOGLE),
+				currentProvider == OAuthProvider.KAKAO || connectedProviders.contains(OAuthProvider.KAKAO),
+				currentProvider == OAuthProvider.NAVER || connectedProviders.contains(OAuthProvider.NAVER)
+			);
+		}
 	}
 
 	public static MemberDetailResponse from(
 		String email,
+		OAuthProvider provider,
 		MemberEntity member,
 		AccountEntity account,
-		AddressEntity address
+		AddressEntity address,
+		SocialConnection socialConnection
 	) {
 		return new MemberDetailResponse(
 			email,
+			provider,
 			member.getName(),
 			member.getMobile(),
-			new BankAccount(
-				account.getBankName(),
-				account.getAccountNumber(),
-				account.getAccountHolder()
-			),
-			new Address(
-				address.getZipCode(),
-				address.getBaseAddress(),
-				address.getDetailAddress()
-			),
-			null
+			account != null ?
+				new BankAccount(
+					account.getBankName(),
+					account.getAccountNumber(),
+					account.getAccountHolder()
+				) :
+				null,
+			address != null ?
+				new Address(
+					address.getZipCode(),
+					address.getBaseAddress(),
+					address.getDetailAddress()
+				) :
+				null,
+			socialConnection
 		);
 	}
 

--- a/user/src/main/java/com/goti/user/dto/response/MemberDetailResponse.java
+++ b/user/src/main/java/com/goti/user/dto/response/MemberDetailResponse.java
@@ -1,0 +1,89 @@
+package com.goti.user.dto.response;
+
+import com.goti.user.domain.entity.user.AccountEntity;
+import com.goti.user.domain.entity.user.AddressEntity;
+import com.goti.user.domain.entity.user.MemberEntity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회원 본인 상세조회 응답")
+public record MemberDetailResponse(
+
+	@Schema(description = "이메일", example = "email@google.com")
+	String email,
+
+	@Schema(description = "이름", example = "홍길동")
+	String name,
+
+	@Schema(description = "휴대전화번호", example = "010-1234-5678")
+	String mobile,
+
+	@Schema(description = "계좌 정보")
+	BankAccount bankAccount,
+
+	@Schema(description = "주소 정보")
+	Address address,
+
+	@Schema(description = "소셜 계정 연결 정보")
+	SocialConnection socialConnection
+
+) {
+
+	@Schema(description = "은행 계좌 정보")
+	public record BankAccount(
+		@Schema(description = "은행명", example = "카카오뱅크")
+		String bankName,
+		@Schema(description = "계좌번호", example = "3333-67-8765445")
+		String accountNumber,
+		@Schema(description = "예금주", example = "김고티")
+		String accountHolder
+	) {
+	}
+
+	@Schema(description = "주소 정보")
+	public record Address(
+		@Schema(description = "우편번호", example = "12345")
+		String zipCode,
+		@Schema(description = "기본 주소", example = "서울특별시 강남구 테헤란로 123")
+		String baseAddress,
+		@Schema(description = "상세 주소", example = "101호")
+		String detailAddress
+	) {
+	}
+
+	@Schema(description = "소셜 연결 상태")
+	public record SocialConnection(
+		@Schema(description = "구글 연결 여부", example = "true")
+		boolean isGoogleConnected,
+		@Schema(description = "카카오 연결 여부", example = "true")
+		boolean isKakaoConnected,
+		@Schema(description = "네이버 연결 여부", example = "false")
+		boolean isNaverConnected
+	) {
+	}
+
+	public static MemberDetailResponse from(
+		String email,
+		MemberEntity member,
+		AccountEntity account,
+		AddressEntity address
+	) {
+		return new MemberDetailResponse(
+			email,
+			member.getName(),
+			member.getMobile(),
+			new BankAccount(
+				account.getBankName(),
+				account.getAccountNumber(),
+				account.getAccountHolder()
+			),
+			new Address(
+				address.getZipCode(),
+				address.getBaseAddress(),
+				address.getDetailAddress()
+			),
+			null
+		);
+	}
+
+}

--- a/user/src/main/java/com/goti/user/repository/AccountRepository.java
+++ b/user/src/main/java/com/goti/user/repository/AccountRepository.java
@@ -13,5 +13,5 @@ import java.util.UUID;
 @Repository
 public interface AccountRepository extends JpaRepository<AccountEntity, UUID> {
 
-	Optional<AccountEntity> findByMember(MemberEntity member);
+	Optional<AccountEntity> findAccount(MemberEntity member);
 }

--- a/user/src/main/java/com/goti/user/repository/AccountRepository.java
+++ b/user/src/main/java/com/goti/user/repository/AccountRepository.java
@@ -13,5 +13,5 @@ import java.util.UUID;
 @Repository
 public interface AccountRepository extends JpaRepository<AccountEntity, UUID> {
 
-	Optional<AccountEntity> findAccount(MemberEntity member);
+	Optional<AccountEntity> findByMember(MemberEntity member);
 }

--- a/user/src/main/java/com/goti/user/repository/SocialProviderRepository.java
+++ b/user/src/main/java/com/goti/user/repository/SocialProviderRepository.java
@@ -16,12 +16,14 @@ import java.util.UUID;
 @Repository
 public interface SocialProviderRepository extends JpaRepository<SocialProviderEntity, UUID> {
 
-	default SocialProviderEntity findSocialProviderOrThrow(String providerId) {
-		return findByProviderId(providerId).orElseThrow(
+	default SocialProviderEntity findSocialProviderOrThrow(String providerId, OAuthProvider provider) {
+		return findByProviderIdAndProvider(
+			providerId, provider
+		).orElseThrow(
 			() -> new CustomException(ErrorCode.SOCIAL_PROVIDER_NOT_FOUND)
 		);
 	}
 
-	Optional<SocialProviderEntity> findByProviderId(String providerId);
+	Optional<SocialProviderEntity> findByProviderIdAndProvider(String providerId, OAuthProvider provider);
 
 }

--- a/user/src/main/java/com/goti/user/repository/SocialProviderRepository.java
+++ b/user/src/main/java/com/goti/user/repository/SocialProviderRepository.java
@@ -16,20 +16,12 @@ import java.util.UUID;
 @Repository
 public interface SocialProviderRepository extends JpaRepository<SocialProviderEntity, UUID> {
 
-	default SocialProviderEntity findSocialProviderOrThrow(String providerId, OAuthProvider provider) {
-		return findSocialProvider(providerId, provider).orElseThrow(
+	default SocialProviderEntity findSocialProviderOrThrow(String providerId) {
+		return findByProviderId(providerId).orElseThrow(
 			() -> new CustomException(ErrorCode.SOCIAL_PROVIDER_NOT_FOUND)
 		);
 	}
 
-	@Query("SELECT s " +
-					 "FROM SocialProviderEntity s " +
-		 "JOIN FETCH s.member " +
-					"WHERE s.providerId = :providerId " +
-		 				"AND s.provider = :provider")
-	Optional<SocialProviderEntity> findSocialProvider(
-		@Param("providerId") String providerId,
-		@Param("provider") OAuthProvider provider
-	);
+	Optional<SocialProviderEntity> findByProviderId(String providerId);
 
 }

--- a/user/src/main/java/com/goti/user/security/ExtendedUserDetails.java
+++ b/user/src/main/java/com/goti/user/security/ExtendedUserDetails.java
@@ -1,5 +1,6 @@
 package com.goti.user.security;
 
+import com.goti.constants.OAuthProvider;
 import com.goti.user.constants.UserRole;
 
 import lombok.EqualsAndHashCode;
@@ -15,11 +16,13 @@ import java.util.UUID;
 public class ExtendedUserDetails extends User {
 	private final UUID id;
 	private final String providerId;
+	private final OAuthProvider provider;
 
-	public ExtendedUserDetails(UUID id, UserRole role, String providerId) {
+	public ExtendedUserDetails(UUID id, UserRole role, String providerId, OAuthProvider provider) {
 		super(String.valueOf(id), "", AuthorityUtils.createAuthorityList("ROLE_" + role.name()));
 		this.id = id;
 		this.providerId = providerId;
+		this.provider = provider;
 	}
 
 }

--- a/user/src/main/java/com/goti/user/security/ExtendedUserDetailsService.java
+++ b/user/src/main/java/com/goti/user/security/ExtendedUserDetailsService.java
@@ -1,10 +1,14 @@
 package com.goti.user.security;
 
+import com.goti.constants.OAuthProvider;
+
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 public interface ExtendedUserDetailsService extends UserDetailsService {
 
-	UserDetails loadUserById(String userId, String providerId) throws UsernameNotFoundException;
+	UserDetails loadUserById(
+		String userId, String providerId, OAuthProvider provider
+	) throws UsernameNotFoundException;
 }

--- a/user/src/main/java/com/goti/user/security/ExtendedUserDetailsServiceImpl.java
+++ b/user/src/main/java/com/goti/user/security/ExtendedUserDetailsServiceImpl.java
@@ -1,5 +1,6 @@
 package com.goti.user.security;
 
+import com.goti.constants.OAuthProvider;
 import com.goti.user.domain.entity.user.UserEntity;
 
 import com.goti.user.service.domain.user.UserService;
@@ -26,23 +27,26 @@ public class ExtendedUserDetailsServiceImpl implements ExtendedUserDetailsServic
 			.orElseThrow(
 				() -> new UsernameNotFoundException("사용자 정보를 찾을 수 없습니다.")
 			);
-		return convert(user, null);
+		return convert(user, null, null);
 	}
 
 	@Override
-	public UserDetails loadUserById(String userId, String providerId) throws UsernameNotFoundException {
+	public UserDetails loadUserById(
+		String userId, String providerId, OAuthProvider provider
+	) throws UsernameNotFoundException {
 		UserEntity user = userService.findUserById(UUID.fromString(userId))
 			.orElseThrow(
 				() -> new UsernameNotFoundException("사용자 정보를 찾을 수 없습니다.")
 			);
-		return convert(user, providerId);
+		return convert(user, providerId, provider);
 	}
 
-	private UserDetails convert(UserEntity user, String providerId) {
+	private UserDetails convert(UserEntity user, String providerId, OAuthProvider provider) {
 		return new ExtendedUserDetails(
 			user.getId(),
 			user.getRole(),
-			providerId
+			providerId,
+			provider
 		);
 	}
 }

--- a/user/src/main/java/com/goti/user/service/application/auth/SocialAuthService.java
+++ b/user/src/main/java/com/goti/user/service/application/auth/SocialAuthService.java
@@ -68,9 +68,8 @@ public class SocialAuthService {
 		SocialUserInfoResponse socialUserInfo = apiClient.getSocialUserInfo(socialAccessToken);
 		String email = socialUserInfo.email();
 		String providerId = socialUserInfo.providerId();
-		boolean isRegistered = socialProviderService.findSocialProvider(
-			providerId, provider
-		).isPresent();
+		boolean isRegistered =
+			socialProviderService.findSocialProvider(providerId).isPresent();
 
 		String socialVerifyToken = jwtTokenProvider.createSocialVerifyToken(
 			provider, providerId, email
@@ -81,9 +80,8 @@ public class SocialAuthService {
 	@Transactional
 	public Pair<String, String> login(String socialVerifyToken) {
 		SocialInfo verifiedSocialInfo = getSocialInfo(socialVerifyToken);
-		SocialProviderEntity socialProvider = socialProviderService.getSocialProvider(
-			verifiedSocialInfo.providerId(), verifiedSocialInfo.provider()
-		);
+		SocialProviderEntity socialProvider =
+			socialProviderService.getSocialProvider(verifiedSocialInfo.providerId());
 		MemberEntity member = socialProvider.getMember();
 		return authService.issueTokens(member, verifiedSocialInfo.providerId());
 	}
@@ -165,8 +163,7 @@ public class SocialAuthService {
 		MemberEntity member, SocialInfo socialInfo
 	) {
 		socialProviderService.findSocialProvider(
-			socialInfo.providerId(),
-			socialInfo.provider
+			socialInfo.providerId()
 		).ifPresentOrElse(
 			existingProvider -> {
 				if (!existingProvider.getMember().getId().equals(member.getId())) {

--- a/user/src/main/java/com/goti/user/service/application/auth/SocialAuthService.java
+++ b/user/src/main/java/com/goti/user/service/application/auth/SocialAuthService.java
@@ -122,7 +122,7 @@ public class SocialAuthService {
 		MemberEntity member = memberService.getMember(memberId);
 		Claims claims = jwtTokenProvider.getClaims(refreshToken);
 		String providerId = claims.get(PROVIDER_ID_KEY, String.class);
-		OAuthProvider provider = claims.get(PROVIDER_TYPE_KEY, OAuthProvider.class);
+		OAuthProvider provider = OAuthProvider.valueOf(claims.get(PROVIDER_TYPE_KEY, String.class));
 		return authService.issueTokens(
 			member, providerId, provider
 		);

--- a/user/src/main/java/com/goti/user/service/application/auth/SocialAuthService.java
+++ b/user/src/main/java/com/goti/user/service/application/auth/SocialAuthService.java
@@ -69,7 +69,7 @@ public class SocialAuthService {
 		String email = socialUserInfo.email();
 		String providerId = socialUserInfo.providerId();
 		boolean isRegistered =
-			socialProviderService.findSocialProvider(providerId).isPresent();
+			socialProviderService.findSocialProvider(providerId, provider).isPresent();
 
 		String socialVerifyToken = jwtTokenProvider.createSocialVerifyToken(
 			provider, providerId, email
@@ -79,11 +79,17 @@ public class SocialAuthService {
 
 	@Transactional
 	public Pair<String, String> login(String socialVerifyToken) {
-		SocialInfo verifiedSocialInfo = getSocialInfo(socialVerifyToken);
+		SocialInfo socialInfo = getSocialInfo(socialVerifyToken);
+
 		SocialProviderEntity socialProvider =
-			socialProviderService.getSocialProvider(verifiedSocialInfo.providerId());
+			socialProviderService.getSocialProvider(
+				socialInfo.providerId(), socialInfo.provider()
+			);
+
 		MemberEntity member = socialProvider.getMember();
-		return authService.issueTokens(member, verifiedSocialInfo.providerId());
+		return authService.issueTokens(
+			member, socialProvider.getProviderId(), socialProvider.getProvider()
+		);
 	}
 
 	@Transactional
@@ -95,13 +101,15 @@ public class SocialAuthService {
 		LocalDate birthDate,
 		String authCode
 	) {
-		SocialInfo verifiedSocialInfo = getSocialInfo(socialVerifyToken);
+		SocialInfo socialInfo = getSocialInfo(socialVerifyToken);
 
 		authService.verifySmsCode(mobile, authCode);
 		MemberEntity member = getOrCreateMember(name, mobile, gender, birthDate);
 
-		createSocialProvider(member, verifiedSocialInfo);
-		return authService.issueTokens(member, verifiedSocialInfo.providerId());
+		createSocialProvider(member, socialInfo);
+		return authService.issueTokens(
+			member, socialInfo.providerId(), socialInfo.provider()
+		);
 	}
 
 	public void sendSignupSmsCode(String socialVerifyToken, String mobile) {
@@ -112,8 +120,12 @@ public class SocialAuthService {
 	public Pair<String, String> reissueToken(String refreshToken) {
 		UUID memberId = authService.validateTokenAndGetMemberId(refreshToken);
 		MemberEntity member = memberService.getMember(memberId);
-		String providerId = jwtTokenProvider.extractProviderId(refreshToken);
-		return authService.issueTokens(member, providerId);
+		Claims claims = jwtTokenProvider.getClaims(refreshToken);
+		String providerId = claims.get(PROVIDER_ID_KEY, String.class);
+		OAuthProvider provider = claims.get(PROVIDER_TYPE_KEY, OAuthProvider.class);
+		return authService.issueTokens(
+			member, providerId, provider
+		);
 	}
 
 	private void validateState(OAuthProvider provider, String state) {
@@ -163,7 +175,7 @@ public class SocialAuthService {
 		MemberEntity member, SocialInfo socialInfo
 	) {
 		socialProviderService.findSocialProvider(
-			socialInfo.providerId()
+			socialInfo.providerId(), socialInfo.provider
 		).ifPresentOrElse(
 			existingProvider -> {
 				if (!existingProvider.getMember().getId().equals(member.getId())) {

--- a/user/src/main/java/com/goti/user/service/application/member/MemberProfileService.java
+++ b/user/src/main/java/com/goti/user/service/application/member/MemberProfileService.java
@@ -30,6 +30,7 @@ public class MemberProfileService {
 	private final AddressService addressService;
 	private final SocialProviderService socialProviderService;
 
+	@Transactional(readOnly = true)
 	public MemberDetailResponse getProfileDetail(String providerId) {
 		SocialProviderEntity socialProvider = socialProviderService.getSocialProvider(providerId);
 		MemberEntity member = socialProvider.getMember();

--- a/user/src/main/java/com/goti/user/service/application/member/MemberProfileService.java
+++ b/user/src/main/java/com/goti/user/service/application/member/MemberProfileService.java
@@ -1,17 +1,25 @@
 package com.goti.user.service.application.member;
 
+import com.goti.constants.OAuthProvider;
+import com.goti.user.domain.entity.user.AccountEntity;
+import com.goti.user.domain.entity.user.AddressEntity;
 import com.goti.user.domain.entity.user.MemberEntity;
+import com.goti.user.domain.entity.user.SocialProviderEntity;
 import com.goti.user.dto.response.AccountRegisterResponse;
 import com.goti.user.dto.response.AddressRegisterResponse;
+import com.goti.user.dto.response.MemberDetailResponse;
 import com.goti.user.service.domain.account.AccountService;
 import com.goti.user.service.domain.address.AddressService;
 import com.goti.user.service.domain.user.MemberService;
+
+import com.goti.user.service.domain.user.SocialProviderService;
 
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -20,6 +28,26 @@ public class MemberProfileService {
 	private final MemberService memberService;
 	private final AccountService accountService;
 	private final AddressService addressService;
+	private final SocialProviderService socialProviderService;
+
+	public MemberDetailResponse getProfileDetail(String providerId) {
+		SocialProviderEntity socialProvider = socialProviderService.getSocialProvider(providerId);
+		MemberEntity member = socialProvider.getMember();
+		OAuthProvider provider = socialProvider.getProvider();
+		AccountEntity account = accountService.findAccount(member).orElse(null);
+		AddressEntity address = addressService.findAddress(member).orElse(null);
+		var socialConnection = MemberDetailResponse.SocialConnection.of(
+			member.getSocialProviders(), provider
+		);
+		return MemberDetailResponse.from(
+			socialProvider.getEmail(),
+			provider,
+			member,
+			account,
+			address,
+			socialConnection
+		);
+	}
 
 	@Transactional
 	public AccountRegisterResponse registerAccount(

--- a/user/src/main/java/com/goti/user/service/application/member/MemberProfileService.java
+++ b/user/src/main/java/com/goti/user/service/application/member/MemberProfileService.java
@@ -19,7 +19,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -31,10 +30,9 @@ public class MemberProfileService {
 	private final SocialProviderService socialProviderService;
 
 	@Transactional(readOnly = true)
-	public MemberDetailResponse getProfileDetail(String providerId) {
-		SocialProviderEntity socialProvider = socialProviderService.getSocialProvider(providerId);
+	public MemberDetailResponse getProfileDetail(String providerId, OAuthProvider provider) {
+		SocialProviderEntity socialProvider = socialProviderService.getSocialProvider(providerId, provider);
 		MemberEntity member = socialProvider.getMember();
-		OAuthProvider provider = socialProvider.getProvider();
 		AccountEntity account = accountService.findAccount(member).orElse(null);
 		AddressEntity address = addressService.findAddress(member).orElse(null);
 		var socialConnection = MemberDetailResponse.SocialConnection.of(

--- a/user/src/main/java/com/goti/user/service/domain/account/AccountService.java
+++ b/user/src/main/java/com/goti/user/service/domain/account/AccountService.java
@@ -1,11 +1,16 @@
 package com.goti.user.service.domain.account;
 
+import com.goti.user.domain.entity.user.AccountEntity;
 import com.goti.user.domain.entity.user.MemberEntity;
 import com.goti.user.dto.response.AccountRegisterResponse;
+
+import java.util.Optional;
 
 public interface AccountService {
 
 	AccountRegisterResponse register(
 		String accountNumber, String bankName, String accountHolder, MemberEntity member
 	);
+
+	Optional<AccountEntity> findAccount(MemberEntity member);
 }

--- a/user/src/main/java/com/goti/user/service/domain/account/AccountServiceImpl.java
+++ b/user/src/main/java/com/goti/user/service/domain/account/AccountServiceImpl.java
@@ -23,7 +23,7 @@ public class AccountServiceImpl implements AccountService {
 	public AccountRegisterResponse register(
 		String accountNumber, String bankName, String accountHolder, MemberEntity member
 	) {
-		AccountEntity account = accountRepository.findByMember(member)
+		AccountEntity account = accountRepository.findAccount(member)
 			.map(existingAccount -> {
 				existingAccount.updateDetails(accountNumber, bankName, accountHolder);
 				return existingAccount;
@@ -39,6 +39,6 @@ public class AccountServiceImpl implements AccountService {
 
 	@Override
 	public Optional<AccountEntity> findAccount(MemberEntity member) {
-		return accountRepository.findByMember(member);
+		return accountRepository.findAccount(member);
 	}
 }

--- a/user/src/main/java/com/goti/user/service/domain/account/AccountServiceImpl.java
+++ b/user/src/main/java/com/goti/user/service/domain/account/AccountServiceImpl.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class AccountServiceImpl implements AccountService {
@@ -33,5 +35,10 @@ public class AccountServiceImpl implements AccountService {
 		accountRepository.save(account);
 
 		return AccountRegisterResponse.from(account);
+	}
+
+	@Override
+	public Optional<AccountEntity> findAccount(MemberEntity member) {
+		return accountRepository.findByMember(member);
 	}
 }

--- a/user/src/main/java/com/goti/user/service/domain/account/AccountServiceImpl.java
+++ b/user/src/main/java/com/goti/user/service/domain/account/AccountServiceImpl.java
@@ -23,7 +23,7 @@ public class AccountServiceImpl implements AccountService {
 	public AccountRegisterResponse register(
 		String accountNumber, String bankName, String accountHolder, MemberEntity member
 	) {
-		AccountEntity account = accountRepository.findAccount(member)
+		AccountEntity account = findAccount(member)
 			.map(existingAccount -> {
 				existingAccount.updateDetails(accountNumber, bankName, accountHolder);
 				return existingAccount;
@@ -39,6 +39,6 @@ public class AccountServiceImpl implements AccountService {
 
 	@Override
 	public Optional<AccountEntity> findAccount(MemberEntity member) {
-		return accountRepository.findAccount(member);
+		return accountRepository.findByMember(member);
 	}
 }

--- a/user/src/main/java/com/goti/user/service/domain/auth/AuthService.java
+++ b/user/src/main/java/com/goti/user/service/domain/auth/AuthService.java
@@ -1,5 +1,6 @@
 package com.goti.user.service.domain.auth;
 
+import com.goti.constants.OAuthProvider;
 import com.goti.user.domain.entity.user.MemberEntity;
 import org.springframework.data.util.Pair;
 
@@ -12,6 +13,8 @@ public interface AuthService {
 
 	UUID validateTokenAndGetMemberId(String token);
 
-	Pair<String, String> issueTokens(MemberEntity member, String providerId);
+	Pair<String, String> issueTokens(
+		MemberEntity member, String providerId, OAuthProvider provider
+	);
 
 }

--- a/user/src/main/java/com/goti/user/service/domain/auth/AuthServiceImpl.java
+++ b/user/src/main/java/com/goti/user/service/domain/auth/AuthServiceImpl.java
@@ -1,5 +1,6 @@
 package com.goti.user.service.domain.auth;
 
+import com.goti.constants.OAuthProvider;
 import com.goti.global.validation.Preconditions;
 import com.goti.user.config.jwt.JwtTokenProvider;
 import com.goti.constants.messages.ErrorCode;
@@ -60,11 +61,15 @@ public class AuthServiceImpl implements AuthService {
 	}
 
 	@Override
-	public Pair<String, String> issueTokens(MemberEntity member, String providerId) {
+	public Pair<String, String> issueTokens(MemberEntity member, String providerId, OAuthProvider provider) {
 		deleteCachedTokenId(member.getId());
 
-		String accessToken = createToken(member, providerId, TokenType.ACCESS);
-		String refreshToken = createToken(member, providerId, TokenType.REFRESH);
+		String accessToken = createToken(
+			member, providerId, provider, TokenType.ACCESS
+		);
+		String refreshToken = createToken(
+			member, providerId, provider, TokenType.REFRESH
+		);
 
 		saveTokenJti(member.getId(), refreshToken);
 		return Pair.of(accessToken, refreshToken);
@@ -76,12 +81,13 @@ public class AuthServiceImpl implements AuthService {
 	}
 
 	private String createToken(
-		MemberEntity member, String providerId, TokenType tokenType
+		MemberEntity member, String providerId, OAuthProvider provider, TokenType tokenType
 	) {
 		return jwtTokenProvider.create(
 			member.getId(),
 			member.getRole(),
 			providerId,
+			provider,
 			tokenType
 		);
 	}

--- a/user/src/main/java/com/goti/user/service/domain/user/SocialProviderService.java
+++ b/user/src/main/java/com/goti/user/service/domain/user/SocialProviderService.java
@@ -12,7 +12,7 @@ public interface SocialProviderService {
 		MemberEntity member, OAuthProvider provider, String providerId, String email
 	);
 
-	Optional<SocialProviderEntity> findSocialProvider(String providerId, OAuthProvider provider);
+	Optional<SocialProviderEntity> findSocialProvider(String providerId);
 
-	SocialProviderEntity getSocialProvider(String providerId, OAuthProvider provider);
+	SocialProviderEntity getSocialProvider(String providerId);
 }

--- a/user/src/main/java/com/goti/user/service/domain/user/SocialProviderService.java
+++ b/user/src/main/java/com/goti/user/service/domain/user/SocialProviderService.java
@@ -12,7 +12,11 @@ public interface SocialProviderService {
 		MemberEntity member, OAuthProvider provider, String providerId, String email
 	);
 
-	Optional<SocialProviderEntity> findSocialProvider(String providerId);
+	Optional<SocialProviderEntity> findSocialProvider(
+		String providerId, OAuthProvider provider
+	);
 
-	SocialProviderEntity getSocialProvider(String providerId);
+	SocialProviderEntity getSocialProvider(
+		String providerId, OAuthProvider provider
+	);
 }

--- a/user/src/main/java/com/goti/user/service/domain/user/SocialProviderServiceImpl.java
+++ b/user/src/main/java/com/goti/user/service/domain/user/SocialProviderServiceImpl.java
@@ -32,12 +32,20 @@ public class SocialProviderServiceImpl implements SocialProviderService {
 	}
 
 	@Override
-	public Optional<SocialProviderEntity> findSocialProvider(String providerId) {
-		return socialProviderRepository.findByProviderId(providerId);
+	public Optional<SocialProviderEntity> findSocialProvider(
+		String providerId, OAuthProvider provider
+	) {
+		return socialProviderRepository.findByProviderIdAndProvider(
+			providerId, provider
+		);
 	}
 
 	@Override
-	public SocialProviderEntity getSocialProvider(String providerId) {
-		return socialProviderRepository.findSocialProviderOrThrow(providerId);
+	public SocialProviderEntity getSocialProvider(
+		String providerId, OAuthProvider provider
+	) {
+		return socialProviderRepository.findSocialProviderOrThrow(
+			providerId, provider
+		);
 	}
 }

--- a/user/src/main/java/com/goti/user/service/domain/user/SocialProviderServiceImpl.java
+++ b/user/src/main/java/com/goti/user/service/domain/user/SocialProviderServiceImpl.java
@@ -32,20 +32,12 @@ public class SocialProviderServiceImpl implements SocialProviderService {
 	}
 
 	@Override
-	public Optional<SocialProviderEntity> findSocialProvider(
-		String providerId, OAuthProvider provider
-	) {
-		return socialProviderRepository.findSocialProvider(
-			providerId, provider
-		);
+	public Optional<SocialProviderEntity> findSocialProvider(String providerId) {
+		return socialProviderRepository.findByProviderId(providerId);
 	}
 
 	@Override
-	public SocialProviderEntity getSocialProvider(
-		String providerId, OAuthProvider provider
-	) {
-		return socialProviderRepository.findSocialProviderOrThrow(
-			providerId, provider
-		);
+	public SocialProviderEntity getSocialProvider(String providerId) {
+		return socialProviderRepository.findSocialProviderOrThrow(providerId);
 	}
 }

--- a/user/src/main/java/com/goti/user/service/test/TestUserService.java
+++ b/user/src/main/java/com/goti/user/service/test/TestUserService.java
@@ -42,8 +42,9 @@ public class TestUserService {
 	public TestUserResponse createUser(CreateTestUserRequest request) {
 		MemberEntity member = findOrCreateMember(request);
 		String providerId = "test_provider_id";
+		OAuthProvider provider = OAuthProvider.KAKAO;
 		String accessToken = jwtTokenProvider.create(
-			member.getId(), member.getRole(), providerId, TokenType.ACCESS
+			member.getId(), member.getRole(), providerId, provider, TokenType.ACCESS
 		);
 
 		return new TestUserResponse(
@@ -104,8 +105,9 @@ public class TestUserService {
 		MemberEntity member = memberService.findByMobile(request.mobile())
 			.orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 		String providerId = "test_provider_id";
+		OAuthProvider provider = OAuthProvider.KAKAO;
 		String accessToken = jwtTokenProvider.create(
-			member.getId(), member.getRole(), providerId, TokenType.ACCESS
+			member.getId(), member.getRole(), providerId, provider, TokenType.ACCESS
 		);
 
 		return new TokenResponse(accessToken);

--- a/user/src/test/java/com/goti/api/address/AddressRegisterApiTest.java
+++ b/user/src/test/java/com/goti/api/address/AddressRegisterApiTest.java
@@ -3,6 +3,7 @@ package com.goti.api.address;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.goti.constants.Gender;
+import com.goti.constants.OAuthProvider;
 import com.goti.user.GotiUserApplication;
 import com.goti.user.domain.entity.user.MemberEntity;
 import com.goti.user.dto.request.AddressRegisterRequest;
@@ -48,9 +49,10 @@ class AddressRegisterApiTest {
 	MemberEntity member;
 	ExtendedUserDetails authenticator;
 	private final static String PROVIDER_ID = "test_provider_id";
-
+	private final static OAuthProvider PROVIDER = OAuthProvider.GOOGLE;
 	@BeforeEach
 	void setup() {
+
 		member = MemberEntity.create(
 			"01012341234",
 			"테스트회원",
@@ -62,7 +64,8 @@ class AddressRegisterApiTest {
 		authenticator = new ExtendedUserDetails(
 			member.getId(),
 			member.getRole(),
-			PROVIDER_ID
+			PROVIDER_ID,
+			PROVIDER
 		);
 	}
 

--- a/user/src/test/java/com/goti/api/auth/SocialAuthReissueTokenApiTest.java
+++ b/user/src/test/java/com/goti/api/auth/SocialAuthReissueTokenApiTest.java
@@ -57,6 +57,7 @@ public class SocialAuthReissueTokenApiTest {
 	MemberEntity member;
 	SocialProviderEntity socialProvider;
 	private final static String PROVIDER_ID = "test_provider_id";
+	private final static OAuthProvider PROVIDER = OAuthProvider.KAKAO;
 	@BeforeEach
 	void setup() {
 		saveMember();
@@ -69,12 +70,14 @@ public class SocialAuthReissueTokenApiTest {
 			member.getId(),
 			member.getRole(),
 			PROVIDER_ID,
+			PROVIDER,
 			TokenType.ACCESS
 		);
 		String loginRefreshToken = jwtTokenProvider.create(
 			member.getId(),
 			member.getRole(),
 			PROVIDER_ID,
+			PROVIDER,
 			TokenType.REFRESH
 		);
 

--- a/user/src/test/java/com/goti/api/member/AccountRegisterApiTest.java
+++ b/user/src/test/java/com/goti/api/member/AccountRegisterApiTest.java
@@ -2,6 +2,7 @@ package com.goti.api.member;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.goti.constants.Gender;
+import com.goti.constants.OAuthProvider;
 import com.goti.user.GotiUserApplication;
 
 import com.goti.user.domain.entity.user.MemberEntity;
@@ -54,6 +55,7 @@ public class AccountRegisterApiTest {
 
 	@BeforeEach
 	void setup() {
+		OAuthProvider provider = OAuthProvider.KAKAO;
 		member = MemberEntity.create(
 			"01012341234",
 			"테스트회원",
@@ -65,7 +67,8 @@ public class AccountRegisterApiTest {
 		authenticator = new ExtendedUserDetails(
 			member.getId(),
 			member.getRole(),
-			PROVIDER_ID
+			PROVIDER_ID,
+			provider
 		);
 	}
 

--- a/user/src/test/java/com/goti/user/config/jwt/JwtTokenProviderRs256Test.java
+++ b/user/src/test/java/com/goti/user/config/jwt/JwtTokenProviderRs256Test.java
@@ -9,6 +9,8 @@ import java.time.Duration;
 import java.util.Base64;
 import java.util.UUID;
 
+import com.goti.constants.OAuthProvider;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -56,7 +58,9 @@ class JwtTokenProviderRs256Test {
 		);
 		ExtendedUserDetailsService mockService = new ExtendedUserDetailsService() {
 			@Override
-			public UserDetails loadUserById(String userId, String providerId) throws UsernameNotFoundException {
+			public UserDetails loadUserById(
+				String userId, String providerId, OAuthProvider provider
+			) throws UsernameNotFoundException {
 				return null;
 			}
 
@@ -85,9 +89,12 @@ class JwtTokenProviderRs256Test {
 			// Given
 			UUID userId = UUID.randomUUID();
 			String providerId = "test_provider_id";
+			OAuthProvider providerName = OAuthProvider.GOOGLE;
 
 			// When
-			String token = provider.create(userId, UserRole.MEMBER, providerId, TokenType.ACCESS);
+			String token = provider.create(
+				userId, UserRole.MEMBER, providerId, providerName, TokenType.ACCESS
+			);
 
 			// Then
 			assertThatCode(() -> provider.validateToken(token))
@@ -100,8 +107,11 @@ class JwtTokenProviderRs256Test {
 			// Given
 			UUID userId = UUID.randomUUID();
 			String providerId = "test_provider_id";
+			OAuthProvider providerName = OAuthProvider.GOOGLE;
 
-			String token = provider.create(userId, UserRole.ADMIN, providerId, TokenType.ACCESS);
+			String token = provider.create(
+				userId, UserRole.ADMIN, providerId, providerName, TokenType.ACCESS
+			);
 
 			// When
 			String jti = provider.extractJti(token);
@@ -150,9 +160,12 @@ class JwtTokenProviderRs256Test {
 			// Given
 			UUID userId = UUID.randomUUID();
 			String providerId = "test_provider_id";
+			OAuthProvider providerName = OAuthProvider.GOOGLE;
 
 			// When
-			String token = provider.create(userId, UserRole.MEMBER, providerId, TokenType.ACCESS);
+			String token = provider.create(
+				userId, UserRole.MEMBER, providerId, providerName, TokenType.ACCESS
+			);
 
 			// Then
 			assertThatCode(() -> provider.validateToken(token))
@@ -174,7 +187,7 @@ class JwtTokenProviderRs256Test {
 		@DisplayName("만료된 토큰은 fallback 없이 즉시 실패한다")
 		void should_throwExpired_when_tokenExpired() {
 			String providerId = "test_provider_id";
-
+			OAuthProvider providerName = OAuthProvider.GOOGLE;
 			// Given: 이미 만료된 토큰을 생성하기 위해 유효시간 0인 provider
 			JwtProperties properties = new JwtProperties(
 				HMAC_SECRET, rsaPrivateKeyPem, rsaPublicKeyPem, "goti-user-service",
@@ -182,7 +195,9 @@ class JwtTokenProviderRs256Test {
 			);
 			ExtendedUserDetailsService mockService = new ExtendedUserDetailsService() {
 				@Override
-				public UserDetails loadUserById(String userId, String providerId) throws UsernameNotFoundException {
+				public UserDetails loadUserById(
+					String userId, String providerId, OAuthProvider provider
+				) throws UsernameNotFoundException {
 					return null;
 				}
 
@@ -195,7 +210,9 @@ class JwtTokenProviderRs256Test {
 			expiredProvider.initKeys();
 
 			UUID userId = UUID.randomUUID();
-			String token = expiredProvider.create(userId, UserRole.MEMBER, providerId, TokenType.ACCESS);
+			String token = expiredProvider.create(
+				userId, UserRole.MEMBER, providerId, providerName, TokenType.ACCESS
+			);
 
 			// When & Then
 			assertThatThrownBy(() -> expiredProvider.validateToken(token))

--- a/user/src/test/java/com/goti/user/service/account/AccountServiceTest.java
+++ b/user/src/test/java/com/goti/user/service/account/AccountServiceTest.java
@@ -61,7 +61,7 @@ public class AccountServiceTest {
 			member
 		);
 		assertNotNull(response);
-		AccountEntity account = accountRepository.findByMember(member).orElse(null);
+		AccountEntity account = accountRepository.findAccount(member).orElse(null);
 		assertNotNull(account);
 		log.info("AccountRegisterResponse: accountId :: {}", response.accountId());
 		log.info("account: accountId :: {}", account.getId());

--- a/user/src/test/java/com/goti/user/service/account/AccountServiceTest.java
+++ b/user/src/test/java/com/goti/user/service/account/AccountServiceTest.java
@@ -61,7 +61,7 @@ public class AccountServiceTest {
 			member
 		);
 		assertNotNull(response);
-		AccountEntity account = accountRepository.findAccount(member).orElse(null);
+		AccountEntity account = accountRepository.findByMember(member).orElse(null);
 		assertNotNull(account);
 		log.info("AccountRegisterResponse: accountId :: {}", response.accountId());
 		log.info("account: accountId :: {}", account.getId());

--- a/user/src/test/java/com/goti/user/service/member/MemberProfileServiceTest.java
+++ b/user/src/test/java/com/goti/user/service/member/MemberProfileServiceTest.java
@@ -1,0 +1,95 @@
+package com.goti.user.service.member;
+
+import com.goti.constants.Gender;
+import com.goti.constants.OAuthProvider;
+import com.goti.user.domain.entity.user.AccountEntity;
+import com.goti.user.domain.entity.user.AddressEntity;
+import com.goti.user.domain.entity.user.MemberEntity;
+import com.goti.user.domain.entity.user.SocialProviderEntity;
+import com.goti.user.dto.response.MemberDetailResponse;
+import com.goti.user.service.application.member.MemberProfileService;
+import com.goti.user.service.domain.account.AccountService;
+import com.goti.user.service.domain.address.AddressService;
+import com.goti.user.service.domain.user.MemberService;
+
+import com.goti.user.service.domain.user.SocialProviderService;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+public class MemberProfileServiceTest {
+
+	@InjectMocks
+	private MemberProfileService memberProfileService;
+
+	@Mock
+	private MemberService memberService;
+
+	@Mock
+	private SocialProviderService socialProviderService;
+
+	@Mock
+	private AccountService accountService;
+
+	@Mock
+	private AddressService addressService;
+
+	@Test
+	@DisplayName("회원 상세 프로필 조회 성공 테스트 (마이페이지)")
+	void 회원_본인_상세_프로필_조회_성공() {
+		String providerId = "google_12345";
+
+		MemberEntity mockMember = MemberEntity.create(
+			"010-1234-5678", "김고티", Gender.MALE, LocalDate.of(2000, 10, 21)
+		);
+
+		SocialProviderEntity mockSocial = mock(SocialProviderEntity.class);
+		given(mockSocial.getMember()).willReturn(mockMember);
+		given(mockSocial.getProvider()).willReturn(OAuthProvider.GOOGLE);
+		given(mockSocial.getEmail()).willReturn("goti1234@google.com");
+
+		given(socialProviderService.getSocialProvider(providerId)).willReturn(mockSocial);
+
+		AccountEntity mockAccount = mock(AccountEntity.class);
+		given(mockAccount.getBankName()).willReturn("카카오뱅크");
+		given(mockAccount.getAccountNumber()).willReturn("3333-67-8765445");
+		given(mockAccount.getAccountHolder()).willReturn("테스트예금주");
+
+		AddressEntity mockAddress = mock(AddressEntity.class);
+		given(mockAddress.getZipCode()).willReturn("12345");
+		given(mockAddress.getBaseAddress()).willReturn("서울특별시 강남구 학동로 343");
+		given(mockAddress.getDetailAddress()).willReturn("(논현동, 포바강남타워) 4층, 15층");
+
+		given(accountService.findAccount(mockMember)).willReturn(Optional.of(mockAccount));
+		given(addressService.findAddress(mockMember)).willReturn(Optional.of(mockAddress));
+
+		MemberDetailResponse response = memberProfileService.getProfileDetail(providerId);
+
+		assertThat(response.name()).isEqualTo("김고티");
+		assertThat(response.oAuthProvider()).isEqualTo(OAuthProvider.GOOGLE);
+		assertThat(response.bankAccount().bankName()).isEqualTo("카카오뱅크");
+		assertThat(response.bankAccount().accountHolder()).isEqualTo("테스트예금주");
+		assertThat(response.address().zipCode()).isEqualTo("12345");
+		assertThat(response.address().baseAddress()).isEqualTo("서울특별시 강남구 학동로 343");
+
+
+		assertThat(response.socialConnection().isGoogleConnected()).isTrue();
+		log.info("response :: {}", response);
+		verify(socialProviderService, times(1)).getSocialProvider(anyString());
+	}
+
+}

--- a/user/src/test/java/com/goti/user/service/member/MemberProfileServiceTest.java
+++ b/user/src/test/java/com/goti/user/service/member/MemberProfileServiceTest.java
@@ -10,7 +10,6 @@ import com.goti.user.dto.response.MemberDetailResponse;
 import com.goti.user.service.application.member.MemberProfileService;
 import com.goti.user.service.domain.account.AccountService;
 import com.goti.user.service.domain.address.AddressService;
-import com.goti.user.service.domain.user.MemberService;
 
 import com.goti.user.service.domain.user.SocialProviderService;
 
@@ -37,9 +36,6 @@ public class MemberProfileServiceTest {
 	private MemberProfileService memberProfileService;
 
 	@Mock
-	private MemberService memberService;
-
-	@Mock
 	private SocialProviderService socialProviderService;
 
 	@Mock
@@ -52,17 +48,19 @@ public class MemberProfileServiceTest {
 	@DisplayName("회원 상세 프로필 조회 성공 테스트 (마이페이지)")
 	void 회원_본인_상세_프로필_조회_성공() {
 		String providerId = "google_12345";
+		OAuthProvider provider = OAuthProvider.GOOGLE;
 
-		MemberEntity mockMember = MemberEntity.create(
+		MemberEntity mockMember = spy(MemberEntity.create(
 			"010-1234-5678", "김고티", Gender.MALE, LocalDate.of(2000, 10, 21)
-		);
+		));
 
 		SocialProviderEntity mockSocial = mock(SocialProviderEntity.class);
 		given(mockSocial.getMember()).willReturn(mockMember);
-		given(mockSocial.getProvider()).willReturn(OAuthProvider.GOOGLE);
 		given(mockSocial.getEmail()).willReturn("goti1234@google.com");
 
-		given(socialProviderService.getSocialProvider(providerId)).willReturn(mockSocial);
+		given(socialProviderService.getSocialProvider(
+			providerId, provider
+		)).willReturn(mockSocial);
 
 		AccountEntity mockAccount = mock(AccountEntity.class);
 		given(mockAccount.getBankName()).willReturn("카카오뱅크");
@@ -77,7 +75,8 @@ public class MemberProfileServiceTest {
 		given(accountService.findAccount(mockMember)).willReturn(Optional.of(mockAccount));
 		given(addressService.findAddress(mockMember)).willReturn(Optional.of(mockAddress));
 
-		MemberDetailResponse response = memberProfileService.getProfileDetail(providerId);
+		MemberDetailResponse response =
+			memberProfileService.getProfileDetail(providerId, provider);
 
 		assertThat(response.name()).isEqualTo("김고티");
 		assertThat(response.oAuthProvider()).isEqualTo(OAuthProvider.GOOGLE);
@@ -86,10 +85,9 @@ public class MemberProfileServiceTest {
 		assertThat(response.address().zipCode()).isEqualTo("12345");
 		assertThat(response.address().baseAddress()).isEqualTo("서울특별시 강남구 학동로 343");
 
-
 		assertThat(response.socialConnection().isGoogleConnected()).isTrue();
 		log.info("response :: {}", response);
-		verify(socialProviderService, times(1)).getSocialProvider(anyString());
+		verify(socialProviderService, times(1)).getSocialProvider(anyString() , any());
 	}
 
 }


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#334 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
회원 정보 상세 조회 (마이페이지) 서비스 로직 추가 및 서비스 테스트 코드 추가 (MemberProfileService)
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- 회원 상세 조회(마이페이지) 서비스 로직 추가 -> getProfileDetail (In MemberProfileService)
- 회원 상세 조회(마이페이지) 서비스 테스트 코드 추가 (MemberProfileServiceTest)
- 회원 (마이페이지) 상세 조회 응답 DTO 추가
- findSocialProvider, getSocialProvider (in SocialProviderService) OAuthProvider 인자값 제거 -> providerId 만 인자에 포함
- findSocialProvider (In SocialProviderRepository) -> findSocialProvider @Query 제거 및 OAuthProvider 인자 값 제거
- AccountRepository: findByMember -> findAccount 로 수정
- MemberDetailResponse: OAuthProvider 필드 추가 및 소셜 연결 상태값 추가(응답 record 내 SocialConnection 생성 로직 추가), account, address null 검증로직 추가
- findAccount(By MemberEntity) 추가 (In AccountService)
- accountRepository: findMember -> findAccount 수정으로 인한 참조 파일들 변경
- MemberEntity -> mappedBy: socialProviders 필드 추가(테이블 컬럼 생성X)
<br/>