### PR TITLE
[REFACTOR] 경기 일정 조회 시 서브쿼리 제거 및 Batch Loading 도입(조회 성능 개선)

### DIFF
--- a/ticketing/src/main/java/com/goti/ticketing/game/dto/response/GameScheduleSearchResponse.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/dto/response/GameScheduleSearchResponse.java
@@ -124,4 +124,21 @@ public record GameScheduleSearchResponse(
 			ticketingStatus, ticketingOpenedAt, ticketingEndAt, remainingSeatCount
 		);
 	}
+
+	public GameScheduleSearchResponse withDynamicInfo(
+		String homeTeamName,
+		String awayTeamName,
+		String stadiumLocation,
+		Long remainingSeatCount
+	) {
+		return new GameScheduleSearchResponse(
+			gameId, startAt, leagueType,
+			homeTeamId, awayTeamId, stadiumId,
+			homeTeamName, awayTeamName, stadiumLocation,
+			gameStatus, homeTeamScore, awayTeamScore, gameResult,
+			ticketingStatus, ticketingOpenedAt, ticketingEndAt,
+			remainingSeatCount
+		);
+	}
+
 }

--- a/ticketing/src/main/java/com/goti/ticketing/game/repository/gameschedule/GameScheduleRepositoryCustom.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/repository/gameschedule/GameScheduleRepositoryCustom.java
@@ -2,6 +2,7 @@ package com.goti.ticketing.game.repository.gameschedule;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -17,6 +18,8 @@ public interface GameScheduleRepositoryCustom {
 	);
 
 	List<GameScheduleSearchResponse> searchSchedules(GameScheduleSearchCondition request);
+
+	Map<UUID, Long> findRemainingSeatCounts(List<UUID> scheduleIds);
 
 	Optional<GameScheduleSearchResponse> findScheduleByGameId(UUID gameId);
 

--- a/ticketing/src/main/java/com/goti/ticketing/game/repository/gameschedule/GameScheduleRepositoryImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/repository/gameschedule/GameScheduleRepositoryImpl.java
@@ -21,10 +21,8 @@ import com.goti.ticketing.domain.entity.seat.QSeatStatusEntity;
 import com.goti.ticketing.game.dto.request.GameScheduleSearchCondition;
 import com.goti.ticketing.game.dto.response.GameScheduleSearchResponse;
 import com.goti.ticketing.game.dto.response.QGameScheduleSearchResponse;
-import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -57,7 +55,8 @@ public class GameScheduleRepositoryImpl implements GameScheduleRepositoryCustom 
 
 	@Override
 	public List<GameScheduleSearchResponse> searchSchedules(GameScheduleSearchCondition condition) {
-		List<GameScheduleSearchResponse> schedules = jpaQueryFactory
+		LocalDateTime now = LocalDateTime.now();
+		return jpaQueryFactory
 			.select(
 				new QGameScheduleSearchResponse(
 					gameSchedule.id,
@@ -84,14 +83,10 @@ public class GameScheduleRepositoryImpl implements GameScheduleRepositoryCustom 
 			.leftJoin(ticketingStatus).on(ticketingStatus.gameSchedule.eq(gameSchedule))
 			.where(
 				teamIdEq(gameSchedule, condition.teamId()),
-				dateFilter(gameSchedule, condition)
+				dateFilter(gameSchedule, condition, now)
 			)
 			.orderBy(gameSchedule.startAt.asc())
 			.fetch();
-
-		if (schedules.isEmpty()) return List.of();
-
-		return schedules;
 	}
 
 	@Override
@@ -136,16 +131,7 @@ public class GameScheduleRepositoryImpl implements GameScheduleRepositoryCustom 
 						ticketingStatus.status,
 						ticketingStatus.ticketingOpenedAt,
 						ticketingStatus.ticketingEndAt,
-						ExpressionUtils.as(
-							JPAExpressions
-								.select(seatStatus.count())
-								.from(seatStatus)
-								.where(
-									seatStatus.game.eq(gameSchedule),
-									seatStatus.status.eq(SeatStatus.AVAILABLE)
-								),
-							"remainingSeatCount"
-						)
+						Expressions.constant(0L)
 					)
 				)
 				.from(gameSchedule)
