### PR TITLE
[REFACTOR] 서비스 간 내부 호출 /internal/ 경로 분리 + Paging null 방어(#471)

### DIFF
--- a/common/src/main/java/com/goti/global/dto/Paging.java
+++ b/common/src/main/java/com/goti/global/dto/Paging.java
@@ -15,6 +15,7 @@ public record Paging(
 	public Paging {
 		if (page == null || page <= 0) page = 1;
 		if (size == null || size <= 0) size = 10;
+		if (size > 30) size = 30;
 	}
 
 	public Pageable toPageable() {

--- a/common/src/main/java/com/goti/global/dto/Paging.java
+++ b/common/src/main/java/com/goti/global/dto/Paging.java
@@ -1,24 +1,20 @@
 package com.goti.global.dto;
 
-import org.hibernate.validator.constraints.Range;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Min;
 
 @Schema(description = "페이징 정보")
 public record Paging(
-	@Min(value = 1, message = "페이지 번호는 1 이상이어야 합니다.")
 	@Schema(defaultValue = "1")
-	int page,
-	@Range(min = 1, max = 30, message = "페이지 사이즈는 1 ~ 30 사이여야 합니다.")
+	Integer page,
 	@Schema(defaultValue = "10")
-	int size
+	Integer size
 ) {
 	public Paging {
-		if (page <= 0) page = 1;
-		if (size <= 0) size = 10;
+		if (page == null || page <= 0) page = 1;
+		if (size == null || size <= 0) size = 10;
 	}
 
 	public Pageable toPageable() {

--- a/common/src/main/java/com/goti/security/MeshSecuritySupport.java
+++ b/common/src/main/java/com/goti/security/MeshSecuritySupport.java
@@ -23,12 +23,13 @@ public final class MeshSecuritySupport {
 	private static final String UNAUTHORIZED_BODY = errorJson(ErrorCode.AUTH_INVALID_ACCESS_PATH);
 	private static final String FORBIDDEN_BODY = errorJson(ErrorCode.AUTH_PERMISSION_DENIED);
 
-	/** MSA 서비스 공통 공개 경로 (health + swagger + API docs) */
+	/** MSA 서비스 공통 공개 경로 (health + swagger + API docs + internal) */
 	public static final String[] PUBLIC_PATHS = {
 		"/actuator/health",
 		"/actuator/health/**",
 		"/swagger-ui/**",
-		"/v3/api-docs/**"
+		"/v3/api-docs/**",
+		"/internal/**"
 	};
 
 	private MeshSecuritySupport() {

--- a/payment/src/main/java/com/goti/payment/controller/InternalPaymentController.java
+++ b/payment/src/main/java/com/goti/payment/controller/InternalPaymentController.java
@@ -1,0 +1,33 @@
+package com.goti.payment.controller;
+
+import static com.goti.global.api.ApiSuccessResponse.*;
+
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.goti.global.api.ApiSuccessResponse;
+import com.goti.payment.dto.response.UnsettledAmountResponse;
+import com.goti.payment.service.application.PaymentLedgerProcessService;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import lombok.RequiredArgsConstructor;
+
+@Hidden
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal/payments")
+public class InternalPaymentController {
+	private final PaymentLedgerProcessService paymentLedgerProcessService;
+
+	@GetMapping("/resales/unsettled")
+	public ResponseEntity<ApiSuccessResponse<UnsettledAmountResponse>> getUnsettledAmounts(
+		@RequestParam UUID userId
+	) {
+		return wrap(paymentLedgerProcessService.getUnsettledAmounts(userId));
+	}
+}

--- a/payment/src/main/java/com/goti/payment/controller/InternalPaymentController.java
+++ b/payment/src/main/java/com/goti/payment/controller/InternalPaymentController.java
@@ -6,15 +6,22 @@ import java.util.UUID;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.goti.global.api.ApiSuccessResponse;
+import com.goti.payment.dto.request.PaymentCancelRequest;
+import com.goti.payment.dto.response.PaymentResponse;
 import com.goti.payment.dto.response.UnsettledAmountResponse;
 import com.goti.payment.service.application.PaymentLedgerProcessService;
+import com.goti.payment.service.domain.PaymentService;
 
 import io.swagger.v3.oas.annotations.Hidden;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @Hidden
@@ -23,11 +30,20 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/internal/payments")
 public class InternalPaymentController {
 	private final PaymentLedgerProcessService paymentLedgerProcessService;
+	private final PaymentService paymentService;
 
 	@GetMapping("/resales/unsettled")
 	public ResponseEntity<ApiSuccessResponse<UnsettledAmountResponse>> getUnsettledAmounts(
 		@RequestParam UUID userId
 	) {
 		return wrap(paymentLedgerProcessService.getUnsettledAmounts(userId));
+	}
+
+	@PostMapping("/orders/{orderId}/cancellations")
+	public ResponseEntity<ApiSuccessResponse<PaymentResponse>> cancel(
+		@PathVariable UUID orderId,
+		@Valid @RequestBody PaymentCancelRequest request
+	) {
+		return wrap(paymentService.cancel(orderId, request.cancellationId()));
 	}
 }

--- a/resale/src/main/java/com/goti/resale/constants/SecurityPathConstants.java
+++ b/resale/src/main/java/com/goti/resale/constants/SecurityPathConstants.java
@@ -8,7 +8,6 @@ public final class SecurityPathConstants {
 
 	public static final String[] PUBLIC_URLS = {
 		"/api/v1/resales/histories/**",
-		"/api/v1/resales/games/**",
-		"/api/v1/resales/listings/count"    // 내부용
+		"/api/v1/resales/games/**"
 	};
 }

--- a/resale/src/main/java/com/goti/resale/controller/InternalResaleController.java
+++ b/resale/src/main/java/com/goti/resale/controller/InternalResaleController.java
@@ -1,0 +1,33 @@
+package com.goti.resale.controller;
+
+import static com.goti.global.api.ApiSuccessResponse.*;
+
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.goti.global.api.ApiSuccessResponse;
+import com.goti.resale.dto.response.ResaleListingsCountResponse;
+import com.goti.resale.service.application.ResaleListingProcessService;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import lombok.RequiredArgsConstructor;
+
+@Hidden
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal/resales")
+public class InternalResaleController {
+	private final ResaleListingProcessService listingService;
+
+	@GetMapping("/listings/count")
+	public ResponseEntity<ApiSuccessResponse<ResaleListingsCountResponse>> getResaleCount(
+		@RequestParam UUID userId
+	) {
+		return wrap(listingService.getResaleCount(userId));
+	}
+}

--- a/ticketing/src/main/java/com/goti/ticketing/infra/api/TicketPaymentApiClient.java
+++ b/ticketing/src/main/java/com/goti/ticketing/infra/api/TicketPaymentApiClient.java
@@ -17,7 +17,7 @@ import com.goti.ticketing.order.dto.request.OrderPaymentCancelRequest;
 @Component
 public class TicketPaymentApiClient extends BaseRestClient implements TicketPaymentClient {
 	private static final String PAYMENT_CANCEL_API = "/api/v1/payments/orders";
-	private static final String PAYMENT_UNSETTLED_API = "/api/v1/payments/resales";
+	private static final String PAYMENT_UNSETTLED_API = "/internal/payments/resales";
 	private static final String PATH_SEPARATOR = "/";
 
 	public TicketPaymentApiClient(RestClient.Builder builder, ApiEndpointProperties properties) {

--- a/ticketing/src/main/java/com/goti/ticketing/infra/api/TicketPaymentApiClient.java
+++ b/ticketing/src/main/java/com/goti/ticketing/infra/api/TicketPaymentApiClient.java
@@ -16,7 +16,7 @@ import com.goti.ticketing.order.dto.request.OrderPaymentCancelRequest;
 
 @Component
 public class TicketPaymentApiClient extends BaseRestClient implements TicketPaymentClient {
-	private static final String PAYMENT_CANCEL_API = "/api/v1/payments/orders";
+	private static final String PAYMENT_CANCEL_API = "/internal/payments/orders";
 	private static final String PAYMENT_UNSETTLED_API = "/internal/payments/resales";
 	private static final String PATH_SEPARATOR = "/";
 

--- a/ticketing/src/main/java/com/goti/ticketing/infra/api/TicketResaleApiClient.java
+++ b/ticketing/src/main/java/com/goti/ticketing/infra/api/TicketResaleApiClient.java
@@ -13,7 +13,7 @@ import com.goti.ticketing.infra.api.dto.response.ResaleListingMyPageCountRespons
 
 @Component
 public class TicketResaleApiClient extends BaseRestClient implements TicketResaleClient {
-	private final static String RESALE_GET_API = "/api/v1/resales";
+	private final static String RESALE_GET_API = "/internal/resales";
 	private final static String PATH_SEPARATOR = "/";
 
 	public TicketResaleApiClient(RestClient.Builder builder, ApiEndpointProperties properties) {


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #471 

<br/>

## 🔎 개요
MSA 서비스 간 내부 호출을 `/internal/*` 경로로 분리하여 Istio RBAC 정책을 일괄 관리할 수 있도록 개선.
추가로 Paging record의 null 바인딩 실패 문제 수정.

## 📋 작업 내용

### Internal API 패턴 도입
- `MeshSecuritySupport.PUBLIC_PATHS`에 `/internal/**` 공통 추가
- `InternalResaleController` 생성 — `GET /internal/resales/listings/count`
- `InternalPaymentController` 생성 — `GET /internal/payments/resales/unsettled`
- `TicketResaleApiClient`, `TicketPaymentApiClient` 호출 경로 `/internal/` 로 변경
- resale `SecurityPathConstants`에서 개별 내부 경로 제거 (공통으로 대체)

### Paging null 방어
- `int` → `Integer` 변경 (Spring MVC null 바인딩 허용)
- `@Min`, `@Range` 제거 → compact constructor에서 방어
- `null`/음수 → 기본값 (page=1, size=10)


<br/>