### PR TITLE
[BUG] 좌석 점유 시 queue token에서 JTI 추출하도록 수정

### DIFF
--- a/queue/src/main/resources/application.yml
+++ b/queue/src/main/resources/application.yml
@@ -58,7 +58,7 @@ queue:
   max-capacity: ${QUEUE_MAX_CAPACITY:5000}
   entry-ttl: ${QUEUE_ENTRY_TTL:10m}
   admitted-ttl: ${QUEUE_ADMITTED_TTL:15m}
-  token-secret: ${QUEUE_TOKEN_SECRET:goti-2026-queue-token-secret-key-minimum-32-chars}
+  token-secret: ${QUEUE_TOKEN_SECRET}
   expiration-check-interval: ${QUEUE_EXPIRATION_CHECK_INTERVAL:30s}
   # 내부 전용 cleanup API 활성화 (안정화 후 false로 전환)
   cleanup-api:

--- a/ticketing/src/main/java/com/goti/ticketing/queue/config/properties/QueueTokenProperties.java
+++ b/ticketing/src/main/java/com/goti/ticketing/queue/config/properties/QueueTokenProperties.java
@@ -1,0 +1,9 @@
+package com.goti.ticketing.queue.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "queue")
+public record QueueTokenProperties(
+	String tokenSecret
+) {
+}

--- a/ticketing/src/main/java/com/goti/ticketing/queue/infra/QueueTokenPayload.java
+++ b/ticketing/src/main/java/com/goti/ticketing/queue/infra/QueueTokenPayload.java
@@ -1,0 +1,13 @@
+package com.goti.ticketing.queue.infra;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record QueueTokenPayload(
+	UUID tokenId,
+	UUID gameId,
+	UUID userId,
+	long queueNumber,
+	Instant issuedAt
+) {
+}

--- a/ticketing/src/main/java/com/goti/ticketing/queue/infra/QueueTokenReader.java
+++ b/ticketing/src/main/java/com/goti/ticketing/queue/infra/QueueTokenReader.java
@@ -3,6 +3,7 @@ package com.goti.ticketing.queue.infra;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
+import java.util.Date;
 import java.util.UUID;
 
 import javax.crypto.SecretKey;
