### PR TITLE
[BUG] Redis 직렬화 불일치 수정 — Lua↔RedisTemplate SISMEMBER/ZRANGEBYSCORE 매칭 실패

### DIFF
--- a/integration/src/main/java/com/goti/infra/queue/QueueAccessReader.java
+++ b/integration/src/main/java/com/goti/infra/queue/QueueAccessReader.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.UUID;
 
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -17,6 +18,7 @@ public class QueueAccessReader {
 	private static final String ADMITTED_STATUS = "ADMITTED";
 
 	private final RedisTemplate<String, Object> redisTemplate;
+	private final StringRedisTemplate stringRedisTemplate;
 	private final ObjectMapper objectMapper;
 
 	public boolean isAdmitted(UUID gameId, UUID userId) {
@@ -25,7 +27,8 @@ public class QueueAccessReader {
 			return false;
 		}
 
-		Boolean activeUser = redisTemplate.opsForSet().isMember(
+		// Lua 스크립트(stringRedisTemplate)가 plain string으로 SADD하므로 동일한 serializer로 조회
+		Boolean activeUser = stringRedisTemplate.opsForSet().isMember(
 			RedisKey.QUEUE_ACTIVE_USERS.getKey(gameId),
 			userId.toString()
 		);

--- a/queue/src/main/java/com/goti/queue/repository/QueueRedisRepository.java
+++ b/queue/src/main/java/com/goti/queue/repository/QueueRedisRepository.java
@@ -53,26 +53,6 @@ public class QueueRedisRepository {
 		redisTemplate.delete(RedisKey.QUEUE_ENTRY.getKey(gameId, userId));
 	}
 
-	public long nextSequence(UUID gameId) {
-		Long sequence = redisTemplate.opsForValue().increment(RedisKey.QUEUE_SEQUENCE.getKey(gameId));
-		return sequence == null ? 1L : sequence;
-	}
-
-	public void addWaiting(UUID gameId, UUID userId, long queueNumber) {
-		redisTemplate.opsForZSet().add(
-			RedisKey.QUEUE_WAITING.getKey(gameId),
-			userId.toString(),
-			queueNumber
-		);
-	}
-
-	public void removeWaiting(UUID gameId, UUID userId) {
-		redisTemplate.opsForZSet().remove(
-			RedisKey.QUEUE_WAITING.getKey(gameId),
-			userId.toString()
-		);
-	}
-
 	public long countWaitingUsers(UUID gameId) {
 		Long count = redisTemplate.opsForZSet().zCard(RedisKey.QUEUE_WAITING.getKey(gameId));
 		return count == null ? 0L : count;

--- a/queue/src/main/java/com/goti/queue/repository/QueueRedisRepository.java
+++ b/queue/src/main/java/com/goti/queue/repository/QueueRedisRepository.java
@@ -78,45 +78,9 @@ public class QueueRedisRepository {
 		return count == null ? 0L : count;
 	}
 
-	public boolean isActiveUser(UUID gameId, UUID userId) {
-		Boolean member = redisTemplate.opsForSet().isMember(
-			RedisKey.QUEUE_ACTIVE_USERS.getKey(gameId),
-			userId.toString()
-		);
-		return Boolean.TRUE.equals(member);
-	}
-
-	public void addActiveUser(UUID gameId, UUID userId) {
-		redisTemplate.opsForSet().add(
-			RedisKey.QUEUE_ACTIVE_USERS.getKey(gameId),
-			userId.toString()
-		);
-	}
-
-	public void removeActiveUser(UUID gameId, UUID userId) {
-		redisTemplate.opsForSet().remove(
-			RedisKey.QUEUE_ACTIVE_USERS.getKey(gameId),
-			userId.toString()
-		);
-	}
-
-	public void addExpirationUser(UUID gameId, UUID userId, Instant expiresAt) {
-		redisTemplate.opsForZSet().add(
-			RedisKey.QUEUE_EXPIRATION_USERS.getKey(),
-			expirationMember(gameId, userId),
-			expiresAt.toEpochMilli()
-		);
-	}
-
-	public void removeExpirationUser(UUID gameId, UUID userId) {
-		redisTemplate.opsForZSet().remove(
-			RedisKey.QUEUE_EXPIRATION_USERS.getKey(),
-			expirationMember(gameId, userId)
-		);
-	}
-
-	public Set<Object> getExpiredUsers(Instant now) {
-		return redisTemplate.opsForZSet().rangeByScore(
+	// Lua 스크립트(stringRedisTemplate)가 plain string으로 ZADD하므로 동일한 serializer로 조회
+	public Set<String> getExpiredUsers(Instant now) {
+		return stringRedisTemplate.opsForZSet().rangeByScore(
 			RedisKey.QUEUE_EXPIRATION_USERS.getKey(),
 			0,
 			now.toEpochMilli()

--- a/queue/src/main/java/com/goti/queue/scheduler/QueueExpirationScheduler.java
+++ b/queue/src/main/java/com/goti/queue/scheduler/QueueExpirationScheduler.java
@@ -23,14 +23,13 @@ public class QueueExpirationScheduler {
 
 	@Scheduled(fixedDelayString = "${queue.expiration-check-interval:30000}")
 	public void expireAdmittedUsers() {
-		Set<Object> expiredUsers = queueRedisRepository.getExpiredUsers(Instant.now());
+		Set<String> expiredUsers = queueRedisRepository.getExpiredUsers(Instant.now());
 		if (expiredUsers == null || expiredUsers.isEmpty()) {
 			return;
 		}
 
-		for (Object expiredUser : expiredUsers) {
+		for (String member : expiredUsers) {
 			try {
-				String member = String.valueOf(expiredUser);
 				String[] parts = member.split(":");
 				if (parts.length != 2) {
 					continue;
@@ -40,7 +39,7 @@ public class QueueExpirationScheduler {
 				UUID userId = UUID.fromString(parts[1]);
 				queueLeaveService.expire(gameId, userId);
 			} catch (Exception e) {
-				log.warn("action=EXPIRE_SKIP member={} error={}", expiredUser, e.getMessage());
+				log.warn("action=EXPIRE_SKIP member={} error={}", member, e.getMessage());
 			}
 		}
 	}


### PR DESCRIPTION

## #️⃣ 관련 이슈
- #459


<br/>

## 🔎 개요
Lua 스크립트(stringRedisTemplate)가 plain string으로 저장한 active-users/expiration-users를
redisTemplate(GenericJackson2JsonRedisSerializer)로 읽으면서 직렬화 형식 불일치 발생.
좌석등급 조회 403, ExpirationScheduler SerializationException 해결.

<br/>

## 📋 작업 내용
### 1. QueueAccessReader — SISMEMBER 직렬화 통일
- `redisTemplate` → `stringRedisTemplate`으로 변경 (Lua가 plain string으로 SADD하므로)

### 2. QueueRedisRepository — getExpiredUsers() 직렬화 통일
- `redisTemplate` → `stringRedisTemplate`으로 변경
- 반환 타입 `Set<Object>` → `Set<String>`

### 3. QueueExpirationScheduler — 타입 변경 반영
- `Set<Object>` → `Set<String>`, 변수명 정리

### 4. Dead code 정리
- Lua로 완전 대체된 5개 메서드 제거: `isActiveUser`, `addActiveUser`, `removeActiveUser`, `addExpirationUser`, `removeExpirationUser`
- 서비스/테스트 레이어에서 호출 없음 확인 완료

<br/>