### PR TITLE
[FEAT] 대용량 좌석 조회 성능 최적화를 위한 잔여좌석엔티티 도입

### DIFF
--- a/common/src/main/java/com/goti/constants/messages/ErrorCode.java
+++ b/common/src/main/java/com/goti/constants/messages/ErrorCode.java
@@ -119,6 +119,8 @@ public enum ErrorCode {
 	DUPLICATE_HOLD_ID_REQUEST(HttpStatus.BAD_REQUEST, "같은 좌석이 중복 선택되었습니다."),
 	ORDER_SEAT_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 주문된 좌석이 포함되어 있습니다."),
 	TICKET_OWNERSHIP_TRANSFER_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "티켓 소유권 전환에 실패했습니다."),
+	SEAT_INVENTORY_EXHAUSTED(HttpStatus.BAD_REQUEST, "잔여 좌석이 부족합니다."),
+	SEAT_INVENTORY_EXCEEDED(HttpStatus.BAD_REQUEST, "잔여 좌석 수는 총 수용 인원을 초과할 수 없습니다."),
 
 	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
 	SOCIAL_PROVIDER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 소셜 계정은 존재하지 않습니다."),

--- a/ticketing/src/main/java/com/goti/ticketing/domain/entity/seat/GameSeatSummaryEntity.java
+++ b/ticketing/src/main/java/com/goti/ticketing/domain/entity/seat/GameSeatSummaryEntity.java
@@ -1,0 +1,44 @@
+package com.goti.ticketing.domain.entity.seat;
+
+import com.goti.domain.base.ModificationTimestampEntity;
+
+import com.goti.ticketing.domain.entity.game.GameScheduleEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Entity
+@Table(name = "game_seat_summaries")
+@NoArgsConstructor(access = PROTECTED)
+public class GameSeatSummaryEntity extends ModificationTimestampEntity {
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "game_schedule_id")
+	private GameScheduleEntity gameSchedule;
+
+	@Column(nullable = false)
+	private Integer availableCount;
+
+	@Column(nullable = false)
+	private Integer totalCount;
+
+	private GameSeatSummaryEntity(GameScheduleEntity gameSchedule, Integer totalCount) {
+		this.gameSchedule = gameSchedule;
+		this.availableCount = totalCount;
+		this.totalCount = totalCount;
+	}
+
+	public static GameSeatSummaryEntity create(GameScheduleEntity gameSchedule, Integer totalCount) {
+		return new GameSeatSummaryEntity(gameSchedule, totalCount);
+	}
+}

--- a/ticketing/src/main/java/com/goti/ticketing/game/service/application/GameScheduleSearchService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/service/application/GameScheduleSearchService.java
@@ -11,6 +11,8 @@ import java.util.stream.Stream;
 
 import com.goti.ticketing.game.dto.response.repository.GameScheduleQueryModel;
 
