### PR TITLE
[BUG] 경기 일정 조회 시 대량의 좌석 데이터 Join으로 인한 응답 지연 이슈

### DIFF
--- a/ticketing/src/main/java/com/goti/ticketing/domain/entity/game/GameScheduleEntity.java
+++ b/ticketing/src/main/java/com/goti/ticketing/domain/entity/game/GameScheduleEntity.java
@@ -20,16 +20,15 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-import static lombok.AccessLevel.*;
+import static lombok.AccessLevel.PROTECTED;
 
 @Getter
 @Entity
 @Table(
 	name = "game_schedules",
 	indexes = {
-		@Index(name = "idx_game_start_at", columnList = "start_at"),
-		@Index(name = "idx_game_home_team", columnList = "home_team_id"),
-		@Index(name = "idx_game_away_team", columnList = "away_team_id")
+		@Index(name = "idx_game_search_home", columnList = "start_at, home_team_id"),
+		@Index(name = "idx_game_search_away", columnList = "start_at, away_team_id")
 	}
 )
 @NoArgsConstructor(access = PROTECTED)

--- a/ticketing/src/main/java/com/goti/ticketing/domain/entity/game/GameScheduleEntity.java
+++ b/ticketing/src/main/java/com/goti/ticketing/domain/entity/game/GameScheduleEntity.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
@@ -23,7 +24,14 @@ import static lombok.AccessLevel.*;
 
 @Getter
 @Entity
-@Table(name = "game_schedules")
+@Table(
+	name = "game_schedules",
+	indexes = {
+		@Index(name = "idx_game_start_at", columnList = "start_at"),
+		@Index(name = "idx_game_home_team", columnList = "home_team_id"),
+		@Index(name = "idx_game_away_team", columnList = "away_team_id")
+	}
+)
 @NoArgsConstructor(access = PROTECTED)
 public class GameScheduleEntity extends ModificationTimestampEntity {
 	@Column(nullable = false)

--- a/ticketing/src/main/java/com/goti/ticketing/game/repository/gameschedule/GameScheduleRepositoryImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/repository/gameschedule/GameScheduleRepositoryImpl.java
@@ -8,8 +8,10 @@ import com.goti.ticketing.constants.SeatStatus;
 import com.goti.ticketing.game.dto.request.GameScheduleSearchCondition;
 import com.goti.ticketing.game.dto.response.GameScheduleSearchResponse;
 import com.goti.ticketing.game.dto.response.QGameScheduleSearchResponse;
+import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -62,9 +64,9 @@ public class GameScheduleRepositoryImpl implements GameScheduleRepositoryCustom 
 					gameSchedule.homeTeamId,
 					gameSchedule.awayTeamId,
 					gameSchedule.stadiumId,
-					Expressions.nullExpression(String.class), // homeTeam DisplayName
-					Expressions.nullExpression(String.class), // awayTeamName DisplayName
-					Expressions.nullExpression(String.class), // stadiumLocation
+					Expressions.nullExpression(String.class),
+					Expressions.nullExpression(String.class),
+					Expressions.nullExpression(String.class),
 					gameStatus.gameStatus,
 					gameStatus.homeTeamScore,
 					gameStatus.awayTeamScore,
@@ -72,34 +74,24 @@ public class GameScheduleRepositoryImpl implements GameScheduleRepositoryCustom 
 					ticketingStatus.status,
 					ticketingStatus.ticketingOpenedAt,
 					ticketingStatus.ticketingEndAt,
-					seatStatus.id.count()
+					ExpressionUtils.as(
+						JPAExpressions
+							.select(seatStatus.count())
+							.from(seatStatus)
+							.where(
+								seatStatus.game.eq(gameSchedule),
+								seatStatus.status.eq(SeatStatus.AVAILABLE)
+							),
+						"remainingSeatCount"
+					)
 				)
 			)
 			.from(gameSchedule)
 			.leftJoin(gameStatus).on(gameStatus.gameSchedule.eq(gameSchedule))
 			.leftJoin(ticketingStatus).on(ticketingStatus.gameSchedule.eq(gameSchedule))
-			.leftJoin(seatStatus).on(
-				seatStatus.game.eq(gameSchedule),
-				seatStatus.status.eq(SeatStatus.AVAILABLE)
-			)
 			.where(
 				teamIdEq(gameSchedule, condition.teamId()),
 				dateFilter(gameSchedule, condition)
-			)
-			.groupBy(
-				gameSchedule.id,
-				gameSchedule.startAt,
-				gameSchedule.leagueType,
-				gameSchedule.homeTeamId,
-				gameSchedule.awayTeamId,
-				gameSchedule.stadiumId,
-				gameStatus.gameStatus,
-				gameStatus.homeTeamScore,
-				gameStatus.awayTeamScore,
-				gameStatus.gameResult,
-				ticketingStatus.status,
-				ticketingStatus.ticketingOpenedAt,
-				ticketingStatus.ticketingEndAt
 			)
 			.orderBy(gameSchedule.startAt.asc())
 			.fetch();


### PR DESCRIPTION
게임일정엔티티 (GameScheduleEntity) startAt, homeTeamId, awayTeamId 인덱스 추가,

게임일정리스트 조회 시 쿼리 개선 (QueryDsl: seatStatus 조인 제거 -> 서브쿼리 seatStatus 로 변경)

<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#399 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
경기 일정 조회 API(searchSchedules)의 심각한 성능 저하 이슈 해결 -> 쿼리 최적화 및 인덱스 튜닝 작업
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- Join 방식 제거: SeatStatusEntity leftJoin 제거
- 서브쿼리 도입: 잔여 좌석 수 -> Select 절 서브쿼리 분리 및 필요한 행에 대해서만 count 연산을 수행
- 불필요한 Group By 제거: 서브쿼리로 전환하여 groupBy 연산을 제거하여 DB CPU 부하 경감
<br/>