@@ -44,19 +45,29 @@ public class QueueTokenReader {
 				.decryptWith(secretKey)
 				.build();
 		} catch (GeneralSecurityException e) {
-			throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+			throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, e);
 		}
 	}
 
 	public QueueTokenPayload parse(String token) {
 		try {
 			Claims claims = jwtParser.parseEncryptedClaims(token).getPayload();
+			String tokenId = claims.getId();
+			String gameId = claims.get(GAME_ID_CLAIM, String.class);
+			String userId = claims.getSubject();
+			Long queueNumber = claims.get(QUEUE_NUMBER_CLAIM, Long.class);
+			Date issuedAt = claims.getIssuedAt();
+
+			if (tokenId == null || gameId == null || userId == null || queueNumber == null || issuedAt == null) {
+				throw new CustomException(ErrorCode.QUEUE_TOKEN_INVALID);
+			}
+
 			return new QueueTokenPayload(
-				UUID.fromString(claims.getId()),
-				UUID.fromString(claims.get(GAME_ID_CLAIM, String.class)),
-				UUID.fromString(claims.getSubject()),
-				claims.get(QUEUE_NUMBER_CLAIM, Long.class),
-				claims.getIssuedAt().toInstant()
+				UUID.fromString(tokenId),
+				UUID.fromString(gameId),
+				UUID.fromString(userId),
+				queueNumber,
+				issuedAt.toInstant()
 			);
 		} catch (JwtException | IllegalArgumentException e) {
 			throw new CustomException(ErrorCode.QUEUE_TOKEN_INVALID);

--- a/ticketing/src/main/java/com/goti/ticketing/queue/infra/QueueTokenReader.java
+++ b/ticketing/src/main/java/com/goti/ticketing/queue/infra/QueueTokenReader.java
@@ -1,0 +1,76 @@
+package com.goti.ticketing.queue.infra;
+
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
+import java.util.UUID;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import jakarta.annotation.PostConstruct;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import com.goti.constants.messages.ErrorCode;
+import com.goti.exception.CustomException;
+import com.goti.ticketing.queue.config.properties.QueueTokenProperties;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class QueueTokenReader {
+
+	private static final String KEY_ALGORITHM = "AES";
+	private static final String GAME_ID_CLAIM = "gameId";
+	private static final String QUEUE_NUMBER_CLAIM = "queueNumber";
+
+	private final QueueTokenProperties queueTokenProperties;
+
+	private SecretKey secretKey;
+	private JwtParser jwtParser;
+
+	@PostConstruct
+	void init() {
+		try {
+			this.secretKey = secretKey();
+			this.jwtParser = Jwts.parser()
+				.decryptWith(secretKey)
+				.build();
+		} catch (GeneralSecurityException e) {
+			throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	public QueueTokenPayload parse(String token) {
+		try {
+			Claims claims = jwtParser.parseEncryptedClaims(token).getPayload();
+			return new QueueTokenPayload(
+				UUID.fromString(claims.getId()),
+				UUID.fromString(claims.get(GAME_ID_CLAIM, String.class)),
+				UUID.fromString(claims.getSubject()),
+				claims.get(QUEUE_NUMBER_CLAIM, Long.class),
+				claims.getIssuedAt().toInstant()
+			);
+		} catch (JwtException | IllegalArgumentException e) {
+			throw new CustomException(ErrorCode.QUEUE_TOKEN_INVALID);
+		}
+	}
+
+	private SecretKey secretKey() throws GeneralSecurityException {
+		String tokenSecret = queueTokenProperties.tokenSecret();
+		if (!StringUtils.hasText(tokenSecret)) {
+			throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+		}
+
+		MessageDigest digest = MessageDigest.getInstance("SHA-256");
+		byte[] keyBytes = digest.digest(tokenSecret.getBytes(StandardCharsets.UTF_8));
+		return new SecretKeySpec(keyBytes, KEY_ALGORITHM);
+	}
+}

--- a/ticketing/src/main/java/com/goti/ticketing/seat/controller/SeatReservationController.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/controller/SeatReservationController.java
@@ -40,12 +40,11 @@ public class SeatReservationController {
 		@AuthenticationPrincipal(expression = "id") UUID memberId,
 		@Valid @RequestBody HoldSeatRequest request
 	) {
-		// TODO: 대기열 구현 완료 후 queueTokenJti를 요청값이 아닌 queue token claim(jti)에서 추출하도록 변경
 		UUID holdId = seatHoldManageService.hold(
 			request.gameId(),
 			seatId,
 			memberId,
-			request.queueTokenJti()
+			request.queueToken()
 		);
 		HoldSeatResponse response = HoldSeatResponse.from(holdId);
 		return wrap(response);

--- a/ticketing/src/main/java/com/goti/ticketing/seat/dto/request/HoldSeatRequest.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/dto/request/HoldSeatRequest.java
@@ -1,5 +1,7 @@
 package com.goti.ticketing.seat.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -11,8 +13,9 @@ public record HoldSeatRequest(
 	@NotNull(message = "경기 ID는 필수입니다.")
 	UUID gameId,
 
-	@Schema(description = "대기열 토큰 식별자", example = "queue-token-jti-123")
-	@NotBlank(message = "큐 토큰 식별자는 필수입니다.")
-	String queueTokenJti
+	@Schema(description = "대기열 토큰", example = "eyJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0...")
+	@NotBlank(message = "대기열 토큰은 필수입니다.")
+	@JsonAlias("queueTokenJti")
+	String queueToken
 ) {
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldManageService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldManageService.java
@@ -5,8 +5,11 @@ import java.util.UUID;
 import org.springframework.stereotype.Service;
 
 import com.goti.constants.messages.ErrorCode;
+import com.goti.exception.CustomException;
 import com.goti.ticketing.domain.entity.seat.SeatHoldEntity;
 import com.goti.infra.lock.DistributedLockManager;
+import com.goti.ticketing.queue.infra.QueueTokenPayload;
+import com.goti.ticketing.queue.infra.QueueTokenReader;
 import com.goti.global.validation.Preconditions;
 import com.goti.ticketing.seat.service.domain.SeatHoldService;
 import com.goti.ticketing.session.service.application.ReservationSessionService;
@@ -20,14 +23,22 @@ public class SeatHoldManageService {
 	private final DistributedLockManager distributedLockManager;
 	private final SeatHoldTransactionalService seatHoldTransactionalService;
 	private final ReservationSessionService reservationSessionService;
+	private final QueueTokenReader queueTokenReader;
 
-	public UUID hold(UUID gameId, UUID seatId, UUID userId, String queueTokenJti) {
+	public UUID hold(UUID gameId, UUID seatId, UUID userId, String queueToken) {
 		reservationSessionService.validateActiveSession(userId, gameId);
+		QueueTokenPayload queueTokenPayload = queueTokenReader.parse(queueToken);
+		validateQueueToken(gameId, userId, queueTokenPayload);
 
 		String lockKey = buildLockKey(gameId, seatId);
 		return distributedLockManager.withLock(
 			lockKey,
-			() -> seatHoldTransactionalService.hold(gameId, seatId, userId, queueTokenJti)
+			() -> seatHoldTransactionalService.hold(
+				gameId,
+				seatId,
+				userId,
+				queueTokenPayload.tokenId().toString()
+			)
 		);
 	}
 
@@ -52,5 +63,11 @@ public class SeatHoldManageService {
 
 	private static String buildLockKey(UUID gameId, UUID seatId) {
 		return "lock:seat:" + gameId + ":" + seatId;
+	}
+
+	private static void validateQueueToken(UUID gameId, UUID userId, QueueTokenPayload queueTokenPayload) {
+		if (!queueTokenPayload.gameId().equals(gameId) || !queueTokenPayload.userId().equals(userId)) {
+			throw new CustomException(ErrorCode.QUEUE_ENTRY_MISMATCH);
+		}
 	}
 }

--- a/ticketing/src/main/resources/application.yml
+++ b/ticketing/src/main/resources/application.yml
@@ -66,7 +66,7 @@ seat:
     batch-size: 200
 
 queue:
-  token-secret: ${QUEUE_TOKEN_SECRET:goti-2026-queue-token-secret-key-minimum-32-chars}
+  token-secret: ${QUEUE_TOKEN_SECRET}
 
 infra:
   api:

--- a/ticketing/src/main/resources/application.yml
+++ b/ticketing/src/main/resources/application.yml
@@ -65,6 +65,9 @@ seat:
     fixed-delay-ms: 1000
     batch-size: 200
 
+queue:
+  token-secret: ${QUEUE_TOKEN_SECRET:goti-2026-queue-token-secret-key-minimum-32-chars}
+
 infra:
   api:
     endpoints:


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#462
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
## 🔎 개요
좌석 점유 API 호출 시 `seat_holds.queue_token_jti` 컬럼에 queue token 전체 문자열이 저장되면서, 길이 초과 오류가 발생 문제 수정

-> ticketing에서 queue token을 직접 파싱한 뒤, 토큰 내부의 id만 추출해 저장하도록 변경

<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- queue token 파싱 전용 `QueueTokenReader`, `QueueTokenPayload`, `QueueTokenProperties` 추가
- `SeatHoldManageService` : queue token 파싱 및 `gameId`, `userId` 일치 여부 검증
- `SeatHold` 저장 시 queue token 전체가 아니라 tokenId만 queue_token_jti 컬럼에 저장

<br/>