### PR TITLE
[BUG] payment 구매내역 seatInfos를 등급명 포함 형식으로 변환

### DIFF
--- a/payment/src/main/java/com/goti/payment/dto/response/SeatGradeInfoResponse.java
+++ b/payment/src/main/java/com/goti/payment/dto/response/SeatGradeInfoResponse.java
@@ -1,0 +1,9 @@
+package com.goti.payment.dto.response;
+
+import java.util.List;
+
+public record SeatGradeInfoResponse(
+	String seatGradeName,
+	List<String> seatInfos
+) {
+}

--- a/payment/src/main/java/com/goti/payment/dto/response/TicketingOrderListItemResponse.java
+++ b/payment/src/main/java/com/goti/payment/dto/response/TicketingOrderListItemResponse.java
@@ -21,6 +21,6 @@ public record TicketingOrderListItemResponse(
 	@JsonFormat(pattern = "yyyy-MM-dd HH:mm")
 	LocalDateTime gameDate,
 	String stadiumLocation,
-	List<String> seatInfos
+	List<SeatGradeInfoResponse> seatGradeGroups
 ) {
 }

--- a/payment/src/main/java/com/goti/payment/service/application/PurchaseSearchService.java
+++ b/payment/src/main/java/com/goti/payment/service/application/PurchaseSearchService.java
@@ -8,6 +8,8 @@ import java.util.stream.Stream;
 
 import com.goti.payment.dto.request.enums.PurchaseSearchType;
 
+import com.goti.payment.dto.response.SeatGradeInfoResponse;
+
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -98,7 +100,7 @@ public class PurchaseSearchService {
 				order.stadiumId(),
 				order.gameTitle(),
 				order.gameDate(),
-				order.seatInfos()
+				extractSeatInfos(order.seatGradeGroups())
 			))
 			.toList();
 	}
@@ -131,6 +133,25 @@ public class PurchaseSearchService {
 				order.seatInfos()
 			))
 			.toList();
+	}
+
+	private List<String> extractSeatInfos(List<SeatGradeInfoResponse> seatGradeGroups) {
+		if (seatGradeGroups == null) {
+			return List.of();
+		}
+
+		return seatGradeGroups.stream()
+			.flatMap(group -> group.seatInfos().stream()
+				.map(seatInfo -> combineSeatGradeAndSeatInfo(group.seatGradeName(), seatInfo)))
+			.toList();
+	}
+
+	private String combineSeatGradeAndSeatInfo(String seatGradeName, String seatInfo) {
+		if (!StringUtils.hasText(seatGradeName)) {
+			return seatInfo;
+		}
+
+		return seatGradeName + " " + seatInfo;
 	}
 
 	private Page<PurchaseSearchResponse> toPage(List<PurchaseSearchResponse> combinedPurchases, Pageable pageable) {

--- a/ticketing/src/main/java/com/goti/ticketing/order/dto/response/OrderListResponse.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/dto/response/OrderListResponse.java
@@ -1,6 +1,7 @@
 package com.goti.ticketing.order.dto.response;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.UUID;
 
@@ -52,7 +53,7 @@ public record OrderListResponse(
 			order.getOrderStatus(),
 			order.getTotalQuantity(),
 			order.getTotalAmount(),
-			LocalDateTime.ofInstant(order.getCreatedAt(), java.time.ZoneId.of("Asia/Seoul")),
+			LocalDateTime.ofInstant(order.getCreatedAt(), ZoneId.of("Asia/Seoul")),
 			order.getGameSchedule().getId(),
 			order.getGameSchedule().getStadiumId(),
 			gameTitle,


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#481

<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
구매내역 조회 시 ticketing 주문 응답의 좌석 등급 정보를 프론트에서 바로 사용할 수 있도록, 좌석 정보를 등급명 포함 문자열 형태로 변환하도록 수정

<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
> ticketing 주문 목록 응답의 `seatGradeGroups`를 payment에서 수신하도록 DTO 구조 정리
> 구매내역 최종 응답은 기존처럼 `seatInfos` 리스트를 유지하되, 각 항목을 `"등급명 + 좌석정보"` 형식으로 변환

<br/>