### PR TITLE
[REFACTOR] 경기 일정 조회 시 조회 전용 DTO 분리 및 경기 일정 목록 응답 페이로드 최적화

### DIFF
--- a/ticketing/src/main/java/com/goti/ticketing/game/dto/response/GameScheduleSearchResponse.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/dto/response/GameScheduleSearchResponse.java
@@ -8,13 +8,7 @@ import com.goti.ticketing.constants.GameStatus;
 import com.goti.ticketing.constants.LeagueType;
 import com.goti.ticketing.constants.TicketingStatus;
 
-import com.goti.ticketing.domain.entity.game.GameScheduleEntity;
-
-import com.goti.ticketing.domain.entity.game.GameStatusEntity;
-
-import com.goti.ticketing.domain.entity.game.GameTicketingStatusEntity;
-
-import com.querydsl.core.annotations.QueryProjection;
+import com.goti.ticketing.game.dto.response.repository.GameScheduleQueryModel;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -32,15 +26,6 @@ public record GameScheduleSearchResponse(
 
 	@Schema(description = "리그 타입", example = "REGULAR")
 	LeagueType leagueType,
-
-	@Schema(description = "홈 팀 ID", example = "550e8400-e29b-41d4-a716-446655440000")
-	UUID homeTeamId,
-
-	@Schema(description = "원정 팀 ID", example = "660f9511-f30c-52d5-b827-557766551111")
-	UUID awayTeamId,
-
-	@Schema(description = "경기장 ID", example = "770g0622-g41d-63e6-c938-668877662222")
-	UUID stadiumId,
 
 	@Schema(description = "홈 팀 표시명", example = "삼성")
 	String homeTeamDisplayName,
@@ -77,67 +62,28 @@ public record GameScheduleSearchResponse(
 	@Schema(description = "잔여 좌석 수", example = "12543")
 	Long remainingSeatCount
 ) {
-
-	@QueryProjection
-	public GameScheduleSearchResponse {}
-
-	public static GameScheduleSearchResponse of(
-		final GameScheduleEntity game,
-		final String homeTeamDisplayName,
-		final String awayTeamDisplayName,
-		final String stadiumLocation,
-		final GameStatusEntity status,
-		final GameTicketingStatusEntity ticketing,
-		final Long remainingSeatCount
+	public static GameScheduleSearchResponse from(
+		GameScheduleQueryModel model,
+		String homeTeamDisplayName,
+		String awayTeamDisplayName,
+		String stadiumLocation,
+		Long seatCount
 	) {
 		return new GameScheduleSearchResponse(
-			game.getId(),
-			game.getStartAt(),
-			game.getLeagueType(),
-			game.getHomeTeamId(),
-			game.getAwayTeamId(),
-			game.getStadiumId(),
+			model.gameId(),
+			model.startAt(),
+			model.leagueType(),
 			homeTeamDisplayName,
 			awayTeamDisplayName,
 			stadiumLocation,
-			status.getGameStatus(),
-			status.getHomeTeamScore(),
-			status.getAwayTeamScore(),
-			status.getGameResult(),
-			ticketing.getStatus(),
-			ticketing.getTicketingOpenedAt(),
-			ticketing.getTicketingEndAt(),
-			remainingSeatCount
-		);
-	}
-
-	public GameScheduleSearchResponse withExternalInfo(
-		String homeTeamName,
-		String awayTeamName,
-		String stadiumLocation
-	) {
-		return new GameScheduleSearchResponse(
-			gameId, startAt, leagueType,
-			homeTeamId, awayTeamId, stadiumId,
-			homeTeamName, awayTeamName, stadiumLocation,
-			gameStatus, homeTeamScore, awayTeamScore, gameResult,
-			ticketingStatus, ticketingOpenedAt, ticketingEndAt, remainingSeatCount
-		);
-	}
-
-	public GameScheduleSearchResponse withDynamicInfo(
-		String homeTeamName,
-		String awayTeamName,
-		String stadiumLocation,
-		Long remainingSeatCount
-	) {
-		return new GameScheduleSearchResponse(
-			gameId, startAt, leagueType,
-			homeTeamId, awayTeamId, stadiumId,
-			homeTeamName, awayTeamName, stadiumLocation,
-			gameStatus, homeTeamScore, awayTeamScore, gameResult,
-			ticketingStatus, ticketingOpenedAt, ticketingEndAt,
-			remainingSeatCount
+			model.gameStatus(),
+			model.homeTeamScore(),
+			model.awayTeamScore(),
+			model.gameResult(),
+			model.ticketingStatus(),
+			model.ticketingOpenedAt(),
+			model.ticketingEndAt(),
+			seatCount
 		);
 	}
 

--- a/ticketing/src/main/java/com/goti/ticketing/game/dto/response/repository/GameScheduleQueryModel.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/dto/response/repository/GameScheduleQueryModel.java
@@ -1,0 +1,30 @@
+package com.goti.ticketing.game.dto.response.repository;
+
+import com.goti.ticketing.constants.GameResult;
+import com.goti.ticketing.constants.GameStatus;
+import com.goti.ticketing.constants.LeagueType;
+import com.goti.ticketing.constants.TicketingStatus;
+import com.querydsl.core.annotations.QueryProjection;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record GameScheduleQueryModel(
+	UUID gameId,
+	LocalDateTime startAt,
+	LeagueType leagueType,
+	UUID homeTeamId,
+	UUID awayTeamId,
+	UUID stadiumId,
+	GameStatus gameStatus,
+	Integer homeTeamScore,
+	Integer awayTeamScore,
+	GameResult gameResult,
+	TicketingStatus ticketingStatus,
+	LocalDateTime ticketingOpenedAt,
+	LocalDateTime ticketingEndAt
+) {
+	@QueryProjection
+	public GameScheduleQueryModel {
+	}
+}

--- a/ticketing/src/main/java/com/goti/ticketing/game/repository/gameschedule/GameScheduleRepositoryCustom.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/repository/gameschedule/GameScheduleRepositoryCustom.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 
 import com.goti.ticketing.game.dto.request.GameScheduleSearchCondition;
 import com.goti.ticketing.game.dto.response.GameScheduleSearchResponse;
+import com.goti.ticketing.game.dto.response.repository.GameScheduleQueryModel;
 
 public interface GameScheduleRepositoryCustom {
 
@@ -17,10 +18,10 @@ public interface GameScheduleRepositoryCustom {
 		LocalDateTime startAt
 	);
 
-	List<GameScheduleSearchResponse> searchSchedules(GameScheduleSearchCondition request);
+	List<GameScheduleQueryModel> searchSchedules(GameScheduleSearchCondition request);
 
 	Map<UUID, Long> findRemainingSeatCounts(List<UUID> scheduleIds);
 
-	Optional<GameScheduleSearchResponse> findScheduleByGameId(UUID gameId);
+	Optional<GameScheduleQueryModel> findScheduleByGameId(UUID gameId);
 
 }

--- a/ticketing/src/main/java/com/goti/ticketing/game/repository/gameschedule/GameScheduleRepositoryImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/repository/gameschedule/GameScheduleRepositoryImpl.java
@@ -11,6 +11,9 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import com.goti.ticketing.game.dto.response.repository.GameScheduleQueryModel;
+import com.goti.ticketing.game.dto.response.repository.QGameScheduleQueryModel;
+
 import org.springframework.stereotype.Repository;
 
 import com.goti.ticketing.constants.SeatStatus;
@@ -19,10 +22,7 @@ import com.goti.ticketing.domain.entity.game.QGameStatusEntity;
 import com.goti.ticketing.domain.entity.game.QGameTicketingStatusEntity;
 import com.goti.ticketing.domain.entity.seat.QSeatStatusEntity;
 import com.goti.ticketing.game.dto.request.GameScheduleSearchCondition;
-import com.goti.ticketing.game.dto.response.GameScheduleSearchResponse;
-import com.goti.ticketing.game.dto.response.QGameScheduleSearchResponse;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -54,28 +54,24 @@ public class GameScheduleRepositoryImpl implements GameScheduleRepositoryCustom 
 	}
 
 	@Override
-	public List<GameScheduleSearchResponse> searchSchedules(GameScheduleSearchCondition condition) {
+	public List<GameScheduleQueryModel> searchSchedules(GameScheduleSearchCondition condition) {
 		LocalDateTime now = LocalDateTime.now();
 		return jpaQueryFactory
 			.select(
-				new QGameScheduleSearchResponse(
+				new QGameScheduleQueryModel(
 					gameSchedule.id,
 					gameSchedule.startAt,
 					gameSchedule.leagueType,
 					gameSchedule.homeTeamId,
 					gameSchedule.awayTeamId,
 					gameSchedule.stadiumId,
-					Expressions.nullExpression(String.class),
-					Expressions.nullExpression(String.class),
-					Expressions.nullExpression(String.class),
 					gameStatus.gameStatus,
 					gameStatus.homeTeamScore,
 					gameStatus.awayTeamScore,
 					gameStatus.gameResult,
 					ticketingStatus.status,
 					ticketingStatus.ticketingOpenedAt,
-					ticketingStatus.ticketingEndAt,
-					Expressions.constant(0L)
+					ticketingStatus.ticketingEndAt
 				)
 			)
 			.from(gameSchedule)
@@ -110,28 +106,24 @@ public class GameScheduleRepositoryImpl implements GameScheduleRepositoryCustom 
 
 
 	@Override
-	public Optional<GameScheduleSearchResponse> findScheduleByGameId(UUID gameId) {
+	public Optional<GameScheduleQueryModel> findScheduleByGameId(UUID gameId) {
 		return Optional.ofNullable(
 			jpaQueryFactory
 				.select(
-					new QGameScheduleSearchResponse(
+					new QGameScheduleQueryModel(
 						gameSchedule.id,
 						gameSchedule.startAt,
 						gameSchedule.leagueType,
 						gameSchedule.homeTeamId,
 						gameSchedule.awayTeamId,
 						gameSchedule.stadiumId,
-						Expressions.nullExpression(String.class), // homeTeam DisplayName
-						Expressions.nullExpression(String.class), // awayTeamName DisplayName
-						Expressions.nullExpression(String.class), // stadiumLocation
 						gameStatus.gameStatus,
 						gameStatus.homeTeamScore,
 						gameStatus.awayTeamScore,
 						gameStatus.gameResult,
 						ticketingStatus.status,
 						ticketingStatus.ticketingOpenedAt,
-						ticketingStatus.ticketingEndAt,
-						Expressions.constant(0L)
+						ticketingStatus.ticketingEndAt
 					)
 				)
 				.from(gameSchedule)

--- a/ticketing/src/main/java/com/goti/ticketing/game/service/application/GameScheduleSearchService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/service/application/GameScheduleSearchService.java
@@ -3,10 +3,15 @@ package com.goti.ticketing.game.service.application;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import com.goti.ticketing.game.dto.response.repository.GameScheduleQueryModel;
+
+import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +27,7 @@ import com.goti.ticketing.infra.api.dto.response.StadiumLocationResponse;
 
 import lombok.RequiredArgsConstructor;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class GameScheduleSearchService {
@@ -30,33 +36,37 @@ public class GameScheduleSearchService {
 
 	@Transactional(readOnly = true)
 	public List<GameScheduleSearchResponse> searchSchedules(GameScheduleSearchCondition condition) {
-		List<GameScheduleSearchResponse> schedules = gameScheduleRepository.searchSchedules(condition);
-
-		if (schedules.isEmpty()) {
-			return schedules;
+		List<GameScheduleQueryModel> queryModels = gameScheduleRepository.searchSchedules(condition);
+		log.info("queryModels :: {}", queryModels);
+		if (queryModels.isEmpty()) {
+			return List.of();
 		}
 
-		List<UUID> gameIds = schedules.stream().map(GameScheduleSearchResponse::gameId).toList();
-		Set<UUID> teamIds = schedules.stream()
-			.flatMap(s -> Stream.of(s.homeTeamId(), s.awayTeamId()))
-			.filter(java.util.Objects::nonNull)
+		List<UUID> gameIds = queryModels.stream().map(GameScheduleQueryModel::gameId).toList();
+
+		Set<UUID> teamIds = queryModels.stream()
+			.flatMap(
+				queryModel -> Stream.of(queryModel.homeTeamId(), queryModel.awayTeamId())
+			)
+			.filter(Objects::nonNull)
 			.collect(Collectors.toSet());
 
-		Set<UUID> stadiumIds = schedules.stream()
-			.map(GameScheduleSearchResponse::stadiumId)
-			.filter(java.util.Objects::nonNull)
+		Set<UUID> stadiumIds = queryModels.stream()
+			.map(GameScheduleQueryModel::stadiumId)
+			.filter(Objects::nonNull)
 			.collect(Collectors.toSet());
 
 		Map<UUID, String> teamDisplayNameMap = getBaseballTeamDisplayNamesMap(teamIds);
 		Map<UUID, String> stadiumLocationMap = getStadiumLocationsMap(stadiumIds);
 		Map<UUID, Long> seatCountMap = gameScheduleRepository.findRemainingSeatCounts(gameIds);
 
-		return schedules.stream().map(
-			schedule -> schedule.withDynamicInfo(
-				teamDisplayNameMap.get(schedule.homeTeamId()),
-				teamDisplayNameMap.get(schedule.awayTeamId()),
-				stadiumLocationMap.get(schedule.stadiumId()),
-				seatCountMap.getOrDefault(schedule.gameId(), 0L)
+		return queryModels.stream().map(
+			queryModel -> GameScheduleSearchResponse.from(
+				queryModel,
+				teamDisplayNameMap.get(queryModel.homeTeamId()),
+				teamDisplayNameMap.get(queryModel.awayTeamId()),
+				stadiumLocationMap.get(queryModel.stadiumId()),
+				seatCountMap.getOrDefault(queryModel.gameId(), 0L)
 			)
 		).toList();
 	}
@@ -83,23 +93,24 @@ public class GameScheduleSearchService {
 
 	@Transactional(readOnly = true)
 	public GameScheduleSearchResponse getGameSchedule(UUID gameId) {
-		GameScheduleSearchResponse schedule = gameScheduleRepository.findScheduleByGameId(gameId)
+		GameScheduleQueryModel queryModel = gameScheduleRepository.findScheduleByGameId(gameId)
 			.orElseThrow(() -> new CustomException(ErrorCode.GAME_NOT_FOUND));
 
 		Map<UUID, String> teamNames = getBaseballTeamDisplayNamesMap(
-			Set.of(schedule.homeTeamId(), schedule.awayTeamId())
+			Set.of(queryModel.homeTeamId(), queryModel.awayTeamId())
 		);
 		Map<UUID, String> stadiumLocations = getStadiumLocationsMap(
-			Set.of(schedule.stadiumId())
+			Set.of(queryModel.stadiumId())
 		);
 
 		List<UUID> gameIds = List.of(gameId);
 		Map<UUID, Long> seatCountMap = gameScheduleRepository.findRemainingSeatCounts(gameIds);
-		return schedule.withDynamicInfo(
-			teamNames.get(schedule.homeTeamId()),
-			teamNames.get(schedule.awayTeamId()),
-			stadiumLocations.get(schedule.stadiumId()),
-			seatCountMap.getOrDefault(schedule.gameId(), 0L)
+		return GameScheduleSearchResponse.from(
+			queryModel,
+			teamNames.get(queryModel.homeTeamId()),
+			teamNames.get(queryModel.awayTeamId()),
+			stadiumLocations.get(queryModel.stadiumId()),
+			seatCountMap.getOrDefault(queryModel.gameId(), 0L)
 		);
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/game/service/application/GameScheduleSearchService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/service/application/GameScheduleSearchService.java
@@ -11,8 +11,6 @@ import java.util.stream.Stream;
 
 import com.goti.ticketing.game.dto.response.repository.GameScheduleQueryModel;
 
-import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,7 +25,6 @@ import com.goti.ticketing.infra.api.dto.response.StadiumLocationResponse;
 
 import lombok.RequiredArgsConstructor;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class GameScheduleSearchService {
@@ -37,10 +34,8 @@ public class GameScheduleSearchService {
 	@Transactional(readOnly = true)
 	public List<GameScheduleSearchResponse> searchSchedules(GameScheduleSearchCondition condition) {
 		List<GameScheduleQueryModel> queryModels = gameScheduleRepository.searchSchedules(condition);
-		log.info("queryModels :: {}", queryModels);
-		if (queryModels.isEmpty()) {
-			return List.of();
-		}
+
+		if (queryModels.isEmpty()) return List.of();
 
 		List<UUID> gameIds = queryModels.stream().map(GameScheduleQueryModel::gameId).toList();
 

--- a/ticketing/src/test/java/com/goti/ticketing/game/service/GameScheduleSearchServiceTest.java
+++ b/ticketing/src/test/java/com/goti/ticketing/game/service/GameScheduleSearchServiceTest.java
@@ -14,6 +14,10 @@ import com.goti.stadium.repository.StadiumRepository;
 
 import com.goti.ticketing.infra.api.StadiumApiClient;
 
+import com.goti.ticketing.infra.api.dto.response.BaseballTeamDisplayNameResponse;
+
+import com.goti.ticketing.infra.api.dto.response.StadiumLocationResponse;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.*;
+import static org.mockito.Mockito.*;
 
 @SpringBootTest(classes = GotiTicketingApplication.class)
 @Transactional
@@ -61,6 +66,17 @@ public class GameScheduleSearchServiceTest {
 		saveSamsung();
 		saveKia();
 		saveStadium();
+
+		when(StadiumApiClient.getBaseballTeamDisplayNames(anyList()))
+			.thenReturn(List.of(
+				new BaseballTeamDisplayNameResponse(kia.getId(), kia.getDisplayName()),
+				new BaseballTeamDisplayNameResponse(samsung.getId(), samsung.getDisplayName())
+			));
+
+		when(StadiumApiClient.getStadiumLocations(anyList()))
+			.thenReturn(List.of(
+				new StadiumLocationResponse(stadium.getId(), stadium.getLocation())
+			));
 
 		gameManagementService.register(
 			kia.getId(),
@@ -96,7 +112,7 @@ public class GameScheduleSearchServiceTest {
 
 		// then
 		assertThat(responses).hasSize(2);
-		assertThat(responses.get(0).homeTeamId()).isEqualTo(kia.getId());
+		assertThat(responses.get(0).homeTeamDisplayName()).isEqualTo(kia.getDisplayName());
 	}
 
 	@Test
@@ -114,8 +130,8 @@ public class GameScheduleSearchServiceTest {
 		List<GameScheduleSearchResponse> responses = gameScheduleSearchService.searchSchedules(condition);
 
 		assertThat(responses).hasSizeGreaterThanOrEqualTo(2);
-		assertThat(responses).extracting("homeTeamId")
-			.contains(kia.getId(), samsung.getId());
+		assertThat(responses).extracting("homeTeamDisplayName")
+			.contains(kia.getDisplayName(), samsung.getDisplayName());
 	}
 
 	@Test


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#443 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
DB Projection 전용(DB Repository 데이터 Read 전용) GameScheduleQueryModel Dto 생성 -> 내부 로직용 ID(UUID) 관리 및 최종 응답용 스펙 분리
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- GameScheduleSearchResponse 에서 화면에 불필요한 UUID 필드 제거
- GameScheduleQueryModel query response 모델 생성 및 관심사 분리

- 게임 일정 조회 시, 응답 DTO(GameScheduleSearchResponse)에서 불필요한 UUID 필드 제거 (페이로드 축소) 및 불필요한 메서드 제거 (withExternalInfo, withDynamicInfo), 게임일정 서비스에서 최초 응답객체 생성 시 -> queryModel + maps 데이터 조합으로 데이터 삽입

- 외부 API 연동 로직 구조 개선 및 테스트 코드 반영
- 특정 게임 조회시 응답 구조 일괄 변경(게임일정(리스트) 조회시와 동일)

<br/>