### PR TITLE
[BUG] 리셀 프로세스 버그 수정

### DIFF
--- a/ticketing/src/main/java/com/goti/ticketing/domain/entity/ticket/TicketEntity.java
+++ b/ticketing/src/main/java/com/goti/ticketing/domain/entity/ticket/TicketEntity.java
@@ -30,7 +30,8 @@ import lombok.NoArgsConstructor;
 	name = "tickets",
 	indexes = {
 		@Index(name = "idx_tickets_game_id", columnList = "game_id"),
-		@Index(name = "idx_tickets_user_id", columnList = "user_id")
+		@Index(name = "idx_tickets_user_id", columnList = "user_id"),
+		@Index(name = "idx_tickets_order_item_id", columnList = "order_item_id")
 	}
 )
 @NoArgsConstructor(access = PROTECTED)
@@ -221,6 +222,10 @@ public class TicketEntity extends ModificationTimestampEntity {
 	}
 
 	public void resaleEnable() {
+		Preconditions.domainValidate(
+			this.ticketStatus == TicketStatus.ISSUED,
+			"발행 완료 상태의 티켓만 리셀 가능 상태로 변경할 수 있습니다."
+		);
 		Preconditions.domainValidate(
 			this.resaleEnabledStatus == ResaleEnabledStatus.DISABLED,
 			"리셀 불가능 상태의 티켓만 가능 상태로 변경할 수 있습니다."

--- a/ticketing/src/main/java/com/goti/ticketing/domain/entity/ticket/TicketEntity.java
+++ b/ticketing/src/main/java/com/goti/ticketing/domain/entity/ticket/TicketEntity.java
@@ -5,13 +5,12 @@ import static lombok.AccessLevel.*;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-import com.goti.ticketing.constants.TicketStatus;
-
 import org.springframework.util.StringUtils;
 
-import com.goti.ticketing.constants.ResaleEnabledStatus;
 import com.goti.domain.base.ModificationTimestampEntity;
 import com.goti.global.validation.Preconditions;
+import com.goti.ticketing.constants.ResaleEnabledStatus;
+import com.goti.ticketing.constants.TicketStatus;
 
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
@@ -40,7 +39,7 @@ public class TicketEntity extends ModificationTimestampEntity {
 	@Column(nullable = false, unique = true)
 	private String ticketNumber;
 
-	@Column(nullable = false, unique = true)
+	@Column(nullable = false)
 	private UUID orderItemId;
 
 	@Column
@@ -219,6 +218,14 @@ public class TicketEntity extends ModificationTimestampEntity {
 			"리셀 발행 상태의 티켓만 일반 상태로 복구할 수 있습니다."
 		);
 		this.ticketStatus = TicketStatus.ISSUED;
+	}
+
+	public void resaleEnable() {
+		Preconditions.domainValidate(
+			this.resaleEnabledStatus == ResaleEnabledStatus.DISABLED,
+			"리셀 불가능 상태의 티켓만 가능 상태로 변경할 수 있습니다."
+		);
+		this.resaleEnabledStatus = ResaleEnabledStatus.ENABLED;
 	}
 
 	public boolean isFrozen() {

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderCancelService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderCancelService.java
@@ -6,8 +6,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-import com.goti.ticketing.order.service.domain.OrderCancellationService;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,7 +18,6 @@ import com.goti.ticketing.constants.GameStatus;
 import com.goti.ticketing.constants.OrderCancellationRequestType;
 import com.goti.ticketing.constants.OrderItemStatus;
 import com.goti.ticketing.constants.TicketStatus;
-import com.goti.ticketing.infra.api.dto.response.PaymentCancelResponse;
 import com.goti.ticketing.domain.entity.order.OrderCancellationEntity;
 import com.goti.ticketing.domain.entity.order.OrderEntity;
 import com.goti.ticketing.domain.entity.order.OrderItemEntity;
@@ -28,10 +25,12 @@ import com.goti.ticketing.domain.entity.ticket.TicketEntity;
 import com.goti.ticketing.game.repository.GameStatusRepository;
 import com.goti.ticketing.game.service.application.GameTicketManagementService;
 import com.goti.ticketing.infra.api.TicketPaymentApiClient;
+import com.goti.ticketing.infra.api.dto.response.PaymentCancelResponse;
 import com.goti.ticketing.order.dto.request.OrderCancelRequest;
 import com.goti.ticketing.order.dto.response.OrderCancelResponse;
 import com.goti.ticketing.order.service.domain.OrderCancellationItemService;
 import com.goti.ticketing.order.service.domain.OrderCancellationRefundPolicy;
+import com.goti.ticketing.order.service.domain.OrderCancellationService;
 import com.goti.ticketing.order.service.domain.OrderItemService;
 import com.goti.ticketing.order.service.domain.OrderService;
 import com.goti.ticketing.seat.service.domain.SeatStatusService;
@@ -76,7 +75,7 @@ public class OrderCancelService {
 		validateTargetItems(targetItems, request.requestType());
 
 		Map<UUID, TicketEntity> ticketMap = ticketService.getByOrderItemIds(
-			targetItems.stream().map(OrderItemEntity::getId).toList()
+			targetItems.stream().map(OrderItemEntity::getId).toList(), memberId
 		);
 		validateTickets(ticketMap, targetItems);
 

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/domain/OrderServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/domain/OrderServiceImpl.java
@@ -8,9 +8,15 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.github.f4b6a3.tsid.TsidCreator;
 import com.goti.constants.messages.ErrorCode;
 import com.goti.exception.CustomException;
 import com.goti.global.validation.Preconditions;
+import com.goti.ticketing.domain.entity.game.GameScheduleEntity;
+import com.goti.ticketing.domain.entity.order.OrderEntity;
 import com.goti.ticketing.domain.entity.order.OrderItemEntity;
 import com.goti.ticketing.domain.entity.ticket.TicketEntity;
 import com.goti.ticketing.infra.api.StadiumClient;
@@ -18,16 +24,9 @@ import com.goti.ticketing.infra.api.dto.response.StadiumLocationResponse;
 import com.goti.ticketing.order.dto.response.OrderListResponse;
 import com.goti.ticketing.order.dto.response.OrderPaymentInfoResponse;
 import com.goti.ticketing.order.dto.response.SeatGradeInfoResponse;
+import com.goti.ticketing.order.repository.OrderRepository;
 import com.goti.ticketing.session.service.application.ReservationSessionService;
 import com.goti.ticketing.ticket.service.domain.TicketService;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import com.github.f4b6a3.tsid.TsidCreator;
-import com.goti.ticketing.domain.entity.game.GameScheduleEntity;
-import com.goti.ticketing.domain.entity.order.OrderEntity;
-import com.goti.ticketing.order.repository.OrderRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -191,7 +190,7 @@ public class OrderServiceImpl implements OrderService {
 			.map(OrderItemEntity::getId)
 			.toList();
 
-		Map<UUID, TicketEntity> ticketsByOrderItemId = ticketService.getByOrderItemIds(orderItemIds);
+		Map<UUID, TicketEntity> ticketsByOrderItemId = ticketService.getByOrderItemIds(orderItemIds, order.getMemberId());
 		List<TicketEntity> tickets = orderItemIds.stream()
 			.map(ticketsByOrderItemId::get)
 			.toList();

--- a/ticketing/src/main/java/com/goti/ticketing/ticket/repository/TicketRepository.java
+++ b/ticketing/src/main/java/com/goti/ticketing/ticket/repository/TicketRepository.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.goti.ticketing.constants.TicketStatus;
@@ -15,7 +17,13 @@ import com.goti.ticketing.domain.entity.ticket.TicketEntity;
 public interface TicketRepository extends JpaRepository<TicketEntity, UUID> {
 	Optional<TicketEntity> findByIdAndUserId(UUID ticketId, UUID userId);
 
-	List<TicketEntity> findAllByOrderItemIdIn(Collection<UUID> orderItemIds);
+	@Query("SELECT t FROM TicketEntity t " +
+		"WHERE t.orderItemId IN :orderItemIds " +
+		"AND t.userId IN :userId")
+	List<TicketEntity> findAllByOrderItemIdIn(
+		@Param("orderItemIds") List<UUID> orderItemIds,
+		@Param("userId") UUID userId
+	);
 
 	List<TicketEntity> findAllByIdIn(Collection<UUID> ticketIds);
 

--- a/ticketing/src/main/java/com/goti/ticketing/ticket/service/domain/TicketService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/ticket/service/domain/TicketService.java
@@ -7,9 +7,8 @@ import java.util.UUID;
 
 import com.goti.ticketing.domain.entity.order.OrderItemEntity;
 import com.goti.ticketing.domain.entity.ticket.TicketEntity;
+import com.goti.ticketing.ticket.dto.response.ResaleTicketResponse;
 import com.goti.ticketing.ticket.dto.response.TicketPurchaseInfoResponse;
-import com.goti.ticketing.ticket.dto.response.ResaleTicketResponse;
-import com.goti.ticketing.ticket.dto.response.ResaleTicketResponse;
 import com.goti.ticketing.ticket.dto.response.TicketResponse;
 
 public interface TicketService {
@@ -27,7 +26,7 @@ public interface TicketService {
 		Integer ticketPrice
 	);
 
-	Map<UUID, TicketEntity> getByOrderItemIds(List<UUID> orderItemIds);
+	Map<UUID, TicketEntity> getByOrderItemIds(List<UUID> orderItemIds, UUID userId);
 
 	void invalidate(TicketEntity ticket);
 

--- a/ticketing/src/main/java/com/goti/ticketing/ticket/service/domain/TicketServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/ticket/service/domain/TicketServiceImpl.java
@@ -71,8 +71,12 @@ public class TicketServiceImpl implements TicketService {
 
 	@Override
 	@Transactional(readOnly = true)
-	public Map<UUID, TicketEntity> getByOrderItemIds(List<UUID> orderItemIds) {
-		return ticketRepository.findAllByOrderItemIdIn(orderItemIds).stream()
+	public Map<UUID, TicketEntity> getByOrderItemIds(List<UUID> orderItemIds, UUID userId) {
+		return ticketRepository.findAllByOrderItemIdIn(
+				orderItemIds,
+				userId
+			)
+			.stream()
 			.collect(toMap(TicketEntity::getOrderItemId, ticket -> ticket));
 	}
 


### PR DESCRIPTION
orderItemId unique 제약 삭

<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#445 

<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
리셀 구매후 재등록시에 재등록이 불가한 버그 수정
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- 기존의 OrderItemId가 unique인 상태에서 리셀 티켓으로 새 티켓을 등록 하려고 하니 유니크제약으로 인해 등록이 불가함
- 임시 방편으로 transactionId를 넣어서 테스트 해봤으나, orderItem에 티켓의 상세 정보(grade,section등) 이 담겨 있어서 참조가 안되어 티켓이 사용 불가능 하였음
- 해결방안으로 OrderItemId의 unique 제약을 없애기로 결정함

<br/>