### PR TITLE
[BUG] 구매내역 통합 조회 응답에 ticketIds 추가

### DIFF
--- a/payment/src/main/java/com/goti/payment/dto/response/PurchaseSearchResponse.java
+++ b/payment/src/main/java/com/goti/payment/dto/response/PurchaseSearchResponse.java
@@ -20,6 +20,7 @@ public record PurchaseSearchResponse(
 	String gameTitle,
 	@JsonFormat(pattern = "yyyy-MM-dd HH:mm")
 	LocalDateTime gameDate,
-	List<String> seatInfos
+	List<String> seatInfos,
+	List<UUID> ticketIds
 ) {
 }

--- a/payment/src/main/java/com/goti/payment/dto/response/ResalePurchaseListItemResponse.java
+++ b/payment/src/main/java/com/goti/payment/dto/response/ResalePurchaseListItemResponse.java
@@ -19,6 +19,7 @@ public record ResalePurchaseListItemResponse(
 	String gameTitle,
 	@JsonFormat(pattern = "yyyy-MM-dd HH:mm")
 	LocalDateTime gameDate,
-	List<String> seatInfos
+	List<String> seatInfos,
+	List<UUID> ticketIds
 ) {
 }

--- a/payment/src/main/java/com/goti/payment/dto/response/TicketingOrderListItemResponse.java
+++ b/payment/src/main/java/com/goti/payment/dto/response/TicketingOrderListItemResponse.java
@@ -21,6 +21,7 @@ public record TicketingOrderListItemResponse(
 	@JsonFormat(pattern = "yyyy-MM-dd HH:mm")
 	LocalDateTime gameDate,
 	String stadiumLocation,
-	List<SeatGradeInfoResponse> seatGradeGroups
+	List<SeatGradeInfoResponse> seatGradeGroups,
+	List<UUID> ticketIds
 ) {
 }

--- a/payment/src/main/java/com/goti/payment/service/application/PurchaseSearchService.java
+++ b/payment/src/main/java/com/goti/payment/service/application/PurchaseSearchService.java
@@ -100,7 +100,8 @@ public class PurchaseSearchService {
 				order.stadiumId(),
 				order.gameTitle(),
 				order.gameDate(),
-				extractSeatInfos(order.seatGradeGroups())
+				extractSeatInfos(order.seatGradeGroups()),
+				order.ticketIds()
 			))
 			.toList();
 	}
@@ -130,7 +131,8 @@ public class PurchaseSearchService {
 				null,
 				order.gameTitle(),
 				order.gameDate(),
-				order.seatInfos()
+				order.seatInfos(),
+				order.ticketIds()
 			))
 			.toList();
 	}

