### PR TITLE
[BUG] MSA 서비스 간 통신 에러 수정 — resale URL 누락, Paging 기본값 (#463)

### DIFF
--- a/common/src/main/java/com/goti/global/dto/Paging.java
+++ b/common/src/main/java/com/goti/global/dto/Paging.java
@@ -17,8 +17,8 @@ public record Paging(
 	int size
 ) {
 	public Paging {
-		if (page == 0) page = 1;
-		if (size == 0) size = 10;
+		if (page <= 0) page = 1;
+		if (size <= 0) size = 10;
 	}
 
 	public Pageable toPageable() {

--- a/common/src/main/java/com/goti/global/dto/Paging.java
+++ b/common/src/main/java/com/goti/global/dto/Paging.java
@@ -10,10 +10,17 @@ import jakarta.validation.constraints.Min;
 @Schema(description = "페이징 정보")
 public record Paging(
 	@Min(value = 1, message = "페이지 번호는 1 이상이어야 합니다.")
+	@Schema(defaultValue = "1")
 	int page,
 	@Range(min = 1, max = 30, message = "페이지 사이즈는 1 ~ 30 사이여야 합니다.")
+	@Schema(defaultValue = "10")
 	int size
 ) {
+	public Paging {
+		if (page == 0) page = 1;
+		if (size == 0) size = 10;
+	}
+
 	public Pageable toPageable() {
 		return PageRequest.of(page - 1, size);
 	}

--- a/ticketing/src/main/resources/application.yml
+++ b/ticketing/src/main/resources/application.yml
@@ -70,6 +70,7 @@ infra:
     endpoints:
       stadium: ${STADIUM_API_URL:http://localhost:8080}
       payment: ${PAYMENT_BASE_URL:http://localhost:8080}
+      resale: ${RESALE_BASE_URL:http://localhost:8080}
 
 cloudflare:
   turnstile:


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #463 

<br/>

## 🔎 개요
dev(K8s) 환경에서 ticketing→resale 서비스 호출 시 URL scheme 누락으로 500 에러, Paging 파라미터 미전달 시 400 에러 수정

<br/>

## 📋 작업 내용
- `ticketing/application.yml`에 `resale: ${RESALE_BASE_URL:http://localhost:8080}` 추가
  - `ApiEndpointProperties.resale()`가 null → BaseRestClient에서 빈 문자열 → "URI with undefined scheme" 해결
- `Paging` record에 compact constructor 추가
  - `page=0`이면 1, `size=0`이면 10으로 기본값 처리
  - 프론트엔드에서 page 미전달 시 null→int 변환 실패(400) 해결

<br/>