### PR TITLE
[FEAT] Queue 재진입 시 active-users cleanup + game cleanup API (#455)

### DIFF
--- a/queue/src/main/java/com/goti/queue/constants/SecurityPathConstants.java
+++ b/queue/src/main/java/com/goti/queue/constants/SecurityPathConstants.java
@@ -8,6 +8,7 @@ public final class SecurityPathConstants {
 
 	public static final String[] PUBLIC_URLS = {
 		"/actuator/prometheus",
-		"/api/v1/queue/*/global-status"
+		"/api/v1/queue/*/global-status",
+		"/internal/**"
 	};
 }

--- a/queue/src/main/java/com/goti/queue/constants/SecurityPathConstants.java
+++ b/queue/src/main/java/com/goti/queue/constants/SecurityPathConstants.java
@@ -9,6 +9,6 @@ public final class SecurityPathConstants {
 	public static final String[] PUBLIC_URLS = {
 		"/actuator/prometheus",
 		"/api/v1/queue/*/global-status",
-		"/internal/**"
+		"/internal/queue/**"
 	};
 }

--- a/queue/src/main/java/com/goti/queue/controller/InternalQueueController.java
+++ b/queue/src/main/java/com/goti/queue/controller/InternalQueueController.java
@@ -1,0 +1,41 @@
+package com.goti.queue.controller;
+
+import java.util.UUID;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.goti.queue.service.QueueCleanupService;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 내부 전용 Queue 관리 API.
+ * - Swagger(OpenAPI) 문서에서 완전 제외 (@Hidden)
+ * - Istio Gateway에서 /internal/* 라우팅 없음 → 외부 접근 불가
+ * - queue.cleanup-api.enabled=true 일 때만 활성화 (기본 비활성)
+ *
+ * WARNING: cleanup은 해당 game의 모든 대기열 데이터를 삭제함.
+ * 진행 중인 game에서 호출하면 활성 사용자 전원이 강제 퇴장됨.
+ * 안정화 후 설정값으로 비활성화할 것.
+ */
+@Hidden
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal/queue")
+@ConditionalOnProperty(name = "queue.cleanup-api.enabled", havingValue = "true")
+public class InternalQueueController {
+
+	private final QueueCleanupService queueCleanupService;
+
+	@DeleteMapping("/{gameId}")
+	public ResponseEntity<Void> cleanupGame(@PathVariable UUID gameId) {
+		queueCleanupService.cleanupGame(gameId);
+		return ResponseEntity.noContent().build();
+	}
+}

--- a/queue/src/main/java/com/goti/queue/repository/QueueRedisRepository.java
+++ b/queue/src/main/java/com/goti/queue/repository/QueueRedisRepository.java
@@ -431,10 +431,14 @@ public class QueueRedisRepository {
 	// ARGV: [1]=gameId prefix (gameId:)
 	private static final String CLEANUP_GAME_SCRIPT =
 		// SMEMBERS로 해당 game의 active users만 가져와서 expiration에서 제거 (ZSCAN 전체 순회 방지)
+		// NOTE: SMEMBERS는 O(N)이므로 active users가 수만 건이면 blocking 발생.
+		// game 종료 시점에는 대부분 leave/expire 처리 후이므로 실제 대상은 수십~수백 수준.
+		// prod 스케일(수만) 시 application 레벨 SSCAN batch + pipeline ZREM으로 전환 필요.
 		"local users = redis.call('SMEMBERS', KEYS[4]) " +
 		"for _, u in ipairs(users) do " +
 		"  redis.call('ZREM', KEYS[5], ARGV[1] .. u) " +
 		"end " +
+		// EXPIRATION_USERS(KEYS[5])는 글로벌 공유 키 → DEL 아닌 개별 ZREM으로 해당 game 엔트리만 제거
 		"redis.call('DEL', KEYS[1], KEYS[2], KEYS[3], KEYS[4]) " +
 		"return 1";
 

--- a/queue/src/main/java/com/goti/queue/repository/QueueRedisRepository.java
+++ b/queue/src/main/java/com/goti/queue/repository/QueueRedisRepository.java
@@ -251,6 +251,8 @@ public class QueueRedisRepository {
 	// ── Lua All-in-One: Enter (5-7 RTT → 1 RTT) ─────────────────────
 	// 기존 entry 존재 시 cleanup + meta 초기화 + sequence 발급 + waiting 추가를 1 Lua로 통합.
 	// saveEntry(JSON 직렬화)만 별도 호출 필요 → 전체 2 RTT.
+	// KEYS: [1]=META, [2]=SEQUENCE, [3]=WAITING, [4]=ENTRY, [5]=ACTIVE_USERS, [6]=EXPIRATION_USERS
+	// ARGV: [1]=userId, [2]=maxCapacity, [3]=now, [4]=expirationMember(gameId:userId)
 	private static final String ENTER_QUEUE_SCRIPT =
 		"local existing = redis.call('GET', KEYS[4]) " +
 		"local oldQueueNumber = -1 " +
@@ -259,6 +261,16 @@ public class QueueRedisRepository {
 		"  if ok and entry.queueNumber then oldQueueNumber = entry.queueNumber end " +
 		"  redis.call('ZREM', KEYS[3], ARGV[1]) " +
 		"  redis.call('DEL', KEYS[4]) " +
+		// re-enter 시 ADMITTED 상태의 잔여 active-users + expiration 정리
+		// WHY: leave 없이 브라우저를 닫고 재진입하면 active-users에 좀비가 남아 409 유발
+		"  if redis.call('SISMEMBER', KEYS[5], ARGV[1]) == 1 then " +
+		"    redis.call('SREM', KEYS[5], ARGV[1]) " +
+		"    if redis.call('EXISTS', KEYS[1]) == 1 then " +
+		"      local cur = tonumber(redis.call('HGET', KEYS[1], 'activeCount') or '0') " +
+		"      if cur > 0 then redis.call('HINCRBY', KEYS[1], 'activeCount', -1) end " +
+		"    end " +
+		"  end " +
+		"  redis.call('ZREM', KEYS[6], ARGV[4]) " +
 		"end " +
 		"if redis.call('EXISTS', KEYS[1]) == 0 then " +
 		"  redis.call('HSET', KEYS[1], " +
@@ -276,18 +288,21 @@ public class QueueRedisRepository {
 	 */
 	public List<Long> enterQueue(UUID gameId, UUID userId, long maxCapacity) {
 		List<String> keys = List.of(
-			RedisKey.QUEUE_META.getKey(gameId),
-			RedisKey.QUEUE_SEQUENCE.getKey(gameId),
-			RedisKey.QUEUE_WAITING.getKey(gameId),
-			RedisKey.QUEUE_ENTRY.getKey(gameId, userId)
+			RedisKey.QUEUE_META.getKey(gameId),          // KEYS[1]
+			RedisKey.QUEUE_SEQUENCE.getKey(gameId),      // KEYS[2]
+			RedisKey.QUEUE_WAITING.getKey(gameId),       // KEYS[3]
+			RedisKey.QUEUE_ENTRY.getKey(gameId, userId), // KEYS[4]
+			RedisKey.QUEUE_ACTIVE_USERS.getKey(gameId),  // KEYS[5]
+			RedisKey.QUEUE_EXPIRATION_USERS.getKey()     // KEYS[6]
 		);
 		@SuppressWarnings("unchecked")
 		List<Long> result = stringRedisTemplate.execute(
 			RedisScript.of(ENTER_QUEUE_SCRIPT, List.class),
 			keys,
-			userId.toString(),
-			String.valueOf(maxCapacity),
-			Instant.now().toString()
+			userId.toString(),                           // ARGV[1]
+			String.valueOf(maxCapacity),                  // ARGV[2]
+			Instant.now().toString(),                     // ARGV[3]
+			expirationMember(gameId, userId)              // ARGV[4]
 		);
 		return result;
 	}
@@ -405,6 +420,41 @@ public class QueueRedisRepository {
 			expirationMember(gameId, userId)
 		);
 		return result;
+	}
+
+	// ── Lua: Game Cleanup (game 단위 전체 키 삭제) ──────────────────
+	// WARNING: 진행 중인 game에서 호출하면 활성 사용자 전원이 강제 퇴장됨.
+	// 반드시 game 종료 후 또는 dev 테스트 정리 용도로만 사용할 것.
+	private static final String CLEANUP_GAME_SCRIPT =
+		"redis.call('DEL', KEYS[1], KEYS[2], KEYS[3], KEYS[4]) " +
+		"local cursor = '0' " +
+		"repeat " +
+		"  local result = redis.call('ZSCAN', KEYS[5], cursor, 'MATCH', ARGV[1] .. '*', 'COUNT', 100) " +
+		"  cursor = result[1] " +
+		"  local members = result[2] " +
+		"  for i = 1, #members, 2 do " +
+		"    redis.call('ZREM', KEYS[5], members[i]) " +
+		"  end " +
+		"until cursor == '0' " +
+		"return 1";
+
+	/**
+	 * 해당 gameId의 모든 queue 관련 Redis 키를 일괄 삭제.
+	 * WARNING: 진행 중인 game에서 호출하면 활성 사용자 전원이 강제 퇴장됨.
+	 */
+	public void cleanupGame(UUID gameId) {
+		List<String> keys = List.of(
+			RedisKey.QUEUE_SEQUENCE.getKey(gameId),     // KEYS[1]
+			RedisKey.QUEUE_META.getKey(gameId),          // KEYS[2]
+			RedisKey.QUEUE_WAITING.getKey(gameId),       // KEYS[3]
+			RedisKey.QUEUE_ACTIVE_USERS.getKey(gameId),  // KEYS[4]
+			RedisKey.QUEUE_EXPIRATION_USERS.getKey()     // KEYS[5]
+		);
+		stringRedisTemplate.execute(
+			RedisScript.of(CLEANUP_GAME_SCRIPT, Long.class),
+			keys,
+			gameId + ":"                                  // ARGV[1]: gameId prefix for ZSCAN
+		);
 	}
 
 	private long longFromString(Object value) {

--- a/queue/src/main/java/com/goti/queue/repository/QueueRedisRepository.java
+++ b/queue/src/main/java/com/goti/queue/repository/QueueRedisRepository.java
@@ -253,6 +253,7 @@ public class QueueRedisRepository {
 	// saveEntry(JSON 직렬화)만 별도 호출 필요 → 전체 2 RTT.
 	// KEYS: [1]=META, [2]=SEQUENCE, [3]=WAITING, [4]=ENTRY, [5]=ACTIVE_USERS, [6]=EXPIRATION_USERS
 	// ARGV: [1]=userId, [2]=maxCapacity, [3]=now, [4]=expirationMember(gameId:userId)
+	// NOTE: standalone Redis 전제. KEYS[6](글로벌 키)은 Cluster 환경에서 cross-slot 에러 발생 → 분리 실행 필요.
 	private static final String ENTER_QUEUE_SCRIPT =
 		"local existing = redis.call('GET', KEYS[4]) " +
 		"local oldQueueNumber = -1 " +
@@ -425,17 +426,16 @@ public class QueueRedisRepository {
 	// ── Lua: Game Cleanup (game 단위 전체 키 삭제) ──────────────────
 	// WARNING: 진행 중인 game에서 호출하면 활성 사용자 전원이 강제 퇴장됨.
 	// 반드시 game 종료 후 또는 dev 테스트 정리 용도로만 사용할 것.
+	// NOTE: standalone Redis 전제. Cluster 전환 시 글로벌 키(KEYS[5]) 분리 실행 필요.
+	// KEYS: [1]=SEQUENCE, [2]=META, [3]=WAITING, [4]=ACTIVE_USERS, [5]=EXPIRATION_USERS
+	// ARGV: [1]=gameId prefix (gameId:)
 	private static final String CLEANUP_GAME_SCRIPT =
+		// SMEMBERS로 해당 game의 active users만 가져와서 expiration에서 제거 (ZSCAN 전체 순회 방지)
+		"local users = redis.call('SMEMBERS', KEYS[4]) " +
+		"for _, u in ipairs(users) do " +
+		"  redis.call('ZREM', KEYS[5], ARGV[1] .. u) " +
+		"end " +
 		"redis.call('DEL', KEYS[1], KEYS[2], KEYS[3], KEYS[4]) " +
-		"local cursor = '0' " +
-		"repeat " +
-		"  local result = redis.call('ZSCAN', KEYS[5], cursor, 'MATCH', ARGV[1] .. '*', 'COUNT', 100) " +
-		"  cursor = result[1] " +
-		"  local members = result[2] " +
-		"  for i = 1, #members, 2 do " +
-		"    redis.call('ZREM', KEYS[5], members[i]) " +
-		"  end " +
-		"until cursor == '0' " +
 		"return 1";
 
 	/**

--- a/queue/src/main/java/com/goti/queue/service/QueueCleanupService.java
+++ b/queue/src/main/java/com/goti/queue/service/QueueCleanupService.java
@@ -2,11 +2,13 @@ package com.goti.queue.service;
 
 import java.util.UUID;
 
+import org.springframework.data.redis.RedisSystemException;
 import org.springframework.stereotype.Service;
 
 import com.goti.queue.repository.QueueRedisRepository;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -26,10 +28,21 @@ public class QueueCleanupService {
 	/**
 	 * 해당 gameId의 모든 queue 키를 일괄 삭제.
 	 * 삭제 대상: sequence, meta, waiting, active-users, expiration:users 내 해당 game 엔트리
+	 * @throws RedisSystemException Redis 명령 실행 실패 시
 	 */
 	public void cleanupGame(UUID gameId) {
-		log.warn("action=QUEUE_CLEANUP gameId={} — 해당 game의 모든 queue 데이터 삭제", gameId);
-		queueRedisRepository.cleanupGame(gameId);
-		meterRegistry.counter("queue.cleanup", "match_id", gameId.toString()).increment();
+		// 파괴적 작업이므로 의도적으로 warn 레벨
+		log.warn("action=QUEUE_CLEANUP gameId={}", gameId);
+		Timer.Sample sample = Timer.start(meterRegistry);
+		try {
+			queueRedisRepository.cleanupGame(gameId);
+			meterRegistry.counter("queue.cleanup").increment();
+		} catch (RedisSystemException e) {
+			log.error("action=QUEUE_CLEANUP_FAILED gameId={} error={}", gameId, e.getMessage());
+			meterRegistry.counter("queue.cleanup.error").increment();
+			throw e;
+		} finally {
+			sample.stop(meterRegistry.timer("queue.cleanup.duration"));
+		}
 	}
 }

--- a/queue/src/main/java/com/goti/queue/service/QueueCleanupService.java
+++ b/queue/src/main/java/com/goti/queue/service/QueueCleanupService.java
@@ -2,7 +2,6 @@ package com.goti.queue.service;
 
 import java.util.UUID;
 
-import org.springframework.data.redis.RedisSystemException;
 import org.springframework.stereotype.Service;
 
 import com.goti.queue.repository.QueueRedisRepository;
@@ -28,16 +27,16 @@ public class QueueCleanupService {
 	/**
 	 * 해당 gameId의 모든 queue 키를 일괄 삭제.
 	 * 삭제 대상: sequence, meta, waiting, active-users, expiration:users 내 해당 game 엔트리
-	 * @throws RedisSystemException Redis 명령 실행 실패 시
 	 */
 	public void cleanupGame(UUID gameId) {
 		// 파괴적 작업이므로 의도적으로 warn 레벨
 		log.warn("action=QUEUE_CLEANUP gameId={}", gameId);
+		// 메트릭에 gameId 태그 미포함 — UUID 카디널리티가 높아 Prometheus 시계열 폭증 방지. gameId는 로그로 추적.
 		Timer.Sample sample = Timer.start(meterRegistry);
 		try {
 			queueRedisRepository.cleanupGame(gameId);
 			meterRegistry.counter("queue.cleanup").increment();
-		} catch (RedisSystemException e) {
+		} catch (Exception e) {
 			log.error("action=QUEUE_CLEANUP_FAILED gameId={} error={}", gameId, e.getMessage());
 			meterRegistry.counter("queue.cleanup.error").increment();
 			throw e;

--- a/queue/src/main/java/com/goti/queue/service/QueueCleanupService.java
+++ b/queue/src/main/java/com/goti/queue/service/QueueCleanupService.java
@@ -1,0 +1,35 @@
+package com.goti.queue.service;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import com.goti.queue.repository.QueueRedisRepository;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Game 단위 대기열 Redis 데이터 일괄 정리 서비스.
+ * WARNING: 진행 중인 game에서 호출하면 활성 사용자 전원이 강제 퇴장됨.
+ * game 종료 후 또는 dev 테스트 정리 용도로만 사용할 것.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class QueueCleanupService {
+
+	private final QueueRedisRepository queueRedisRepository;
+	private final MeterRegistry meterRegistry;
+
+	/**
+	 * 해당 gameId의 모든 queue 키를 일괄 삭제.
+	 * 삭제 대상: sequence, meta, waiting, active-users, expiration:users 내 해당 game 엔트리
+	 */
+	public void cleanupGame(UUID gameId) {
+		log.warn("action=QUEUE_CLEANUP gameId={} — 해당 game의 모든 queue 데이터 삭제", gameId);
+		queueRedisRepository.cleanupGame(gameId);
+		meterRegistry.counter("queue.cleanup", "match_id", gameId.toString()).increment();
+	}
+}

--- a/queue/src/main/resources/application.yml
+++ b/queue/src/main/resources/application.yml
@@ -60,3 +60,6 @@ queue:
   admitted-ttl: ${QUEUE_ADMITTED_TTL:15m}
   token-secret: ${QUEUE_TOKEN_SECRET:goti-2026-queue-token-secret-key-minimum-32-chars}
   expiration-check-interval: ${QUEUE_EXPIRATION_CHECK_INTERVAL:30s}
+  # 내부 전용 cleanup API 활성화 (안정화 후 false로 전환)
+  cleanup-api:
+    enabled: ${QUEUE_CLEANUP_API_ENABLED:false}

--- a/ticketing/src/main/java/com/goti/ticketing/seat/controller/StadiumSeatController.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/controller/StadiumSeatController.java
@@ -5,12 +5,6 @@ import static com.goti.global.api.ApiSuccessResponse.*;
 import java.util.List;
 import java.util.UUID;
 
-import com.goti.constants.messages.ErrorCode;
-import com.goti.exception.CustomException;
-import com.goti.infra.cloudflare.TurnstileService;
-
-import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,7 +12,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -36,17 +29,14 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
-@Slf4j
 @Tag(name = "Seat Grade", description = "구장 별 좌석 등급 및 구역 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/stadium-seats")
 public class StadiumSeatController {
-	private static final String TURNSTILE_TOKEN_HEADER = "X-Turnstile-Token";
 
 	private final SeatGradeService seatGradeService;
 	private final SeatSectionService seatSectionService;
-	private final TurnstileService turnstileService;
 
 	@Operation(
 		summary = "좌석 등급 생성",
@@ -67,20 +57,14 @@ public class StadiumSeatController {
 
 	@Operation(
 		summary = "좌석 등급 조회",
-		description = "구장별 좌석 등급 조회 API"
+		description = "구장별 좌석 등급 조회 API. 대기열 입장 완료(POST /api/v1/queue/{gameId}/seat-enter) 후에만 호출 가능합니다. 미입장 시 403 QUEUE_ADMISSION_REQUIRED 에러가 반환됩니다."
 	)
 	@GetMapping("/games/{gameId}/seat-grades")
 	public ResponseEntity<ApiSuccessResponse<SeatGradeSearchResultResponse>> getSeatGrades(
 		@AuthenticationPrincipal(expression = "id") UUID userId,
 		@PathVariable UUID gameId,
-		@RequestHeader(name = TURNSTILE_TOKEN_HEADER, required = false) String turnstileToken,
 		@RequestParam(defaultValue = "false") boolean forceNewSession
 	) {
-		log.info("StadiumSeatController::turnstileToken::{}", turnstileToken);
-		// if (!turnstileService.verify(turnstileToken)) {
-		// 	throw new CustomException(ErrorCode.TURNSTILE_VERIFICATION_FAILED);
-		// }
-
 		return wrap(seatGradeService.findSeatGrades(gameId, userId, forceNewSession));
 	}
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #455
- 
<br/>

## 🔎 개요
Queue 대기열에서 leave 없이 재진입 시 active-users 잔류로 409 ALREADY_ADMITTED 발생하는 문제 해결 및 game 종료 후 잔여 Redis 키 일괄 정리 내부 API 추가.

<br/>


## 📋 작업 내용
### 1. ENTER_QUEUE_SCRIPT Lua 수정
- 재진입 시 기존 entry cleanup에 active-users/expiration 정리 로직 추가
- KEYS 4→6, ARGV 3→4로 확장
- leave 없이 브라우저 닫고 재진입해도 409 발생하지 않음

### 2. Game Cleanup 내부 전용 API
- `DELETE /internal/queue/{gameId}` — game 단위 Redis 키 일괄 삭제
- `@Hidden` (Swagger 숨김), `@ConditionalOnProperty(queue.cleanup-api.enabled)` 기본
비활성
- Istio Gateway 라우팅 없음 → 외부 접근 차단
- `QueueCleanupService` + `InternalQueueController` 신규 생성

### 3. 기타
- `SecurityPathConstants`에 `/internal/**` permitAll 추가
- `application.yml`에 `queue.cleanup-api.enabled` 설정 추가 (기본 false)

<br/>