--- a/resale/src/main/java/com/goti/resale/domain/entity/resale/ResaleTransactionEntity.java
+++ b/resale/src/main/java/com/goti/resale/domain/entity/resale/ResaleTransactionEntity.java
@@ -51,6 +51,8 @@ public class ResaleTransactionEntity extends ModificationTimestampEntity {
 	@Column(nullable = false)
 	private UUID sellerId;
 
+	private UUID buyerTicketId;
+
 	@Column(nullable = false)
 	private Integer transactionPrice;
 
@@ -91,6 +93,7 @@ public class ResaleTransactionEntity extends ModificationTimestampEntity {
 		this.resaleTicketNumber = resaleTicketNumber;
 		this.buyerId = buyerId;
 		this.sellerId = sellerId;
+		this.buyerTicketId = null;
 		this.transactionPrice = transactionPrice;
 		this.buyerFee = buyerFee;
 		this.sellerFee = sellerFee;
@@ -169,6 +172,11 @@ public class ResaleTransactionEntity extends ModificationTimestampEntity {
 		this.transactionStatus = ResaleTransactionStatus.COMPLETED;
 		this.confirmedAt = LocalDateTime.now();
 		this.escrowId = escrowId;
+	}
+
+	public void assignBuyerTicketId(UUID buyerTicketId) {
+		Preconditions.domainValidate(buyerTicketId != null, "구매자 티켓 ID는 비어 있을 수 없습니다.");
+		this.buyerTicketId = buyerTicketId;
 	}
 
 }

--- a/resale/src/main/java/com/goti/resale/dto/response/ResalePurchaseListResponse.java
+++ b/resale/src/main/java/com/goti/resale/dto/response/ResalePurchaseListResponse.java
@@ -34,14 +34,17 @@ public record ResalePurchaseListResponse(
 	@JsonFormat(pattern = "yyyy-MM-dd HH:mm")
 	LocalDateTime gameDate,
 	@Schema(description = "좌석 정보 목록", example = "[\"1루 K8석(3)\", \"109구역 1열 8번\"]")
-	List<String> seatInfos
+	List<String> seatInfos,
+	@Schema(description = "티켓 ID 목록")
+	List<UUID> ticketIds
 ) {
 	public static ResalePurchaseListResponse of(
 		ResaleOrderEntity order,
 		UUID gameId,
 		String gameTitle,
 		LocalDateTime gameDate,
-		List<String> seatInfos
+		List<String> seatInfos,
+		List<UUID> ticketIds
 	) {
 		return new ResalePurchaseListResponse(
 			order.getId(),
@@ -53,7 +56,8 @@ public record ResalePurchaseListResponse(
 			gameId,
 			gameTitle,
 			gameDate,
-			seatInfos
+			seatInfos,
+			ticketIds
 		);
 	}
 }

--- a/resale/src/main/java/com/goti/resale/infra/TicketApiClient.java
+++ b/resale/src/main/java/com/goti/resale/infra/TicketApiClient.java
@@ -21,6 +21,7 @@ import com.goti.infra.api.base.BaseRestClient;
 import com.goti.resale.dto.response.ResaleTicketResponse;
 import com.goti.resale.infra.dto.GameScheduleResponse;
 import com.goti.resale.infra.dto.ResaleTicketPurchaseInfo;
+import com.goti.resale.infra.dto.TicketOwnershipTransferResponse;
 import com.goti.resale.infra.dto.TicketGameInfo;
 import com.goti.resale.infra.dto.TicketTransferRequest;
 
@@ -123,7 +124,7 @@ public class TicketApiClient extends BaseRestClient implements TicketClient {
 	}
 
 	@Override
-	public void transferOwnership(
+	public TicketOwnershipTransferResponse transferOwnership(
 		UUID ticketId,
 		UUID buyerId,
 		String buyerNickname,
@@ -148,7 +149,19 @@ public class TicketApiClient extends BaseRestClient implements TicketClient {
 			? createBearerHeader(authToken)
 			: getHeaders();
 
-		postVoid(uri, headers, request);
+		ApiSuccessResponse<TicketOwnershipTransferResponse> response = restClient.post()
+			.uri(uri)
+			.headers(header -> {
+				if (headers != null) {
+					headers.forEach(header::add);
+				}
+			})
+			.body(request)
+			.retrieve()
+			.body(new ParameterizedTypeReference<ApiSuccessResponse<TicketOwnershipTransferResponse>>() {
+			});
+
+		return response.getData();
 	}
 
 	private Map<String, String> getHeaders() {

--- a/resale/src/main/java/com/goti/resale/infra/TicketClient.java
+++ b/resale/src/main/java/com/goti/resale/infra/TicketClient.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import com.goti.resale.dto.response.ResaleTicketResponse;
 import com.goti.resale.infra.dto.GameScheduleResponse;
 import com.goti.resale.infra.dto.ResaleTicketPurchaseInfo;
+import com.goti.resale.infra.dto.TicketOwnershipTransferResponse;
 import com.goti.resale.infra.dto.TicketGameInfo;
 
 public interface TicketClient {
@@ -26,7 +27,7 @@ public interface TicketClient {
 
 	List<ResaleTicketPurchaseInfo> getPurchaseInfos(List<UUID> ticketIds);
 
-	void transferOwnership(
+	TicketOwnershipTransferResponse transferOwnership(
 		UUID ticketId,
 		UUID buyerId,
 		String buyerNickname,

--- a/resale/src/main/java/com/goti/resale/infra/dto/TicketOwnershipTransferResponse.java
+++ b/resale/src/main/java/com/goti/resale/infra/dto/TicketOwnershipTransferResponse.java
@@ -1,0 +1,8 @@
+package com.goti.resale.infra.dto;
+
+import java.util.UUID;
+
+public record TicketOwnershipTransferResponse(
+	UUID ticketId
+) {
+}

--- a/resale/src/main/java/com/goti/resale/service/application/TicketOwnershipTransferListener.java
+++ b/resale/src/main/java/com/goti/resale/service/application/TicketOwnershipTransferListener.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 import com.goti.resale.domain.entity.resale.ResaleOrderEntity;
 import com.goti.resale.domain.entity.resale.ResaleTransactionEntity;
 import com.goti.resale.infra.TicketClient;
+import com.goti.resale.infra.dto.TicketOwnershipTransferResponse;
 import com.goti.resale.infra.dto.TicketOwnershipTransferEvent;
 import com.goti.resale.service.domain.ResaleOrderService;
 
@@ -76,7 +77,7 @@ public class TicketOwnershipTransferListener {
 	) {
 		String ticketNumberPrefix = createPrefix(order.getCreatedAt(), order.getOrderNumber());
 		try {
-			ticketClient.transferOwnership(
+			TicketOwnershipTransferResponse response = ticketClient.transferOwnership(
 				transaction.getListing().getTicketId(),
 				event.buyerId(),
 				order.getBuyerNickname(),
@@ -87,6 +88,7 @@ public class TicketOwnershipTransferListener {
 				generateTicketNumber(ticketNumberPrefix, sequence),
 				event.authToken()
 			);
+			transaction.assignBuyerTicketId(response.ticketId());
 			return true;
 		} catch (Exception e) {
 			log.error("티켓 소유권 이전 실패 - 티켓ID: {}", transaction.getListing().getTicketId(), e);

--- a/resale/src/main/java/com/goti/resale/service/domain/ResaleOrderServiceImpl.java
+++ b/resale/src/main/java/com/goti/resale/service/domain/ResaleOrderServiceImpl.java
@@ -289,7 +289,8 @@ public class ResaleOrderServiceImpl implements ResaleOrderService {
 			gameId,
 			representativeTicket.gameTitle(),
 			representativeTicket.gameDate(),
-			seatInfos
+			seatInfos,
+			ticketIds
 		);
 	}
 

--- a/resale/src/main/java/com/goti/resale/service/domain/ResaleOrderServiceImpl.java
+++ b/resale/src/main/java/com/goti/resale/service/domain/ResaleOrderServiceImpl.java
@@ -190,7 +190,7 @@ public class ResaleOrderServiceImpl implements ResaleOrderService {
 				Collectors.toList()
 			));
 		List<UUID> ticketIds = transactions.stream()
-			.map(transaction -> transaction.getListing().getTicketId())
+			.map(this::getPurchaseInfoTicketId)
 			.distinct()
 			.toList();
 		Map<UUID, ResaleTicketPurchaseInfo> ticketInfoMap = ticketClient.getPurchaseInfos(ticketIds).stream()
@@ -273,12 +273,17 @@ public class ResaleOrderServiceImpl implements ResaleOrderService {
 		UUID gameId = transactions.getFirst().getListing().getGameId();
 
 		List<UUID> ticketIds = transactions.stream()
-			.map(transaction -> transaction.getListing().getTicketId())
+			.map(ResaleTransactionEntity::getBuyerTicketId)
+			.filter(Objects::nonNull)
 			.toList();
 
-		ResaleTicketPurchaseInfo representativeTicket = ticketInfoMap.get(ticketIds.getFirst());
+		List<UUID> purchaseInfoTicketIds = transactions.stream()
+			.map(this::getPurchaseInfoTicketId)
+			.toList();
 
-		List<String> seatInfos = ticketIds.stream()
+		ResaleTicketPurchaseInfo representativeTicket = ticketInfoMap.get(purchaseInfoTicketIds.getFirst());
+
+		List<String> seatInfos = purchaseInfoTicketIds.stream()
 			.map(ticketInfoMap::get)
 			.filter(Objects::nonNull)
 			.map(ResaleTicketPurchaseInfo::seatInfo)
@@ -291,6 +296,13 @@ public class ResaleOrderServiceImpl implements ResaleOrderService {
 			representativeTicket.gameDate(),
 			seatInfos,
 			ticketIds
+		);
+	}
+
+	private UUID getPurchaseInfoTicketId(ResaleTransactionEntity transaction) {
+		return Objects.requireNonNullElse(
+			transaction.getBuyerTicketId(),
+			transaction.getListing().getTicketId()
 		);
 	}
 

--- a/ticketing/src/main/java/com/goti/ticketing/order/dto/response/OrderListResponse.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/dto/response/OrderListResponse.java
@@ -38,14 +38,17 @@ public record OrderListResponse(
 	@Schema(description = "구장 지역", example = "대구")
 	String stadiumLocation,
 	@Schema(description = "등급별 좌석 정보 묶음")
-	List<SeatGradeInfoResponse> seatGradeGroups
+	List<SeatGradeInfoResponse> seatGradeGroups,
+	@Schema(description = "티켓 ID 목록")
+	List<UUID> ticketIds
 ) {
 	public static OrderListResponse of(
 		OrderEntity order,
 		String gameTitle,
 		LocalDateTime gameDate,
 		String stadiumLocation,
-		List<SeatGradeInfoResponse> seatGradeGroups
+		List<SeatGradeInfoResponse> seatGradeGroups,
+		List<UUID> ticketIds
 	) {
 		return new OrderListResponse(
 			order.getId(),
@@ -59,7 +62,8 @@ public record OrderListResponse(
 			gameTitle,
 			gameDate,
 			stadiumLocation,
-			seatGradeGroups
+			seatGradeGroups,
+			ticketIds
 		);
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/domain/OrderServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/domain/OrderServiceImpl.java
@@ -205,13 +205,17 @@ public class OrderServiceImpl implements OrderService {
 			.entrySet().stream()
 			.map(entry -> new SeatGradeInfoResponse(entry.getKey(), entry.getValue()))
 			.toList();
+		List<UUID> ticketIds = tickets.stream()
+			.map(TicketEntity::getId)
+			.toList();
 
 		return OrderListResponse.of(
 			order,
 			representativeTicket.getGameTitle(),
 			representativeTicket.getGameDate(),
 			stadiumLocation,
-			seatGradeGroups
+			seatGradeGroups,
+			ticketIds
 		);
 	}
 


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#491 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
구매내역 통합 조회 응답에서 티켓 상세 조회에 사용할 수 있도록 `ticketIds`를 함께 반환하도록 수정
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
> ticketing 주문 목록 내부 API 응답에 `ticketIds` 필드 추가
> resale 구매내역 내부 API 응답에 `ticketIds` 필드 추가
> payment 구매내역 통합 조회 응답에 `ticketIds`를 포함하도록 DTO 및 매핑 로직 수정

<br/>