+import com.goti.ticketing.seat.service.application.GameSeatSummaryQueryService;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +32,7 @@ import lombok.RequiredArgsConstructor;
 public class GameScheduleSearchService {
 	private final GameScheduleRepository gameScheduleRepository;
 	private final StadiumApiClient stadiumApiClient;
+	private final GameSeatSummaryQueryService gameSeatSummaryQueryService;
 
 	@Transactional(readOnly = true)
 	public List<GameScheduleSearchResponse> searchSchedules(GameScheduleSearchCondition condition) {
@@ -53,7 +56,7 @@ public class GameScheduleSearchService {
 
 		Map<UUID, String> teamDisplayNameMap = getBaseballTeamDisplayNamesMap(teamIds);
 		Map<UUID, String> stadiumLocationMap = getStadiumLocationsMap(stadiumIds);
-		Map<UUID, Long> seatCountMap = gameScheduleRepository.findRemainingSeatCounts(gameIds);
+		Map<UUID, Integer> seatCountMap = gameSeatSummaryQueryService.getRemainingSeatCounts(gameIds);
 
 		return queryModels.stream().map(
 			queryModel -> GameScheduleSearchResponse.from(
@@ -61,7 +64,7 @@ public class GameScheduleSearchService {
 				teamDisplayNameMap.get(queryModel.homeTeamId()),
 				teamDisplayNameMap.get(queryModel.awayTeamId()),
 				stadiumLocationMap.get(queryModel.stadiumId()),
-				seatCountMap.getOrDefault(queryModel.gameId(), 0L)
+				seatCountMap.getOrDefault(queryModel.gameId(), 0).longValue()
 			)
 		).toList();
 	}
@@ -99,13 +102,13 @@ public class GameScheduleSearchService {
 		);
 
 		List<UUID> gameIds = List.of(gameId);
-		Map<UUID, Long> seatCountMap = gameScheduleRepository.findRemainingSeatCounts(gameIds);
+		Map<UUID, Integer> seatCountMap = gameSeatSummaryQueryService.getRemainingSeatCounts(gameIds);
 		return GameScheduleSearchResponse.from(
 			queryModel,
 			teamNames.get(queryModel.homeTeamId()),
 			teamNames.get(queryModel.awayTeamId()),
 			stadiumLocations.get(queryModel.stadiumId()),
-			seatCountMap.getOrDefault(queryModel.gameId(), 0L)
+			seatCountMap.getOrDefault(queryModel.gameId(), 0).longValue()
 		);
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderCancelService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderCancelService.java
@@ -6,6 +6,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import com.goti.ticketing.domain.entity.seat.SeatStatusEntity;
+
+import com.goti.ticketing.seat.handler.GameSeatUpdateHandler;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -58,6 +62,7 @@ public class OrderCancelService {
 	private final TicketPaymentApiClient ticketPaymentApiClient;
 	private final GameStatusRepository gameStatusRepository;
 	private final GameTicketManagementService gameTicketManagementService;
+	private final GameSeatUpdateHandler gameSeatUpdateHandler;
 
 	@Transactional
 	public OrderCancelResponse cancel(
@@ -126,11 +131,16 @@ public class OrderCancelService {
 
 			TicketEntity ticket = ticketMap.get(targetItem.getId());
 			ticketService.invalidate(ticket);
-			seatStatusService.cancelSale(
-				seatStatusService.get(order.getGameSchedule(), targetItem.getSeat())
+			SeatStatusEntity seatStatus = seatStatusService.get(
+				order.getGameSchedule(), targetItem.getSeat()
 			);
+			seatStatusService.cancelSale(seatStatus);
 			orderItemService.cancel(targetItem);
 		}
+		int updateSeatCount = targetItems.size();
+		gameSeatUpdateHandler.onSeatIncrease(
+			order.getGameSchedule().getId(), updateSeatCount
+		);
 
 		gameTicketManagementService.processRestoreAvailable(order.getGameSchedule());
 		updateOrderStatus(order, orderItems);

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderExpiryService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderExpiryService.java
@@ -61,7 +61,8 @@ public class OrderExpiryService {
 				ErrorCode.SEAT_STATUS_NOT_FOUND
 			);
 
-			seatHoldService.expire(seatStatus, seatHold, LocalDateTime.now());
+			seatHoldService.expire(seatHold, LocalDateTime.now());
+			seatStatusService.expire(seatStatus);
 			orderItemService.expire(orderItem);
 		}
 	}

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderPaymentConfirmService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderPaymentConfirmService.java
@@ -89,10 +89,6 @@ public class OrderPaymentConfirmService {
 		List<TicketResponse> tickets = ticketCreateService.create(order);
 		gameTicketManagementService.processSoldout(order.getGameSchedule());
 
-		UUID gameId = order.getGameSchedule().getId();
-		int ticketCount = orderItems.size();
-		gameSeatUpdateHandler.onSeatDecrease(gameId, ticketCount);
-
 		log.info(
 			"action=PAYMENT_CONFIRM gameId={} userId={} orderId={} ticketCount={}",
 			order.getGameSchedule().getId(),

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderPaymentConfirmService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderPaymentConfirmService.java
@@ -6,6 +6,8 @@ import java.util.UUID;
 
 import com.goti.ticketing.domain.entity.seat.SeatStatusEntity;
 
+import com.goti.ticketing.seat.handler.GameSeatUpdateHandler;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,6 +41,7 @@ public class OrderPaymentConfirmService {
 	private final SeatHoldService seatHoldService;
 	private final TicketCreateService ticketCreateService;
 	private final GameTicketManagementService gameTicketManagementService;
+	private final GameSeatUpdateHandler gameSeatUpdateHandler;
 
 	@Transactional
 	public OrderPaymentConfirmResponse confirm(
@@ -55,8 +58,11 @@ public class OrderPaymentConfirmService {
 			pgTid
 		);
 
-		OrderEntity order = orderRepository.findByIdAndMemberId(orderId, userId)
-			.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+		OrderEntity order = orderRepository.findByIdAndMemberId(
+			orderId, userId
+		).orElseThrow(
+			() -> new CustomException(ErrorCode.ORDER_NOT_FOUND)
+		);
 
 		Preconditions.validate(
 			order.getOrderStatus() == OrderStatus.PENDING,
@@ -82,6 +88,10 @@ public class OrderPaymentConfirmService {
 
 		List<TicketResponse> tickets = ticketCreateService.create(order);
 		gameTicketManagementService.processSoldout(order.getGameSchedule());
+
+		UUID gameId = order.getGameSchedule().getId();
+		int ticketCount = orderItems.size();
+		gameSeatUpdateHandler.onSeatDecrease(gameId, ticketCount);
 
 		log.info(
 			"action=PAYMENT_CONFIRM gameId={} userId={} orderId={} ticketCount={}",

--- a/ticketing/src/main/java/com/goti/ticketing/seat/handler/GameSeatUpdateHandler.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/handler/GameSeatUpdateHandler.java
@@ -1,0 +1,48 @@
+package com.goti.ticketing.seat.handler;
+
+import com.goti.ticketing.seat.service.domain.GameSeatSummaryService;
+
+import lombok.RequiredArgsConstructor;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GameSeatUpdateHandler {
+	private final GameSeatSummaryService summaryService;
+
+	@Transactional(propagation = Propagation.MANDATORY)
+	public void onSeatDecrease(UUID gameScheduleId, int count) {
+		log.info("[Inventory-Update] action=DECREASE, gameScheduleId={}, count={}", gameScheduleId, count);
+
+		try {
+			summaryService.decrease(gameScheduleId, count);
+			log.debug("[Inventory-Update] Successfully decreased inventory for gameScheduleId={}", gameScheduleId);
+		} catch (Exception e) {
+			log.error("[Inventory-Update] Failed to decrease inventory for gameScheduleId={}. Error={}",
+				gameScheduleId, e.getMessage());
+			throw e;
+		}
+	}
+
+	@Transactional(propagation = Propagation.MANDATORY)
+	public void onSeatIncrease(UUID gameScheduleId, int count) {
+		log.info("[Inventory-Update] action=INCREASE, gameScheduleId={}, count={}", gameScheduleId, count);
+
+		try {
+			summaryService.increase(gameScheduleId, count);
+			log.debug("[Inventory-Update] Successfully increased inventory for gameScheduleId={}", gameScheduleId);
+		} catch (Exception e) {
+			log.error("[Inventory-Update] Failed to increase inventory for gameScheduleId={}. Error={}",
+				gameScheduleId, e.getMessage());
+			throw e;
+		}
+	}
+}

--- a/ticketing/src/main/java/com/goti/ticketing/seat/repository/GameSeatSummaryRepository.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/repository/GameSeatSummaryRepository.java
@@ -22,7 +22,7 @@ public interface GameSeatSummaryRepository extends JpaRepository<GameSeatSummary
 			UPDATE GameSeatSummaryEntity summary
 				 SET summary.availableCount = summary.availableCount + :count
 			 WHERE summary.gameSchedule.id = :gameScheduleId
-				 AND summary.availableCount < summary.totalCount
+				 AND summary.availableCount + :count <= summary.totalCount
 		"""
 	)
 	int increaseAvailableCount(
@@ -36,7 +36,7 @@ public interface GameSeatSummaryRepository extends JpaRepository<GameSeatSummary
 			UPDATE GameSeatSummaryEntity summary
 				 SET summary.availableCount = summary.availableCount - :count
      	 WHERE summary.gameSchedule.id = :gameScheduleId
-       	 AND summary.availableCount > 0
+       	 AND summary.availableCount >= :count
 		"""
 	)
 	int decreaseAvailableCount(

--- a/ticketing/src/main/java/com/goti/ticketing/seat/repository/GameSeatSummaryRepository.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/repository/GameSeatSummaryRepository.java
@@ -25,7 +25,10 @@ public interface GameSeatSummaryRepository extends JpaRepository<GameSeatSummary
 				 AND summary.availableCount < summary.totalCount
 		"""
 	)
-	int increaseAvailableCount(@Param("gameScheduleId") UUID gameScheduleId, int count);
+	int increaseAvailableCount(
+		@Param("gameScheduleId") UUID gameScheduleId,
+		@Param("count") int count
+	);
 
 	@Modifying(clearAutomatically = true)
 	@Query(
@@ -36,5 +39,8 @@ public interface GameSeatSummaryRepository extends JpaRepository<GameSeatSummary
        	 AND summary.availableCount > 0
 		"""
 	)
-	int decreaseAvailableCount(UUID gameScheduleId, int count);
+	int decreaseAvailableCount(
+		@Param("gameScheduleId") UUID gameScheduleId,
+		@Param("count") int count
+	);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/repository/GameSeatSummaryRepository.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/repository/GameSeatSummaryRepository.java
@@ -1,0 +1,40 @@
+package com.goti.ticketing.seat.repository;
+
+import com.goti.ticketing.domain.entity.seat.GameSeatSummaryEntity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface GameSeatSummaryRepository extends JpaRepository<GameSeatSummaryEntity, UUID> {
+
+	List<GameSeatSummaryEntity> findAllByGameScheduleIdIn(List<UUID> gameIds);
+
+	@Modifying(clearAutomatically = true)
+	@Query(
+    """
+			UPDATE GameSeatSummaryEntity summary
+				 SET summary.availableCount = summary.availableCount + :count
+			 WHERE summary.gameSchedule.id = :gameScheduleId
+				 AND summary.availableCount < summary.totalCount
+		"""
+	)
+	int increaseAvailableCount(@Param("gameScheduleId") UUID gameScheduleId, int count);
+
+	@Modifying(clearAutomatically = true)
+	@Query(
+    """
+			UPDATE GameSeatSummaryEntity summary
+				 SET summary.availableCount = summary.availableCount - :count
+     	 WHERE summary.gameSchedule.id = :gameScheduleId
+       	 AND summary.availableCount > 0
+		"""
+	)
+	int decreaseAvailableCount(UUID gameScheduleId, int count);
+}

--- a/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatStatusRepositoryCustom.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatStatusRepositoryCustom.java
@@ -6,7 +6,7 @@ import java.util.UUID;
 import com.goti.ticketing.domain.entity.seat.SeatStatusEntity;
 
 public interface SeatStatusRepositoryCustom {
-	List<SeatStatusEntity> findAllByGameAndSeatIds(UUID gameId, List<UUID> seatIds);
+	List<SeatStatusEntity> findSeatStatuses(UUID gameId, List<UUID> seatIds);
 
 	List<UUID> findSeatIdsByGameId(UUID gameId);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatStatusRepositoryImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/repository/SeatStatusRepositoryImpl.java
@@ -18,7 +18,7 @@ public class SeatStatusRepositoryImpl implements SeatStatusRepositoryCustom {
 	private final JPAQueryFactory queryFactory;
 
 	@Override
-	public List<SeatStatusEntity> findAllByGameAndSeatIds(UUID gameId, List<UUID> seatIds) {
+	public List<SeatStatusEntity> findSeatStatuses(UUID gameId, List<UUID> seatIds) {
 		QSeatStatusEntity seatStatus = QSeatStatusEntity.seatStatusEntity;
 		QSeatEntity seat = QSeatEntity.seatEntity;
 

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/application/GameSeatSummaryQueryService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/application/GameSeatSummaryQueryService.java
@@ -1,0 +1,38 @@
+package com.goti.ticketing.seat.service.application;
+
+import com.goti.ticketing.domain.entity.seat.GameSeatSummaryEntity;
+import com.goti.ticketing.seat.service.domain.GameSeatSummaryService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class GameSeatSummaryQueryService {
+
+	private final GameSeatSummaryService gameSeatSummaryService;
+
+	@Transactional(readOnly = true)
+	public Map<UUID, Integer> getRemainingSeatCounts(List<UUID> gameIds) {
+		if (gameIds == null || gameIds.isEmpty()) {
+			return Collections.emptyMap();
+		}
+		List<GameSeatSummaryEntity> summaries = gameSeatSummaryService.getRemainingSeatCounts(gameIds);
+
+		return summaries.stream()
+			.collect(Collectors.toMap(
+				summary -> summary.getGameSchedule().getId(),
+				GameSeatSummaryEntity::getAvailableCount
+			));
+	}
+}

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldExpiryTransactionalService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldExpiryTransactionalService.java
@@ -3,6 +3,10 @@ package com.goti.ticketing.seat.service.application;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+import com.goti.ticketing.seat.handler.GameSeatUpdateHandler;
+
+import com.goti.ticketing.seat.service.domain.SeatStatusService;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,21 +25,28 @@ import lombok.RequiredArgsConstructor;
 public class SeatHoldExpiryTransactionalService {
 	private final SeatHoldRepository seatHoldRepository;
 	private final SeatStatusRepository seatStatusRepository;
+
 	private final SeatHoldService seatHoldService;
+	private final SeatStatusService seatStatusService;
+
+	private final GameSeatUpdateHandler gameSeatUpdateHandler;
 
 	@Transactional
 	public void expire(UUID holdId, LocalDateTime now) {
 		SeatHoldEntity seatHold = seatHoldRepository.findHoldWithSeatAndGame(holdId)
-			.orElseThrow(() -> new CustomException(ErrorCode.SEAT_HOLD_NOT_FOUND));
+			.orElseThrow(
+				() -> new CustomException(ErrorCode.SEAT_HOLD_NOT_FOUND)
+			);
 
 		SeatStatusEntity seatStatus = seatStatusRepository.findByGameAndSeat(
 			seatHold.getGameSchedule(),
 			seatHold.getSeat()
-		)
-			.orElseThrow(() -> new CustomException(ErrorCode.SEAT_STATUS_NOT_FOUND));
-
-		seatHoldService.expire(seatStatus, seatHold, now);
-		seatStatusRepository.save(seatStatus);
-		seatHoldRepository.save(seatHold);
+		).orElseThrow(
+			() -> new CustomException(ErrorCode.SEAT_STATUS_NOT_FOUND)
+		);
+		UUID gameId = seatStatus.getGame().getId();
+		seatHoldService.expire(seatHold, now);
+		seatStatusService.expire(seatStatus);
+		gameSeatUpdateHandler.onSeatIncrease(gameId, 1);
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldTransactionalService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/application/SeatHoldTransactionalService.java
@@ -3,6 +3,8 @@ package com.goti.ticketing.seat.service.application;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+import com.goti.ticketing.seat.handler.GameSeatUpdateHandler;
+
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.stereotype.Service;
@@ -31,9 +33,15 @@ public class SeatHoldTransactionalService {
 	private final SeatStatusRepository seatStatusRepository;
 	private final SeatHoldRepository seatHoldRepository;
 	private final SeatHoldProperties seatHoldProperties;
+	private final GameSeatUpdateHandler gameSeatUpdateHandler;
 
 	@Transactional
-	public UUID hold(UUID gameId, UUID seatId, UUID userId, String queueTokenJti) {
+	public UUID hold(
+		UUID gameId,
+		UUID seatId,
+		UUID userId,
+		String queueTokenJti
+	) {
 		SeatStatusEntity seatStatus = seatStatusRepository.findByGameAndSeat(
 				gameScheduleRepository.getReferenceById(gameId),
 				seatRepository.getReferenceById(seatId)
@@ -45,9 +53,7 @@ public class SeatHoldTransactionalService {
 		}
 
 		seatStatus.hold();
-		seatStatusRepository.save(seatStatus);
-
-		// TODO: 좌석 점유 시 game_seat_inventories 카운트 반영
+		gameSeatUpdateHandler.onSeatDecrease(gameId, 1);
 		SeatHoldEntity seatHold = SeatHoldEntity.create(
 			seatStatus.getSeat(),
 			seatStatus.getGame(),
@@ -56,9 +62,10 @@ public class SeatHoldTransactionalService {
 			LocalDateTime.now().plus(seatHoldProperties.ttl())
 		);
 
-		UUID holdId = seatHoldRepository.save(seatHold).getId();
-		log.info("action=SEAT_HOLD gameId={} userId={} seatId={} holdId={}", gameId, userId, seatId, holdId);
-		return holdId;
+		seatHoldRepository.save(seatHold);
+
+		log.info("action=SEAT_HOLD gameId={} userId={} seatId={} holdId={}", gameId, userId, seatId, seatHold.getId());
+		return seatHold.getId();
 	}
 
 	private CustomException blocked(UUID gameId, UUID userId, UUID seatId, ErrorCode errorCode) {
@@ -72,7 +79,9 @@ public class SeatHoldTransactionalService {
 	@Transactional
 	public UUID release(UUID holdId, UUID userId) {
 		SeatHoldEntity seatHold = seatHoldRepository.findHoldWithSeatAndGame(holdId)
-			.orElseThrow(() -> new CustomException(ErrorCode.SEAT_HOLD_NOT_FOUND));
+			.orElseThrow(
+				() -> new CustomException(ErrorCode.SEAT_HOLD_NOT_FOUND)
+			);
 
 		Preconditions.validate(
 			seatHold.getUserId().equals(userId),
@@ -82,14 +91,14 @@ public class SeatHoldTransactionalService {
 		SeatStatusEntity seatStatus = seatStatusRepository.findByGameAndSeat(
 			seatHold.getGameSchedule(),
 			seatHold.getSeat()
-		).orElseThrow(() -> new CustomException(ErrorCode.SEAT_STATUS_NOT_FOUND));
+		).orElseThrow(
+			() -> new CustomException(ErrorCode.SEAT_STATUS_NOT_FOUND)
+		);
 
 		seatStatus.release();
 		seatHold.release();
-
-		// TODO: 좌석 해제 시 game_seat_inventories 카운트 반영
-		seatStatusRepository.save(seatStatus);
-		seatHoldRepository.save(seatHold);
+		UUID gameId = seatHold.getGameSchedule().getId();
+		gameSeatUpdateHandler.onSeatIncrease(gameId, 1);
 
 		return seatHold.getId();
 	}

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/GameSeatSummaryService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/GameSeatSummaryService.java
@@ -1,0 +1,15 @@
+package com.goti.ticketing.seat.service.domain;
+
+import com.goti.ticketing.domain.entity.seat.GameSeatSummaryEntity;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface GameSeatSummaryService {
+
+	List<GameSeatSummaryEntity> getRemainingSeatCounts(List<UUID> gameIds);
+
+	void increase(UUID gameId, int count);
+
+	void decrease(UUID gameId, int count);
+}

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/GameSeatSummaryServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/GameSeatSummaryServiceImpl.java
@@ -1,0 +1,45 @@
+package com.goti.ticketing.seat.service.domain;
+
+import com.goti.constants.messages.ErrorCode;
+import com.goti.exception.CustomException;
+import com.goti.ticketing.domain.entity.seat.GameSeatSummaryEntity;
+import com.goti.ticketing.seat.repository.GameSeatSummaryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class GameSeatSummaryServiceImpl implements GameSeatSummaryService {
+
+	private final GameSeatSummaryRepository gameSeatSummaryRepository;
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<GameSeatSummaryEntity> getRemainingSeatCounts(List<UUID> gameIds) {
+		return gameSeatSummaryRepository.findAllByGameScheduleIdIn(gameIds);
+	}
+
+	@Override
+	@Transactional
+	public void decrease(UUID gameId, int count) {
+		int affectedRows = gameSeatSummaryRepository.decreaseAvailableCount(gameId, count);
+		if (affectedRows == 0) {
+			throw new CustomException(ErrorCode.SEAT_INVENTORY_EXHAUSTED);
+		}
+	}
+
+	@Override
+	@Transactional
+	public void increase(UUID gameId, int count) {
+		int affectedRows = gameSeatSummaryRepository.increaseAvailableCount(gameId, count);
+		if (affectedRows == 0) {
+			throw new CustomException(ErrorCode.SEAT_INVENTORY_EXCEEDED);
+		}
+	}
+}

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatHoldService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatHoldService.java
@@ -15,9 +15,5 @@ public interface SeatHoldService {
 
 	Map<UUID, SeatHoldEntity> getByIds(List<UUID> holdIds);
 
-	void expire(
-		SeatStatusEntity seatStatus,
-		SeatHoldEntity seatHold,
-		LocalDateTime now
-	);
+	void expire(SeatHoldEntity seatHold, LocalDateTime now);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatHoldServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatHoldServiceImpl.java
@@ -1,9 +1,7 @@
 package com.goti.ticketing.seat.service.domain;
 
 import com.goti.constants.messages.ErrorCode;
-import com.goti.ticketing.constants.SeatStatus;
 import com.goti.ticketing.domain.entity.seat.SeatHoldEntity;
-import com.goti.ticketing.domain.entity.seat.SeatStatusEntity;
 import com.goti.exception.CustomException;
 import com.goti.global.validation.Preconditions;
 import com.goti.ticketing.seat.repository.SeatHoldRepository;
@@ -45,22 +43,13 @@ public class SeatHoldServiceImpl implements SeatHoldService {
 	}
 
 	@Override
-	public void expire(
-		SeatStatusEntity seatStatus,
-		SeatHoldEntity seatHold,
-		LocalDateTime now
-	) {
-		Preconditions.domainValidate(seatStatus != null, "좌석 상태는 필수입니다.");
-		Preconditions.domainValidate(seatHold != null, "좌석 점유 정보는 필수입니다.");
+	@Transactional
+	public void expire(SeatHoldEntity seatHold, LocalDateTime now) {
 		Preconditions.domainValidate(now != null, "만료 처리 시각은 필수입니다.");
 		Preconditions.domainValidate(
 			!seatHold.getExpiredAt().isAfter(now),
 			"만료되지 않은 점유는 해제할 수 없습니다."
 		);
-
-		if (seatStatus.getStatus() == SeatStatus.HELD) {
-			seatStatus.release();
-		}
 		seatHold.release();
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatStatusService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatStatusService.java
@@ -18,9 +18,9 @@ public interface SeatStatusService {
 
 	SeatStatusEntity get(GameScheduleEntity game, SeatEntity seat);
 
+	void expire(SeatStatusEntity seatStatus);
+
 	long countAvailableSeats(GameScheduleEntity gameSchedule);
 
 	void cancelSale(SeatStatusEntity seatStatus);
-
-	void release(SeatStatusEntity seatStatus);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatStatusServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/SeatStatusServiceImpl.java
@@ -36,7 +36,7 @@ public class SeatStatusServiceImpl implements SeatStatusService {
 			return Map.of();
 		}
 
-		return seatStatusRepository.findAllByGameAndSeatIds(gameId, seatIds)
+		return seatStatusRepository.findSeatStatuses(gameId, seatIds)
 			.stream()
 			.collect(Collectors.toMap(
 				seatStatus -> seatStatus.getSeat().getId(),
@@ -73,6 +73,12 @@ public class SeatStatusServiceImpl implements SeatStatusService {
 	}
 
 	@Override
+	@Transactional
+	public void expire(SeatStatusEntity seatStatus) {
+		seatStatus.release();
+	}
+
+	@Override
 	@Transactional(readOnly = true)
 	public long countAvailableSeats(GameScheduleEntity gameSchedule) {
 		return seatStatusRepository.countByGameAndStatus(gameSchedule, SeatStatus.AVAILABLE);
@@ -88,12 +94,4 @@ public class SeatStatusServiceImpl implements SeatStatusService {
 		seatStatus.cancelSale();
 	}
 
-	@Override
-	public void release(SeatStatusEntity seatStatus) {
-		Preconditions.domainValidate(
-			seatStatus != null,
-			"좌석 상태는 필수입니다."
-		);
-		seatStatus.release();
-	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/session/service/application/ReservationSessionService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/session/service/application/ReservationSessionService.java
@@ -6,6 +6,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.goti.ticketing.seat.handler.GameSeatUpdateHandler;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +32,7 @@ public class ReservationSessionService {
 	private final RedisCache redisCache;
 	private final SeatHoldService seatHoldService;
 	private final SeatStatusService seatStatusService;
+	private final GameSeatUpdateHandler gameSeatUpdateHandler;
 
 	public ReservationSessionCache getOrCreate(
 		UUID memberId,
@@ -45,29 +48,27 @@ public class ReservationSessionService {
 			ErrorCode.BAD_REQUEST
 		);
 
-		if (forceNewSession) {
+		ReservationSessionCache reservationSession = findReservationSession(
+			memberId, gameId
+		).orElseThrow(
+			() -> new CustomException(ErrorCode.RESERVATION_SESSION_EXPIRED)
+		);
+
+		boolean isExpired = reservationSession.expiresAt().isBefore(LocalDateTime.now());
+
+		if (forceNewSession || isExpired) {
 			releaseHeldSeats(memberId, gameId);
 			delete(memberId, gameId);
+			if (isExpired)
+				throw new CustomException(ErrorCode.RESERVATION_SESSION_EXPIRED);
 			return create(memberId, gameId);
-		}
-
-		ReservationSessionCache reservationSession = findReservationSession(memberId, gameId)
-			.orElseThrow(() -> new CustomException(ErrorCode.RESERVATION_SESSION_EXPIRED));
-
-		if (reservationSession.expiresAt().isBefore(LocalDateTime.now())) {
-			releaseHeldSeats(memberId, gameId);
-			delete(memberId, gameId);
-			throw new CustomException(ErrorCode.RESERVATION_SESSION_EXPIRED);
 		}
 
 		return reservationSession;
 	}
 
 	@Transactional
-	public void validateActiveSession(
-		UUID memberId,
-		UUID gameId
-	) {
+	public void validateActiveSession(UUID memberId, UUID gameId) {
 		Preconditions.validate(
 			memberId != null,
 			ErrorCode.AUTH_INVALID
@@ -77,10 +78,15 @@ public class ReservationSessionService {
 			ErrorCode.BAD_REQUEST
 		);
 
-		ReservationSessionCache reservationSession = findReservationSession(memberId, gameId)
-			.orElseThrow(() -> new CustomException(ErrorCode.RESERVATION_SESSION_EXPIRED));
+		ReservationSessionCache reservationSession = findReservationSession(
+			memberId, gameId
+		).orElseThrow(
+			() -> new CustomException(ErrorCode.RESERVATION_SESSION_EXPIRED)
+		);
 
-		if (reservationSession.expiresAt().isBefore(LocalDateTime.now())) {
+		boolean isExpired = reservationSession.expiresAt().isBefore(LocalDateTime.now());
+
+		if (isExpired) {
 			releaseHeldSeats(memberId, gameId);
 			delete(memberId, gameId);
 			throw new CustomException(ErrorCode.RESERVATION_SESSION_EXPIRED);
@@ -128,9 +134,11 @@ public class ReservationSessionService {
 		Map<UUID, SeatStatusEntity> seatStatuses = seatStatusService.getByGameIdAndSeatIds(gameId, seatIds);
 
 		for (SeatHoldEntity seatHold : seatHolds) {
-			SeatStatusEntity seatStatus = seatStatuses.get(seatHold.getSeat().getId());
+			UUID seatId = seatHold.getSeat().getId();
+			SeatStatusEntity seatStatus = seatStatuses.get(seatId);
 			if (seatStatus != null) {
-				seatStatusService.release(seatStatus);
+				seatStatus.release();
+				gameSeatUpdateHandler.onSeatIncrease(gameId, 1);
 			}
 			seatHold.release();
 		}


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#496 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
대용량 좌석 집계 지연 -> 해결을 위한 요약 테이블(Summary) 도입 및 기존 잔여좌석 로직 제거
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- 대용량 트래픽 대응을 위한 재고 관리 성능 최적화
  - 게임 좌석 엔티티 추가
  - GameSeatUpdateHandler를 통한 명시적 재고 업데이트 흐름 구축
  - 트랜잭션 정합성 보장을 위해 Propagation.MANDATORY 설정 적용
  - 주문 결제 및 좌석 점유 시 -> 좌석 수 감소 로직 추가
  - 주문 취소 및 좌석 점유 해제 시 -> 좌석 수 증가 로직 추가
  - 잔여 좌석 부족 및 초과 에러 코드 추가

- Seat 관련 로직 개선 (불필요한 Repository 저장 로직 및 중복 로직 제거)
- GameSeatSummaryEntity (게임 좌석 요약 테이블) 생성 로직 추후 추가 예정 (게임 일정 생성 시)
<br/>