### PR TITLE
[BUG] 티켓팅 좌석 점유/해제 N+1 문제 해결

### DIFF
--- a/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatHoldRepository.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatHoldRepository.java
@@ -16,13 +16,15 @@ import com.goti.ticketing.domain.entity.seat.SeatHoldEntity;
 @Repository
 public interface SeatHoldRepository extends JpaRepository<SeatHoldEntity, UUID>, SeatHoldRepositoryCustom {
 	@Query("""
-		SELECT sh.id
+		SELECT sh
 			FROM SeatHoldEntity sh
+		JOIN FETCH sh.gameSchedule
+		JOIN FETCH sh.seat
 		WHERE sh.status = :status
 		  AND sh.expiredAt < :now
 		ORDER BY sh.expiredAt ASC
 	""")
-	List<UUID> findExpiredHoldIds(
+	List<SeatHoldEntity> findHoldsWithSeatAndGame(
 		@Param("status") SeatHoldStatus status,
 		@Param("now") LocalDateTime now,
 		Pageable pageable

--- a/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatHoldRepository.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatHoldRepository.java
@@ -16,13 +16,13 @@ import com.goti.ticketing.domain.entity.seat.SeatHoldEntity;
 @Repository
 public interface SeatHoldRepository extends JpaRepository<SeatHoldEntity, UUID>, SeatHoldRepositoryCustom {
 	@Query("""
-		SELECT sh
+		SELECT sh.id
 			FROM SeatHoldEntity sh
 		WHERE sh.status = :status
 		  AND sh.expiredAt < :now
 		ORDER BY sh.expiredAt ASC
 	""")
-	List<SeatHoldEntity> findExpiredHolds(
+	List<UUID> findExpiredHoldIds(
 		@Param("status") SeatHoldStatus status,
 		@Param("now") LocalDateTime now,
 		Pageable pageable

--- a/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatHoldRepository.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatHoldRepository.java
@@ -1,32 +1,12 @@
 package com.goti.ticketing.seat.repository;
 
-import java.time.LocalDateTime;
-import java.util.List;
 import java.util.UUID;
 
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import com.goti.ticketing.constants.SeatHoldStatus;
 import com.goti.ticketing.domain.entity.seat.SeatHoldEntity;
 
 @Repository
 public interface SeatHoldRepository extends JpaRepository<SeatHoldEntity, UUID>, SeatHoldRepositoryCustom {
-	@Query("""
-		SELECT sh
-			FROM SeatHoldEntity sh
-		JOIN FETCH sh.gameSchedule
-		JOIN FETCH sh.seat
-		WHERE sh.status = :status
-		  AND sh.expiredAt < :now
-		ORDER BY sh.expiredAt ASC
-	""")
-	List<SeatHoldEntity> findHoldsWithSeatAndGame(
-		@Param("status") SeatHoldStatus status,
-		@Param("now") LocalDateTime now,
-		Pageable pageable
-	);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatHoldRepositoryCustom.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatHoldRepositoryCustom.java
@@ -12,12 +12,7 @@ import com.goti.ticketing.domain.entity.seat.SeatHoldEntity;
 public interface SeatHoldRepositoryCustom {
 	List<SeatHoldEntity> findAllWithDetailsByIdIn(List<UUID> holdIds);
 
-	List<SeatHoldEntity> findAllHoldingSeats(UUID gameId, UUID userId);
+	List<SeatHoldEntity> findExpiredHoldsByIds(List<UUID> holdIds);
 
-	Optional<SeatHoldEntity> findLatestActiveHold(
-		GameScheduleEntity gameSchedule,
-		SeatEntity seat,
-		UUID userId,
-		SeatHoldStatus status
-	);
+	List<SeatHoldEntity> findAllHoldingSeats(UUID gameId, UUID userId);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatHoldRepositoryCustom.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatHoldRepositoryCustom.java
@@ -1,13 +1,17 @@
 package com.goti.ticketing.seat.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.goti.ticketing.constants.SeatHoldStatus;
 import com.goti.ticketing.domain.entity.seat.SeatHoldEntity;
 
 public interface SeatHoldRepositoryCustom {
 	List<SeatHoldEntity> findAllWithDetailsByIdIn(List<UUID> holdIds);
+
+	List<SeatHoldEntity> findHoldsWithSeatAndGame(SeatHoldStatus status, LocalDateTime now, int limit);
 
 	Optional<SeatHoldEntity> findHoldWithSeatAndGame(UUID holdId);
 

--- a/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatHoldRepositoryCustom.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatHoldRepositoryCustom.java
@@ -9,8 +9,6 @@ import com.goti.ticketing.domain.entity.seat.SeatHoldEntity;
 public interface SeatHoldRepositoryCustom {
 	List<SeatHoldEntity> findAllWithDetailsByIdIn(List<UUID> holdIds);
 
-	List<SeatHoldEntity> findExpiredHoldsByIds(List<UUID> holdIds);
-
 	Optional<SeatHoldEntity> findHoldWithSeatAndGame(UUID holdId);
 
 	List<SeatHoldEntity> findAllHoldingSeats(UUID gameId, UUID userId);

--- a/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatHoldRepositoryCustom.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatHoldRepositoryCustom.java
@@ -11,7 +11,7 @@ public interface SeatHoldRepositoryCustom {
 
 	List<SeatHoldEntity> findExpiredHoldsByIds(List<UUID> holdIds);
 
-	Optional<SeatHoldEntity> findSeatHoldWithDetails(UUID holdId);
+	Optional<SeatHoldEntity> findHoldWithSeatAndGame(UUID holdId);
 
 	List<SeatHoldEntity> findAllHoldingSeats(UUID gameId, UUID userId);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatHoldRepositoryCustom.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatHoldRepositoryCustom.java
@@ -4,15 +4,14 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import com.goti.ticketing.constants.SeatHoldStatus;
-import com.goti.ticketing.domain.entity.game.GameScheduleEntity;
-import com.goti.ticketing.domain.entity.seat.SeatEntity;
 import com.goti.ticketing.domain.entity.seat.SeatHoldEntity;
 
 public interface SeatHoldRepositoryCustom {
 	List<SeatHoldEntity> findAllWithDetailsByIdIn(List<UUID> holdIds);
 
 	List<SeatHoldEntity> findExpiredHoldsByIds(List<UUID> holdIds);
+
+	Optional<SeatHoldEntity> findSeatHoldWithDetails(UUID holdId);
 
 	List<SeatHoldEntity> findAllHoldingSeats(UUID gameId, UUID userId);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatHoldRepositoryImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatHoldRepositoryImpl.java
@@ -62,7 +62,7 @@ public class SeatHoldRepositoryImpl implements SeatHoldRepositoryCustom {
 	}
 
 	@Override
-	public Optional<SeatHoldEntity> findSeatHoldWithDetails(UUID holdId) {
+	public Optional<SeatHoldEntity> findHoldWithSeatAndGame(UUID holdId) {
 		QSeatHoldEntity seatHold = QSeatHoldEntity.seatHoldEntity;
 		QGameScheduleEntity gameSchedule = QGameScheduleEntity.gameScheduleEntity;
 		QSeatEntity seat = QSeatEntity.seatEntity;

--- a/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatHoldRepositoryImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatHoldRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.goti.ticketing.seat.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -39,6 +40,25 @@ public class SeatHoldRepositoryImpl implements SeatHoldRepositoryCustom {
 			.join(seat.seatSection, seatSection).fetchJoin()
 			.join(seatSection.seatGrade, seatGrade).fetchJoin()
 			.where(seatHold.id.in(holdIds))
+			.fetch();
+	}
+
+	@Override
+	public List<SeatHoldEntity> findHoldsWithSeatAndGame(SeatHoldStatus status, LocalDateTime now, int limit) {
+		QSeatHoldEntity seatHold = QSeatHoldEntity.seatHoldEntity;
+		QGameScheduleEntity gameSchedule = QGameScheduleEntity.gameScheduleEntity;
+		QSeatEntity seat = QSeatEntity.seatEntity;
+
+		return queryFactory
+			.selectFrom(seatHold)
+			.join(seatHold.gameSchedule, gameSchedule).fetchJoin()
+			.join(seatHold.seat, seat).fetchJoin()
+			.where(
+				seatHold.status.eq(status),
+				seatHold.expiredAt.before(now)
+			)
+			.orderBy(seatHold.expiredAt.asc())
+			.limit(limit)
 			.fetch();
 	}
 

--- a/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatHoldRepositoryImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatHoldRepositoryImpl.java
@@ -43,25 +43,6 @@ public class SeatHoldRepositoryImpl implements SeatHoldRepositoryCustom {
 	}
 
 	@Override
-	public List<SeatHoldEntity> findExpiredHoldsByIds(List<UUID> holdIds) {
-		if (holdIds.isEmpty()) {
-			return List.of();
-		}
-
-		QSeatHoldEntity seatHold = QSeatHoldEntity.seatHoldEntity;
-		QGameScheduleEntity gameSchedule = QGameScheduleEntity.gameScheduleEntity;
-		QSeatEntity seat = QSeatEntity.seatEntity;
-
-		return queryFactory
-			.selectFrom(seatHold)
-			.join(seatHold.gameSchedule, gameSchedule).fetchJoin()
-			.join(seatHold.seat, seat).fetchJoin()
-			.where(seatHold.id.in(holdIds))
-			.orderBy(seatHold.expiredAt.asc())
-			.fetch();
-	}
-
-	@Override
 	public Optional<SeatHoldEntity> findHoldWithSeatAndGame(UUID holdId) {
 		QSeatHoldEntity seatHold = QSeatHoldEntity.seatHoldEntity;
 		QGameScheduleEntity gameSchedule = QGameScheduleEntity.gameScheduleEntity;

--- a/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatHoldRepositoryImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatHoldRepositoryImpl.java
@@ -62,6 +62,22 @@ public class SeatHoldRepositoryImpl implements SeatHoldRepositoryCustom {
 	}
 
 	@Override
+	public Optional<SeatHoldEntity> findSeatHoldWithDetails(UUID holdId) {
+		QSeatHoldEntity seatHold = QSeatHoldEntity.seatHoldEntity;
+		QGameScheduleEntity gameSchedule = QGameScheduleEntity.gameScheduleEntity;
+		QSeatEntity seat = QSeatEntity.seatEntity;
+
+		return Optional.ofNullable(
+			queryFactory
+				.selectFrom(seatHold)
+				.join(seatHold.gameSchedule, gameSchedule).fetchJoin()
+				.join(seatHold.seat, seat).fetchJoin()
+				.where(seatHold.id.eq(holdId))
+				.fetchOne()
+		);
+	}
+
+	@Override
 	public List<SeatHoldEntity> findAllHoldingSeats(UUID gameId, UUID userId) {
 		QSeatHoldEntity seatHold = QSeatHoldEntity.seatHoldEntity;
 		QGameScheduleEntity gameSchedule = QGameScheduleEntity.gameScheduleEntity;

--- a/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatHoldRepositoryImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatHoldRepositoryImpl.java
@@ -43,6 +43,25 @@ public class SeatHoldRepositoryImpl implements SeatHoldRepositoryCustom {
 	}
 
 	@Override
+	public List<SeatHoldEntity> findExpiredHoldsByIds(List<UUID> holdIds) {
+		if (holdIds.isEmpty()) {
+			return List.of();
+		}
+
+		QSeatHoldEntity seatHold = QSeatHoldEntity.seatHoldEntity;
+		QGameScheduleEntity gameSchedule = QGameScheduleEntity.gameScheduleEntity;
+		QSeatEntity seat = QSeatEntity.seatEntity;
+
+		return queryFactory
+			.selectFrom(seatHold)
+			.join(seatHold.gameSchedule, gameSchedule).fetchJoin()
+			.join(seatHold.seat, seat).fetchJoin()
+			.where(seatHold.id.in(holdIds))
+			.orderBy(seatHold.expiredAt.asc())
+			.fetch();
+	}
+
+	@Override
 	public List<SeatHoldEntity> findAllHoldingSeats(UUID gameId, UUID userId) {
 		QSeatHoldEntity seatHold = QSeatHoldEntity.seatHoldEntity;
 		QGameScheduleEntity gameSchedule = QGameScheduleEntity.gameScheduleEntity;
@@ -62,28 +81,5 @@ public class SeatHoldRepositoryImpl implements SeatHoldRepositoryCustom {
 				seatHold.status.eq(SeatHoldStatus.HOLDING)
 			)
 			.fetch();
-	}
-
-	@Override
-	public Optional<SeatHoldEntity> findLatestActiveHold(
-		GameScheduleEntity gameSchedule,
-		SeatEntity seat,
-		UUID userId,
-		SeatHoldStatus status
-	) {
-		QSeatHoldEntity seatHold = QSeatHoldEntity.seatHoldEntity;
-
-		return Optional.ofNullable(
-			queryFactory
-				.selectFrom(seatHold)
-				.where(
-					seatHold.gameSchedule.eq(gameSchedule),
-					seatHold.seat.eq(seat),
-					seatHold.userId.eq(userId),
-					seatHold.status.eq(status)
-				)
-				.orderBy(seatHold.createdAt.desc())
-				.fetchFirst()
-		);
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldExpiryService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldExpiryService.java
@@ -6,7 +6,6 @@ import com.goti.infra.lock.DistributedLockManager;
 import com.goti.ticketing.seat.repository.SeatHoldRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -27,7 +26,7 @@ public class SeatHoldExpiryService {
 		List<SeatHoldEntity> expiredHolds = seatHoldRepository.findHoldsWithSeatAndGame(
 			SeatHoldStatus.HOLDING,
 			now,
-			PageRequest.of(0, batchSize)
+			batchSize
 		);
 
 		int succeeded = 0;

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldExpiryService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldExpiryService.java
@@ -24,12 +24,11 @@ public class SeatHoldExpiryService {
 	// TODO: 동시성 및 hold/release/expire 경합 상황 테스트 추가
 	public SeatHoldExpiryBatchResult expireHolds(int batchSize) {
 		LocalDateTime now = LocalDateTime.now();
-		List<UUID> expiredHoldIds = seatHoldRepository.findExpiredHoldIds(
+		List<SeatHoldEntity> expiredHolds = seatHoldRepository.findHoldsWithSeatAndGame(
 			SeatHoldStatus.HOLDING,
 			now,
 			PageRequest.of(0, batchSize)
 		);
-		List<SeatHoldEntity> expiredHolds = seatHoldRepository.findExpiredHoldsByIds(expiredHoldIds);
 
 		int succeeded = 0;
 		int failed = 0;

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldExpiryService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldExpiryService.java
@@ -24,11 +24,12 @@ public class SeatHoldExpiryService {
 	// TODO: 동시성 및 hold/release/expire 경합 상황 테스트 추가
 	public SeatHoldExpiryBatchResult expireHolds(int batchSize) {
 		LocalDateTime now = LocalDateTime.now();
-		List<SeatHoldEntity> expiredHolds = seatHoldRepository.findExpiredHolds(
+		List<UUID> expiredHoldIds = seatHoldRepository.findExpiredHoldIds(
 			SeatHoldStatus.HOLDING,
 			now,
 			PageRequest.of(0, batchSize)
 		);
+		List<SeatHoldEntity> expiredHolds = seatHoldRepository.findExpiredHoldsByIds(expiredHoldIds);
 
 		int succeeded = 0;
 		int failed = 0;

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldExpiryTransactionalService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldExpiryTransactionalService.java
@@ -25,7 +25,7 @@ public class SeatHoldExpiryTransactionalService {
 
 	@Transactional
 	public void expire(UUID holdId, LocalDateTime now) {
-		SeatHoldEntity seatHold = seatHoldRepository.findById(holdId)
+		SeatHoldEntity seatHold = seatHoldRepository.findSeatHoldWithDetails(holdId)
 			.orElseThrow(() -> new CustomException(ErrorCode.SEAT_HOLD_NOT_FOUND));
 
 		SeatStatusEntity seatStatus = seatStatusRepository.findByGameAndSeat(

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldExpiryTransactionalService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldExpiryTransactionalService.java
@@ -25,7 +25,7 @@ public class SeatHoldExpiryTransactionalService {
 
 	@Transactional
 	public void expire(UUID holdId, LocalDateTime now) {
-		SeatHoldEntity seatHold = seatHoldRepository.findSeatHoldWithDetails(holdId)
+		SeatHoldEntity seatHold = seatHoldRepository.findHoldWithSeatAndGame(holdId)
 			.orElseThrow(() -> new CustomException(ErrorCode.SEAT_HOLD_NOT_FOUND));
 
 		SeatStatusEntity seatStatus = seatStatusRepository.findByGameAndSeat(

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldTransactionalService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldTransactionalService.java
@@ -71,7 +71,7 @@ public class SeatHoldTransactionalService {
 
 	@Transactional
 	public UUID release(UUID holdId, UUID userId) {
-		SeatHoldEntity seatHold = seatHoldRepository.findById(holdId)
+		SeatHoldEntity seatHold = seatHoldRepository.findSeatHoldWithDetails(holdId)
 			.orElseThrow(() -> new CustomException(ErrorCode.SEAT_HOLD_NOT_FOUND));
 
 		Preconditions.validate(

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldTransactionalService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldTransactionalService.java
@@ -71,7 +71,7 @@ public class SeatHoldTransactionalService {
 
 	@Transactional
 	public UUID release(UUID holdId, UUID userId) {
-		SeatHoldEntity seatHold = seatHoldRepository.findSeatHoldWithDetails(holdId)
+		SeatHoldEntity seatHold = seatHoldRepository.findHoldWithSeatAndGame(holdId)
 			.orElseThrow(() -> new CustomException(ErrorCode.SEAT_HOLD_NOT_FOUND));
 
 		Preconditions.validate(

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatHoldServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatHoldServiceImpl.java
@@ -27,7 +27,7 @@ public class SeatHoldServiceImpl implements SeatHoldService {
 	@Override
 	@Transactional(readOnly = true)
 	public SeatHoldEntity findSeatHold(UUID holdId) {
-		return seatHoldRepository.findSeatHoldWithDetails(holdId)
+		return seatHoldRepository.findHoldWithSeatAndGame(holdId)
 			.orElseThrow(() -> new CustomException(ErrorCode.SEAT_HOLD_NOT_FOUND));
 	}
 

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatHoldServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatHoldServiceImpl.java
@@ -27,7 +27,7 @@ public class SeatHoldServiceImpl implements SeatHoldService {
 	@Override
 	@Transactional(readOnly = true)
 	public SeatHoldEntity findSeatHold(UUID holdId) {
-		return seatHoldRepository.findById(holdId)
+		return seatHoldRepository.findSeatHoldWithDetails(holdId)
 			.orElseThrow(() -> new CustomException(ErrorCode.SEAT_HOLD_NOT_FOUND));
 	}
 


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#425 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
SeatHold 만료/해제 처리 과정에서 발생하던 JPA N+1 문제 개선
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
> SeatHold 만료 배치 조회 구조 개선
>> 만료 대상 SeatHold의 ID를 먼저 페이지 단위로 조회
>> 이후 gameSchedule, seat를 fetch join으로 함께 조회하도록 2단계 조회 구조 적용

> SeatHold 단건 조회 시 fetch join 메서드 추가 `findSeatHoldWithDetails`
>> gameSchedule, seat를 함께 조회해 lazy loading으로 인한 추가 SELECT 방지

> `SeatHoldExpiryTransactionalService`의 만료 처리 로직에서 fetch join 단건 조회 사용
`SeatHoldTransactionalService`의 좌석 해제 로직에서 fetch join 단건 조회 사용
`SeatHoldServiceImpl.findSeatHold()`도 동일한 fetch join 단건 조회 사용
<br/>