### PR TITLE
[BUG] 리셀 구매내역 내부 호출에 인증 헤더 추가

### DIFF
--- a/payment/src/main/java/com/goti/payment/infra/ResaleOrderApiClient.java
+++ b/payment/src/main/java/com/goti/payment/infra/ResaleOrderApiClient.java
@@ -62,10 +62,9 @@ public class ResaleOrderApiClient extends BaseRestClient implements ResaleOrderC
 	) {
 		List<ResalePurchaseListItemResponse> response = getGotiResponse(
 			RESALE_ORDER_API + "/purchases",
-			null,
+			getHeaders(),
 			createPurchaseQueryParams(buyerId, months, startDate, endDate),
-			new ParameterizedTypeReference<>() {
-			}
+			new ParameterizedTypeReference<>() {}
 		);
 		return response != null ? response : List.of();
 	}


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#488 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
리셀 조회 내부 API 호출 시 Unauthorized 401 에러 발생 
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
> `ResaleOrderApiClient`에서 리셀 구매내역 내부 호출에 인증 헤더 추가
resale 구매내역 내부 API 호출 정상 동작 확인 완료

<br/>