### PR TITLE
[BUG] 티켓 생성 시 경기명 저장 로직 추가

### DIFF
--- a/ticketing/src/main/java/com/goti/ticketing/ticket/service/application/TicketCreateService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/ticket/service/application/TicketCreateService.java
@@ -3,11 +3,13 @@ package com.goti.ticketing.ticket.service.application;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +19,8 @@ import com.goti.ticketing.domain.entity.order.OrderEntity;
 import com.goti.ticketing.domain.entity.order.OrderItemEntity;
 import com.goti.ticketing.domain.entity.order.OrderHistoryEntity;
 import com.goti.exception.CustomException;
+import com.goti.ticketing.infra.api.StadiumClient;
+import com.goti.ticketing.infra.api.dto.response.BaseballTeamDisplayNameResponse;
 import com.goti.ticketing.order.repository.OrderItemRepository;
 import com.goti.ticketing.order.repository.OrderHistoryRepository;
 import com.goti.ticketing.ticket.dto.response.TicketResponse;
@@ -35,6 +39,7 @@ public class TicketCreateService {
 	private final OrderHistoryRepository orderHistoryRepository;
 	private final OrderItemRepository orderItemRepository;
 	private final TicketService ticketService;
+	private final StadiumClient stadiumClient;
 
 	@Transactional
 	public List<TicketResponse> create(OrderEntity order) {
@@ -43,9 +48,17 @@ public class TicketCreateService {
 
 		List<OrderItemEntity> orderItems = orderItemRepository.findOrderItemsByOrderId(order.getId());
 		String ticketNumberPrefix = createPrefix(order.getCreatedAt(), order.getOrderNumber());
+		String gameTitle = buildGameTitle(order);
 
 		return IntStream.range(0, orderItems.size())
-			.mapToObj(index -> createTicket(order, orderHistory, orderItems.get(index), ticketNumberPrefix, index + 1))
+			.mapToObj(index -> createTicket(
+				order,
+				orderHistory,
+				orderItems.get(index),
+				ticketNumberPrefix,
+				gameTitle,
+				index + 1
+			))
 			.toList();
 	}
 
@@ -54,6 +67,7 @@ public class TicketCreateService {
 		OrderHistoryEntity orderHistory,
 		OrderItemEntity orderItem,
 		String ticketNumberPrefix,
+		String gameTitle,
 		int ticketSequence
 	) {
 		return TicketResponse.from(
@@ -65,7 +79,7 @@ public class TicketCreateService {
 				orderHistory.getName(),
 				orderHistory.getEmail(),
 				orderHistory.getMobile(),
-				null,
+				gameTitle,
 				order.getGameSchedule().getStartAt(),
 				buildSeatInfo(orderItem),
 				orderItem.getTicketPrice()
@@ -91,6 +105,28 @@ public class TicketCreateService {
 
 	private String generateTicketNumber(String ticketNumberPrefix, int ticketSequence) {
 		return ticketNumberPrefix + "-" + String.format("%03d", ticketSequence);
+	}
+
+	private String buildGameTitle(OrderEntity order) {
+		UUID homeTeamId = order.getGameSchedule().getHomeTeamId();
+		UUID awayTeamId = order.getGameSchedule().getAwayTeamId();
+
+		Map<UUID, String> teamDisplayNames = stadiumClient.getBaseballTeamDisplayNames(
+				new ArrayList<>(List.of(homeTeamId, awayTeamId))
+			).stream()
+			.collect(Collectors.toMap(
+				BaseballTeamDisplayNameResponse::teamId,
+				BaseballTeamDisplayNameResponse::teamDisplayName
+			));
+
+		String homeTeamDisplayName = teamDisplayNames.get(homeTeamId);
+		String awayTeamDisplayName = teamDisplayNames.get(awayTeamId);
+
+		if (homeTeamDisplayName == null || awayTeamDisplayName == null) {
+			throw new CustomException(ErrorCode.GAME_NOT_FOUND);
+		}
+
+		return homeTeamDisplayName + "vs" + awayTeamDisplayName;
 	}
 
 	private String buildSeatInfo(OrderItemEntity orderItem) {

--- a/ticketing/src/main/java/com/goti/ticketing/ticket/service/application/TicketCreateService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/ticket/service/application/TicketCreateService.java
@@ -47,7 +47,7 @@ public class TicketCreateService {
 
 		List<OrderItemEntity> orderItems = orderItemRepository.findOrderItemsByOrderId(order.getId());
 		String ticketNumberPrefix = createPrefix(order.getCreatedAt(), order.getOrderNumber());
-		String gameTitle = buildGameTitle(order);
+		String gameTitle = createGameTitle(order);
 
 		return IntStream.range(0, orderItems.size())
 			.mapToObj(index -> createTicket(
@@ -106,7 +106,7 @@ public class TicketCreateService {
 		return ticketNumberPrefix + "-" + String.format("%03d", ticketSequence);
 	}
 
-	private String buildGameTitle(OrderEntity order) {
+	private String createGameTitle(OrderEntity order) {
 		UUID homeTeamId = order.getGameSchedule().getHomeTeamId();
 		UUID awayTeamId = order.getGameSchedule().getAwayTeamId();
 

--- a/ticketing/src/main/java/com/goti/ticketing/ticket/service/application/TicketCreateService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/ticket/service/application/TicketCreateService.java
@@ -3,7 +3,6 @@ package com.goti.ticketing.ticket.service.application;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -112,7 +111,7 @@ public class TicketCreateService {
 		UUID awayTeamId = order.getGameSchedule().getAwayTeamId();
 
 		Map<UUID, String> teamDisplayNames = stadiumClient.getBaseballTeamDisplayNames(
-				new ArrayList<>(List.of(homeTeamId, awayTeamId))
+				List.of(homeTeamId, awayTeamId)
 			).stream()
 			.collect(Collectors.toMap(
 				BaseballTeamDisplayNameResponse::teamId,


### PR DESCRIPTION

<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#476 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
티켓 생성 시 `gameTitle`이 `null`로 저장되던 문제 해결

<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
> `TicketCreateService`에서 경기 생성 시 `gameTitle`을 `null`로 넘기던 로직 제거
> `GameSchedule`의 `homeTeamId`, `awayTeamId`를 기반으로 stadium 내부 API 호출 -> 팀 displayName 조회
> 조회한 홈팀/원정팀명 조합 -> `"{home} vs {away}"` format 경기명 생성
> 생성한 경기명 -> 티켓 `gameTitle` 필드 저장 로직 추가


<br/>