### PR TITLE
[BUG] 소셜 로그인 토큰 응답 역직렬화 실패 수정

### DIFF
--- a/integration/src/main/java/com/goti/infra/api/dto/response/common/SocialAccessTokenResponse.java
+++ b/integration/src/main/java/com/goti/infra/api/dto/response/common/SocialAccessTokenResponse.java
@@ -1,7 +1,9 @@
 package com.goti.infra.api.dto.response.common;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record SocialAccessTokenResponse(
 	@JsonProperty("access_token")
 	String accessToken


### PR DESCRIPTION


## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->

<br/>

## 🔎 개요
소셜 로그인(Google/Naver) 토큰 교환 시 provider 응답에 `expires_in` 등 미정의 필드가 포함되어
 Jackson `UnrecognizedPropertyException` 발생 → 로그인 전체 실패

<br/>


## 📋 작업 내용
### SocialAccessTokenResponse
- `@JsonIgnoreProperties(ignoreUnknown = true)` 추가
- 소셜 provider 응답의 알 수 없는 필드(`expires_in`, `token_type` 등)를 무시하도록 처리
- `TurnstileVerifyResponse`와 동일한 패턴 적용 (기존 컨벤션 준수)

<br/>