### PR TITLE
[FEAT] 회원 정보 변경(이름, 휴대폰번호) 서비스 로직 추가 및 테스트 코드 추가

### DIFF
--- a/common/src/main/java/com/goti/constants/messages/ErrorCode.java
+++ b/common/src/main/java/com/goti/constants/messages/ErrorCode.java
@@ -58,6 +58,8 @@ public enum ErrorCode {
 	AUTH_REFRESH_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다. 재로그인이 필요합니다."),
 	AUTH_CODE_NOT_FOUND(HttpStatus.UNAUTHORIZED, "인증 시간이 만료되었거나 해당 휴대전화번호로 인증번호 전송 이력이 없습니다."),
 	AUTH_CODE_INVALID(HttpStatus.UNAUTHORIZED, "인증 코드가 일치하지 않습니다."),
+	AUTH_IDENTITY_VERIFY_FAILED(HttpStatus.BAD_REQUEST, "본인인증에 실패했습니다."),
+	AUTH_MOBILE_ALREADY_REGISTERED(HttpStatus.CONFLICT, "이미 가입된 휴대폰 번호입니다. 관리자에게 문의 바랍니다."),
 
 	RESERVATION_SESSION_EXPIRED(HttpStatus.BAD_REQUEST, "예매 가능 시간이 만료되었습니다."),
 

--- a/integration/src/main/java/com/goti/infra/constants/redis/RedisKey.java
+++ b/integration/src/main/java/com/goti/infra/constants/redis/RedisKey.java
@@ -12,8 +12,9 @@ public enum RedisKey {
 	OAUTH_STATE("oauth:state:", Duration.ofMinutes(5)),
 	TICKET_QR("ticket:qr-token:", Duration.ofMinutes(3)),
 	RESERVATION_SESSION("ticketing:reservation-session:", Duration.ofMinutes(10)),
-	REFRESH_TOKEN("auth:refresh-token:", Duration.ofDays(7));
-
+	REFRESH_TOKEN("auth:refresh-token:", Duration.ofDays(7)),
+	MEMBER_IDENTITY_VERIFY("member:identity:verify:", Duration.ofMinutes(3))
+	;
 	private final String prefix;
 
 	private final Duration ttl;

--- a/user/src/main/java/com/goti/user/domain/entity/user/MemberEntity.java
+++ b/user/src/main/java/com/goti/user/domain/entity/user/MemberEntity.java
@@ -42,6 +42,20 @@ public class MemberEntity extends UserEntity {
 		);
 	}
 
+	public boolean verifyIdentity(Gender gender, LocalDate birthDate) {
+		if (gender == null || birthDate == null) return false;
+		return this.getGender() == gender && this.getBirthDate().equals(birthDate);
+	}
+
+	public void updateIdentity(
+		final String mobile,
+		final String name
+	) {
+		validateIdentityInput(mobile, name);
+		updateName(name);
+		updateMobile(mobile);
+	}
+
 	public static MemberEntity create(
 		final String mobile,
 		final String name,
@@ -77,6 +91,16 @@ public class MemberEntity extends UserEntity {
 
 		Preconditions.domainValidate(
 			birthDate.isBefore(LocalDate.now()), "회원 생년월일은 과거 날짜여야 합니다."
+		);
+	}
+
+	private static void validateIdentityInput(String mobile, String name) {
+		Preconditions.domainValidate(
+			StringUtils.hasText(mobile), "회원 휴대전화 번호는 비어 있을 수 없습니다."
+		);
+
+		Preconditions.domainValidate(
+			StringUtils.hasText(name), "회원 이름은 비어 있을 수 없습니다."
 		);
 	}
 }

--- a/user/src/main/java/com/goti/user/domain/entity/user/UserEntity.java
+++ b/user/src/main/java/com/goti/user/domain/entity/user/UserEntity.java
@@ -67,4 +67,12 @@ public class UserEntity extends ModificationTimestampEntity {
 		this.status = UserStatus.ACTIVATED;
 		this.role = role;
 	}
+
+	protected void updateName(String name) {
+		this.name = name;
+	}
+
+	protected void updateMobile(String mobile) {
+		this.mobile = mobile;
+	}
 }

