### PR TITLE
[BUG] orderedAt 타입 LocalDateTime으로 변경

### DIFF
--- a/payment/src/main/java/com/goti/payment/dto/response/PurchaseSearchResponse.java
+++ b/payment/src/main/java/com/goti/payment/dto/response/PurchaseSearchResponse.java
@@ -1,6 +1,5 @@
 package com.goti.payment.dto.response;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -15,7 +14,7 @@ public record PurchaseSearchResponse(
 	Integer totalQuantity,
 	Integer totalAmount,
 	@JsonFormat(pattern = "yyyy-MM-dd HH:mm")
-	Instant orderedAt,
+	LocalDateTime orderedAt,
 	UUID gameId,
 	UUID stadiumId,
 	String gameTitle,

--- a/payment/src/main/java/com/goti/payment/dto/response/ResalePurchaseListItemResponse.java
+++ b/payment/src/main/java/com/goti/payment/dto/response/ResalePurchaseListItemResponse.java
@@ -14,7 +14,7 @@ public record ResalePurchaseListItemResponse(
 	Integer totalQuantity,
 	Integer totalAmount,
 	@JsonFormat(pattern = "yyyy-MM-dd HH:mm")
-	Instant orderedAt,
+	LocalDateTime orderedAt,
 	UUID gameId,
 	String gameTitle,
 	@JsonFormat(pattern = "yyyy-MM-dd HH:mm")

--- a/payment/src/main/java/com/goti/payment/dto/response/TicketingOrderListItemResponse.java
+++ b/payment/src/main/java/com/goti/payment/dto/response/TicketingOrderListItemResponse.java
@@ -1,6 +1,5 @@
 package com.goti.payment.dto.response;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -15,7 +14,7 @@ public record TicketingOrderListItemResponse(
 	Integer totalQuantity,
 	Integer totalAmount,
 	@JsonFormat(pattern = "yyyy-MM-dd HH:mm")
-	Instant orderedAt,
+	LocalDateTime orderedAt,
 	UUID gameId,
 	UUID stadiumId,
 	String gameTitle,

--- a/ticketing/src/main/java/com/goti/ticketing/order/dto/response/OrderListResponse.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/dto/response/OrderListResponse.java
@@ -1,6 +1,5 @@
 package com.goti.ticketing.order.dto.response;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -24,8 +23,8 @@ public record OrderListResponse(
 	@Schema(description = "총 결제 금액", example = "42000")
 	Integer totalAmount,
 	@Schema(description = "주문 일시", example = "2026-03-16 10:15")
-	@JsonFormat(pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
-	Instant orderedAt,
+	@JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+	LocalDateTime orderedAt,
 	@Schema(description = "경기 ID", example = "62c73f2d-87ab-4f5c-9d66-97d4d7771111")
 	UUID gameId,
 	@Schema(description = "구장 ID", example = "8347997b-886f-4e6e-80e6-ff64f1e9e057")
@@ -53,7 +52,7 @@ public record OrderListResponse(
 			order.getOrderStatus(),
 			order.getTotalQuantity(),
 			order.getTotalAmount(),
-			order.getCreatedAt(),
+			LocalDateTime.ofInstant(order.getCreatedAt(), java.time.ZoneId.of("Asia/Seoul")),
 			order.getGameSchedule().getId(),
 			order.getGameSchedule().getStadiumId(),
 			gameTitle,


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#477 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
resale 모듈이 `"yyyy-MM-dd HH:mm"` 형식으로 보내는 날짜 문자열을 정상적으로 역직렬화할 수 있도록 수정
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
> `payment` 모듈의 구매 내역 응답 DTO에서 `orderedAt` 타입을 `Instant`에서 `LocalDateTime`으로 변경

<br/>