### PR TITLE
[FEAT] SocialProvider 엔티티 상태 필드 추가

### DIFF
--- a/user/src/main/java/com/goti/user/constants/SocialStatus.java
+++ b/user/src/main/java/com/goti/user/constants/SocialStatus.java
@@ -1,0 +1,13 @@
+package com.goti.user.constants;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SocialStatus {
+	ACTIVE("활성화"),
+	INACTIVE("비활성화");
+
+	private final String description;
+}

--- a/user/src/main/java/com/goti/user/domain/entity/user/SocialProviderEntity.java
+++ b/user/src/main/java/com/goti/user/domain/entity/user/SocialProviderEntity.java
@@ -4,6 +4,8 @@ import com.goti.global.validation.Preconditions;
 import com.goti.constants.OAuthProvider;
 import com.goti.domain.base.ModificationTimestampEntity;
 
+import com.goti.user.constants.SocialStatus;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -39,6 +41,10 @@ public class SocialProviderEntity extends ModificationTimestampEntity {
 	@Column(nullable = false)
 	private String email;
 
+	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
+	private SocialStatus status;
+
 	private SocialProviderEntity(
 		MemberEntity member,
 		OAuthProvider provider,
@@ -49,6 +55,7 @@ public class SocialProviderEntity extends ModificationTimestampEntity {
 		this.provider = provider;
 		this.providerId = providerId;
 		this.email = email;
+		this.status = SocialStatus.ACTIVE;
 	}
 
 	public static SocialProviderEntity create(


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#414 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
SocialProvider 상태값 추가 (SocialStatus) 및 엔티티생성 시 활성화상태 기본값 로직 추가
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- SocialStatus Enum 파일 추가
- SocialProvider -> SocialStatus status 필드 추가
- SocialProvider 생성 시 -> status = 활성화 (ACIVATE) 상태 생성자 Set
<br/>