--- a/user/src/main/java/com/goti/user/service/domain/user/MemberService.java
+++ b/user/src/main/java/com/goti/user/service/domain/user/MemberService.java
@@ -14,4 +14,8 @@ public interface MemberService {
   Optional<MemberEntity> findByMobile(String mobile);
 
 	MemberEntity getMember(UUID memberId);
+
+	MemberEntity update(
+		UUID memberId, String mobile, String name, Gender gender, LocalDate birthDate, String authCode
+	);
 }

--- a/user/src/main/java/com/goti/user/service/domain/user/MemberServiceImpl.java
+++ b/user/src/main/java/com/goti/user/service/domain/user/MemberServiceImpl.java
@@ -1,6 +1,11 @@
 package com.goti.user.service.domain.user;
 
 import com.goti.constants.Gender;
+import com.goti.constants.messages.ErrorCode;
+import com.goti.exception.CustomException;
+import com.goti.global.validation.Preconditions;
+import com.goti.infra.cache.RedisCache;
+import com.goti.infra.constants.redis.RedisKey;
 import com.goti.user.domain.entity.user.MemberEntity;
 import com.goti.user.repository.MemberRepository;
 
@@ -18,6 +23,7 @@ import java.util.UUID;
 public class MemberServiceImpl implements MemberService {
 
 	private final MemberRepository memberRepository;
+	private final RedisCache redisCache;
 
 	@Override
 	@Transactional
@@ -37,5 +43,57 @@ public class MemberServiceImpl implements MemberService {
 	@Override
 	public MemberEntity getMember(UUID memberId) {
 		return memberRepository.findByIdOrThrow(memberId);
+	}
+
+	@Override
+	@Transactional
+	public MemberEntity update(
+		UUID memberId,
+		String mobile,
+		String name,
+		Gender gender,
+		LocalDate birthDate,
+		String authCode
+	) {
+		verifySmsCode(String.valueOf(memberId), authCode);
+
+		MemberEntity member = getMember(memberId);
+		Preconditions.validate(
+			member.verifyIdentity(gender, birthDate),
+			ErrorCode.AUTH_IDENTITY_VERIFY_FAILED
+		);
+		verifyDuplicatedMobile(member, mobile);
+		member.updateIdentity(mobile, name);
+		return member;
+	}
+
+	private void verifyDuplicatedMobile(MemberEntity member, String mobile) {
+		memberRepository.findByMobile(mobile).ifPresent(
+			existingMember -> {
+				if (!existingMember.getId().equals(member.getId())) {
+					throw new CustomException(ErrorCode.AUTH_MOBILE_ALREADY_REGISTERED);
+				}
+			});
+	}
+
+	private void verifySmsCode(String memberId, String authCode) {
+		String redisKey = RedisKey.MEMBER_IDENTITY_VERIFY.getKey(memberId);
+
+		String cachedAuthCode = getCachedAuthCode(redisKey);
+
+		if (!cachedAuthCode.equals(authCode))
+			throw new CustomException(ErrorCode.AUTH_CODE_INVALID);
+
+		if (!redisCache.consume(redisKey))
+			throw new CustomException(ErrorCode.AUTH_CODE_NOT_FOUND);
+	}
+
+	private String getCachedAuthCode(String key) {
+		String cachedCode = redisCache.get(
+			key, String.class
+		);
+		if (cachedCode == null)
+			throw new CustomException(ErrorCode.AUTH_CODE_NOT_FOUND);
+		return cachedCode;
 	}
 }

--- a/user/src/main/java/com/goti/user/service/domain/user/MemberServiceImpl.java
+++ b/user/src/main/java/com/goti/user/service/domain/user/MemberServiceImpl.java
@@ -55,7 +55,12 @@ public class MemberServiceImpl implements MemberService {
 		LocalDate birthDate,
 		String authCode
 	) {
-		verifySmsCode(String.valueOf(memberId), authCode);
+		String key = RedisKey.MEMBER_IDENTITY_VERIFY.getKey(memberId);
+		String cachedAuthCode = getCachedAuthCode(key);
+		Preconditions.validate(
+			cachedAuthCode.equals(authCode),
+			ErrorCode.AUTH_CODE_INVALID
+		);
 
 		MemberEntity member = getMember(memberId);
 		Preconditions.validate(
@@ -64,6 +69,10 @@ public class MemberServiceImpl implements MemberService {
 		);
 		verifyDuplicatedMobile(member, mobile);
 		member.updateIdentity(mobile, name);
+		Preconditions.validate(
+			redisCache.consume(key),
+			ErrorCode.AUTH_CODE_NOT_FOUND
+		);
 		return member;
 	}
 
@@ -76,24 +85,13 @@ public class MemberServiceImpl implements MemberService {
 			});
 	}
 