@@ -162,7 +148,9 @@ public class GameScheduleRepositoryImpl implements GameScheduleRepositoryCustom 
 		return game.homeTeamId.eq(teamId).or(game.awayTeamId.eq(teamId));
 	}
 
-	private BooleanExpression dateFilter(QGameScheduleEntity game, GameScheduleSearchCondition condition) {
+	private BooleanExpression dateFilter(
+		QGameScheduleEntity game, GameScheduleSearchCondition condition, LocalDateTime now
+	) {
 		if (condition.today()) {
 			LocalDate today = LocalDate.now();
 			return game.startAt.between(today.atStartOfDay(), today.atTime(LocalTime.MAX));
@@ -179,7 +167,7 @@ public class GameScheduleRepositoryImpl implements GameScheduleRepositoryCustom 
 
 			return game.startAt.between(startOfMonth, startOfMonth.plusMonths(1).minusNanos(1));
 		}
-		int currentYear = LocalDateTime.now().getYear();
+		int currentYear = now.getYear();
 		LocalDateTime startOfYear = LocalDateTime.of(
 			currentYear, 1, 1, 0, 0
 		);

--- a/ticketing/src/main/java/com/goti/ticketing/game/repository/gameschedule/GameScheduleRepositoryImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/repository/gameschedule/GameScheduleRepositoryImpl.java
@@ -6,8 +6,10 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Repository;
 
@@ -55,7 +57,7 @@ public class GameScheduleRepositoryImpl implements GameScheduleRepositoryCustom 
 
 	@Override
 	public List<GameScheduleSearchResponse> searchSchedules(GameScheduleSearchCondition condition) {
-		return jpaQueryFactory
+		List<GameScheduleSearchResponse> schedules = jpaQueryFactory
 			.select(
 				new QGameScheduleSearchResponse(
 					gameSchedule.id,
@@ -74,16 +76,7 @@ public class GameScheduleRepositoryImpl implements GameScheduleRepositoryCustom 
 					ticketingStatus.status,
 					ticketingStatus.ticketingOpenedAt,
 					ticketingStatus.ticketingEndAt,
-					ExpressionUtils.as(
-						JPAExpressions
-							.select(seatStatus.count())
-							.from(seatStatus)
-							.where(
-								seatStatus.game.eq(gameSchedule),
-								seatStatus.status.eq(SeatStatus.AVAILABLE)
-							),
-						"remainingSeatCount"
-					)
+					Expressions.constant(0L)
 				)
 			)
 			.from(gameSchedule)
@@ -95,7 +88,31 @@ public class GameScheduleRepositoryImpl implements GameScheduleRepositoryCustom 
 			)
 			.orderBy(gameSchedule.startAt.asc())
 			.fetch();
+
+		if (schedules.isEmpty()) return List.of();
+
+		return schedules;
 	}
+
+	@Override
+	public Map<UUID, Long> findRemainingSeatCounts(List<UUID> scheduleIds) {
+		return jpaQueryFactory
+			.select(seatStatus.game.id, seatStatus.count())
+			.from(seatStatus)
+			.where(
+				seatStatus.game.id.in(scheduleIds),
+				seatStatus.status.eq(SeatStatus.AVAILABLE)
+			)
+			.groupBy(seatStatus.game.id)
+			.fetch()
+			.stream()
+			.collect(Collectors.toMap(
+				tuple -> tuple.get(seatStatus.game.id),
+				tuple -> tuple.get(seatStatus.count())
+			));
+	}
+
+
 
 	@Override
 	public Optional<GameScheduleSearchResponse> findScheduleByGameId(UUID gameId) {
@@ -162,7 +179,11 @@ public class GameScheduleRepositoryImpl implements GameScheduleRepositoryCustom 
 
 			return game.startAt.between(startOfMonth, startOfMonth.plusMonths(1).minusNanos(1));
 		}
-		return null;
+		int currentYear = LocalDateTime.now().getYear();
+		LocalDateTime startOfYear = LocalDateTime.of(
+			currentYear, 1, 1, 0, 0
+		);
+		return game.startAt.between(startOfYear, startOfYear.plusYears(1).minusNanos(1));
 	}
 
 	private BooleanExpression isAnyTeamInvolved(UUID homeId, UUID awayId) {

--- a/ticketing/src/main/java/com/goti/ticketing/game/service/application/GameScheduleSearchService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/service/application/GameScheduleSearchService.java
@@ -32,9 +32,11 @@ public class GameScheduleSearchService {
 	public List<GameScheduleSearchResponse> searchSchedules(GameScheduleSearchCondition condition) {
 		List<GameScheduleSearchResponse> schedules = gameScheduleRepository.searchSchedules(condition);
 
-		if (schedules.isEmpty())
+		if (schedules.isEmpty()) {
 			return schedules;
+		}
 
+		List<UUID> gameIds = schedules.stream().map(GameScheduleSearchResponse::gameId).toList();
 		Set<UUID> teamIds = schedules.stream()
 			.flatMap(s -> Stream.of(s.homeTeamId(), s.awayTeamId()))
 			.filter(java.util.Objects::nonNull)
@@ -47,12 +49,14 @@ public class GameScheduleSearchService {
 
 		Map<UUID, String> teamDisplayNameMap = getBaseballTeamDisplayNamesMap(teamIds);
 		Map<UUID, String> stadiumLocationMap = getStadiumLocationsMap(stadiumIds);
+		Map<UUID, Long> seatCountMap = gameScheduleRepository.findRemainingSeatCounts(gameIds);
 
 		return schedules.stream().map(
-			schedule -> schedule.withExternalInfo(
+			schedule -> schedule.withDynamicInfo(
 				teamDisplayNameMap.get(schedule.homeTeamId()),
 				teamDisplayNameMap.get(schedule.awayTeamId()),
-				stadiumLocationMap.get(schedule.stadiumId())
+				stadiumLocationMap.get(schedule.stadiumId()),
+				seatCountMap.getOrDefault(schedule.gameId(), 0L)
 			)
 		).toList();
 	}
@@ -89,10 +93,13 @@ public class GameScheduleSearchService {
 			Set.of(schedule.stadiumId())
 		);
 
-		return schedule.withExternalInfo(
+		List<UUID> gameIds = List.of(gameId);
+		Map<UUID, Long> seatCountMap = gameScheduleRepository.findRemainingSeatCounts(gameIds);
+		return schedule.withDynamicInfo(
 			teamNames.get(schedule.homeTeamId()),
 			teamNames.get(schedule.awayTeamId()),
-			stadiumLocations.get(schedule.stadiumId())
+			stadiumLocations.get(schedule.stadiumId()),
+			seatCountMap.get(schedule.gameId())
 		);
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/game/service/application/GameScheduleSearchService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/service/application/GameScheduleSearchService.java
@@ -99,7 +99,7 @@ public class GameScheduleSearchService {
 			teamNames.get(schedule.homeTeamId()),
 			teamNames.get(schedule.awayTeamId()),
 			stadiumLocations.get(schedule.stadiumId()),
-			seatCountMap.get(schedule.gameId())
+			seatCountMap.getOrDefault(schedule.gameId(), 0L)
 		);
 	}
 }


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#437 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
운영 데이터(10만 건 이상 데이터) 증가에 따른 상관 서브쿼리 병목 지점 제거 및 Batch Loading(1+1 쿼리) 방식을 도입(조회 성능 개선)
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- 쿼리 성능 최적화 (DB 부하 감소)
  - N+1 문제 해결: Select 절의 잔여 좌석 카운트 서브쿼리를 제거하고, IN 절 기반의 별도 집계 쿼리로 분리하여 쿼리 실행 횟수를 1 + N에서 1 + 1로 고정

- Full Scan 방지
  - dateFilter에 당해 연도(현재 2026년) 기본 조회 범위 강제 및 불필요한 과거 데이터 전수 조사 차단

- 아키텍처 및 코드 구조 개선
  - Batch Mapping 도입: DB 연산 부하를 줄이기 위해 조회된 데이터를 자바 메모리(Map) 단에서 매핑하도록 로직 변경
  - 관심사 분리: Repository의 데이터 조립 로직을 서비스 계층으로 이관하여 도메인 간 결합도 완화
  - Response DTO 최적화: record 객체의 불변성을 유지하면서 효율적인 데이터 조립을 위한 withDynamicInfo 통합 매핑 메서드 구현
<br/>