### PR TITLE
[BUG] JWT 인증 시 OAuthProvider 타입 캐스팅 오류 수정

### DIFF
--- a/user/src/main/java/com/goti/user/config/jwt/JwtTokenProvider.java
+++ b/user/src/main/java/com/goti/user/config/jwt/JwtTokenProvider.java
@@ -161,7 +161,9 @@ public class JwtTokenProvider {
 		Claims claims = getClaims(token);
 		String userId = claims.getSubject();
 		String providerId = claims.get(PROVIDER_ID_KEY, String.class);
-		OAuthProvider provider = claims.get(PROVIDER_TYPE_KEY, OAuthProvider.class);
+		OAuthProvider provider = OAuthProvider.valueOf(
+			claims.get(PROVIDER_TYPE_KEY, String.class)
+		);
 		UserDetails userDetails = userDetailsService.loadUserById(userId, providerId, provider);
 		return UsernamePasswordAuthenticationToken.authenticated(
 			userDetails,


### PR DESCRIPTION
- Claims에서 Enum 타입 직접 추출 시 발생하는 ClassCastException 해결
- 토큰 생성 시 String으로 저장되는 특성을 고려하여 String으로 추출 후 valueOf로 변환 (In JwtTokenProvider)

<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#465 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
JWT Claims에서 OAuthProvider(Enum) 타입을 직접 추출할 때 발생하는 ClassCastException 이슈 해결
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- JwtTokenProvider 내 인증 로직 수정
  - Claims.get(key, Class<T>) 사용 시 Enum 클래스로의 직접 역질렬화 실패 이슈 대응
  - 토큰 생성 시 JSON 직렬화로 인해 데이터가 String으로 저장되는 특성을 반영하여, String.class로 먼저 추출하도록 변경
  - 추출된 문자열을 OAuthProvider.valueOf()를 통해 명시적으로 Enum 타입으로 변환하도록 로직 개선

- 런타임 안정성 확보
  - 소셜 로그인 후 Security Context에 인증 객체를 등록하는 과정에서 발생하던 런타임 에러 해결
<br/>