-	private void verifySmsCode(String memberId, String authCode) {
-		String redisKey = RedisKey.MEMBER_IDENTITY_VERIFY.getKey(memberId);
-
-		String cachedAuthCode = getCachedAuthCode(redisKey);
-
-		if (!cachedAuthCode.equals(authCode))
-			throw new CustomException(ErrorCode.AUTH_CODE_INVALID);
-
-		if (!redisCache.consume(redisKey))
-			throw new CustomException(ErrorCode.AUTH_CODE_NOT_FOUND);
-	}
-
 	private String getCachedAuthCode(String key) {
 		String cachedCode = redisCache.get(
 			key, String.class
 		);
-		if (cachedCode == null)
+		if (cachedCode == null) {
 			throw new CustomException(ErrorCode.AUTH_CODE_NOT_FOUND);
+		}
 		return cachedCode;
 	}
 }

--- a/user/src/test/java/com/goti/user/service/MemberServiceTest.java
+++ b/user/src/test/java/com/goti/user/service/MemberServiceTest.java
@@ -18,14 +18,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.*;

--- a/user/src/test/java/com/goti/user/service/MemberServiceTest.java
+++ b/user/src/test/java/com/goti/user/service/MemberServiceTest.java
@@ -1,0 +1,77 @@
+package com.goti.user.service;
+
+import com.goti.constants.Gender;
+import com.goti.infra.cache.RedisCache;
+import com.goti.infra.constants.redis.RedisKey;
+import com.goti.user.GotiUserApplication;
+
+import com.goti.user.domain.entity.user.MemberEntity;
+import com.goti.user.repository.MemberRepository;
+
+import com.goti.user.service.domain.user.MemberServiceImpl;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+public class MemberServiceTest {
+
+	@InjectMocks
+	MemberServiceImpl memberService;
+	@Mock MemberRepository memberRepository;
+	@Mock RedisCache redisCache;
+
+	private final UUID memberId = UUID.randomUUID();
+	private MemberEntity member;
+
+	@BeforeEach
+	void setup() {
+		member = MemberEntity.create(
+			"01012345678", "홍길동", Gender.MALE, LocalDate.of(2000, 2, 3)
+		);
+	}
+
+	@Test
+	@Transactional
+	void 회원_정보_변경_성공() {
+		String newName = "테스트개명";
+		String newMobile = "01099998888";
+		String authCode = "123456";
+		String redisKey = RedisKey.MEMBER_IDENTITY_VERIFY.getKey(memberId);
+
+		when(memberRepository.findByIdOrThrow(memberId)).thenReturn(member);
+
+		when(redisCache.get(redisKey, String.class)).thenReturn(authCode);
+		when(redisCache.consume(redisKey)).thenReturn(true);
+
+		memberService.update(
+			memberId, newMobile, newName, Gender.MALE, LocalDate.of(2000, 2, 3), authCode
+		);
+
+		assertThat(member.getName()).isEqualTo(newName);
+		assertThat(member.getMobile()).isEqualTo(newMobile);
+		verify(redisCache).consume(redisKey);
+		log.info("member mobile :: {}", member.getMobile());
+		log.info("member name :: {}", member.getName());
+	}
+}


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#396 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
회원 정보 변경(이름 및 휴대폰번호) 비즈니스 로직 추가 및 테스트 코드 추가
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- 회원 정보 변경 (mobile, name) 서비스 로직 구현 (In MemberService)
  - (인증코드 전송 및 저장 로직 다음 PR 생성 예정)
- 휴대폰 번호 및 이름 변경 메서드 추가 (In UserEntity)
- 휴대폰 번호 및 이름 변경 시 불변데이터(성별 및 생일) 검증 메서드 추가 (In MemberEntity)
- RedisKey 추가 -> 인증번호 전송 후 (다른 PR) 검증된 변경 건 redis 저장
- 본인인증 실패 및 중복 휴대폰 번호(휴대폰번호 변경 시) ErrorCode 추가
<br/>