### PR TITLE
게임 일정 생성 시, 게임 잔여좌석 정보 (GameSeatSummaryEntity) 생성 로직 추가

### DIFF
--- a/stadium/src/main/java/com/goti/stadium/controller/internal/StadiumInternalController.java
+++ b/stadium/src/main/java/com/goti/stadium/controller/internal/StadiumInternalController.java
@@ -1,0 +1,29 @@
+package com.goti.stadium.controller.internal;
+
+import com.goti.stadium.dto.response.internal.StadiumTotalSeatsResponse;
+
+import com.goti.stadium.service.internal.StadiumInternalService;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/internal/stadiums")
+@RequiredArgsConstructor
+public class StadiumInternalController {
+
+	private final StadiumInternalService stadiumInternalService;
+
+	@GetMapping("/{stadiumId}")
+	public StadiumTotalSeatsResponse getTotalSeats(
+		@PathVariable UUID stadiumId
+	) {
+		return stadiumInternalService.getTotalSeats(stadiumId);
+	}
+}

--- a/stadium/src/main/java/com/goti/stadium/controller/internal/StadiumInternalController.java
+++ b/stadium/src/main/java/com/goti/stadium/controller/internal/StadiumInternalController.java
@@ -20,7 +20,7 @@ public class StadiumInternalController {
 
 	private final StadiumInternalService stadiumInternalService;
 
-	@GetMapping("/{stadiumId}")
+	@GetMapping("/{stadiumId}/total-seats")
 	public StadiumTotalSeatsResponse getTotalSeats(
 		@PathVariable UUID stadiumId
 	) {

--- a/stadium/src/main/java/com/goti/stadium/dto/response/internal/StadiumTotalSeatsResponse.java
+++ b/stadium/src/main/java/com/goti/stadium/dto/response/internal/StadiumTotalSeatsResponse.java
@@ -1,0 +1,9 @@
+package com.goti.stadium.dto.response.internal;
+
+public record StadiumTotalSeatsResponse(
+	int totalSeats
+) {
+	public static StadiumTotalSeatsResponse from(int totalSeats) {
+		return new StadiumTotalSeatsResponse(totalSeats);
+	}
+}

--- a/stadium/src/main/java/com/goti/stadium/service/internal/StadiumInternalService.java
+++ b/stadium/src/main/java/com/goti/stadium/service/internal/StadiumInternalService.java
@@ -1,0 +1,24 @@
+package com.goti.stadium.service.internal;
+
+import com.goti.stadium.domain.entity.stadium.StadiumEntity;
+import com.goti.stadium.dto.response.internal.StadiumTotalSeatsResponse;
+import com.goti.stadium.repository.StadiumRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class StadiumInternalService {
+
+	private final StadiumRepository stadiumRepository;
+
+	public StadiumTotalSeatsResponse getTotalSeats(UUID stadiumId) {
+		StadiumEntity stadium = stadiumRepository.findByIdOrThrow(stadiumId);
+		return StadiumTotalSeatsResponse.from(stadium.getTotalSeats());
+	}
+
+}

--- a/ticketing/src/main/java/com/goti/ticketing/game/service/application/GameManagementService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/service/application/GameManagementService.java
@@ -34,7 +34,6 @@ public class GameManagementService {
 	private final StadiumClient stadiumClient;
 	private final GameSeatSummaryService gameSeatSummaryService;
 
-	@Transactional
 	public GameCreateResponse register(
 		UUID homeTeamId,
 		UUID awayTeamId,
@@ -42,25 +41,34 @@ public class GameManagementService {
 		LocalDateTime startAt,
 		LeagueType leagueType
 	) {
-
 		validateBaseballTeam(homeTeamId);
 		validateBaseballTeam(awayTeamId);
-		validateStadium(stadiumId);
 
+		StadiumTotalSeatsResponse totalSeatsResponse = stadiumClient.getStadiumTotalSeats(stadiumId);
+		int totalSeats = totalSeatsResponse.totalSeats();
+
+		return createGameSchedule(homeTeamId, awayTeamId, stadiumId, startAt, leagueType, totalSeats);
+	}
+
+	@Transactional
+	public GameCreateResponse createGameSchedule(
+		UUID homeTeamId,
+		UUID awayTeamId,
+		UUID stadiumId,
+		LocalDateTime startAt,
+		LeagueType leagueType,
+		int totalSeats
+	) {
 		GameScheduleEntity gameSchedule = gameScheduleService.create(
 			homeTeamId, awayTeamId, stadiumId, startAt, leagueType
 		);
 
 		GameStatusEntity gameStatus = gameStatusService.create(gameSchedule);
-
-		GameTicketingStatusEntity gameTicketingStatus =
-			gameTicketingStatusService.create(gameSchedule);
+		GameTicketingStatusEntity gameTicketingStatus = gameTicketingStatusService.create(gameSchedule);
 
 		gameSchedule.initGameStatus(gameStatus);
 		gameSchedule.initTicketingStatus(gameTicketingStatus);
 
-		StadiumTotalSeatsResponse totalSeatsResponse = stadiumClient.getStadiumTotalSeats(stadiumId);
-		int totalSeats = totalSeatsResponse.totalSeats();
 		gameSeatSummaryService.create(gameSchedule, totalSeats);
 
 		return GameCreateResponse.from(
@@ -79,9 +87,5 @@ public class GameManagementService {
 
 	private void validateBaseballTeam(UUID teamId) {
 		stadiumClient.validateBaseballTeam(teamId);
-	}
-
-	private void validateStadium(UUID stadiumId) {
-		stadiumClient.validateStadium(stadiumId);
 	}
 }

--- a/ticketing/src/main/java/com/goti/ticketing/game/service/application/GameManagementService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/game/service/application/GameManagementService.java
@@ -13,6 +13,9 @@ import com.goti.ticketing.game.service.domain.GameTicketingStatusService;
 
 import com.goti.ticketing.infra.api.StadiumClient;
 
+import com.goti.ticketing.infra.api.dto.response.StadiumTotalSeatsResponse;
+import com.goti.ticketing.seat.service.domain.GameSeatSummaryService;
+
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
@@ -29,6 +32,7 @@ public class GameManagementService {
 	private final GameStatusService gameStatusService;
 	private final GameTicketingStatusService gameTicketingStatusService;
 	private final StadiumClient stadiumClient;
+	private final GameSeatSummaryService gameSeatSummaryService;
 
 	@Transactional
 	public GameCreateResponse register(
@@ -54,6 +58,10 @@ public class GameManagementService {
 
 		gameSchedule.initGameStatus(gameStatus);
 		gameSchedule.initTicketingStatus(gameTicketingStatus);
+
+		StadiumTotalSeatsResponse totalSeatsResponse = stadiumClient.getStadiumTotalSeats(stadiumId);
+		int totalSeats = totalSeatsResponse.totalSeats();
+		gameSeatSummaryService.create(gameSchedule, totalSeats);
 
 		return GameCreateResponse.from(
 			gameSchedule.getId(),

--- a/ticketing/src/main/java/com/goti/ticketing/infra/api/StadiumApiClient.java
+++ b/ticketing/src/main/java/com/goti/ticketing/infra/api/StadiumApiClient.java
@@ -38,12 +38,6 @@ public class StadiumApiClient extends BaseRestClient implements StadiumClient {
 	}
 
 	@Override
-	public void validateStadium(UUID stadiumId) {
-		String uri = STADIUM_GET_API + PATH_SEPARATOR + stadiumId;
-		getVoid(uri, null, null);
-	}
-
-	@Override
 	public List<BaseballTeamDisplayNameResponse> getBaseballTeamDisplayNames(List<UUID> teamIds) {
 		Map<String, Object> queryParams = Map.of(
 			"teamIds", teamIds.stream()

--- a/ticketing/src/main/java/com/goti/ticketing/infra/api/StadiumApiClient.java
+++ b/ticketing/src/main/java/com/goti/ticketing/infra/api/StadiumApiClient.java
@@ -7,6 +7,8 @@ import com.goti.infra.api.base.BaseRestClient;
 import com.goti.ticketing.infra.api.dto.response.StadiumLocationResponse;
 import com.goti.ticketing.infra.api.dto.response.BaseballTeamDisplayNameResponse;
 
+import com.goti.ticketing.infra.api.dto.response.StadiumTotalSeatsResponse;
+
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
@@ -22,6 +24,7 @@ public class StadiumApiClient extends BaseRestClient implements StadiumClient {
 
 	private final static String BASEBALL_TEAM_GET_API = "/api/v1/baseball-teams";
 	private final static String STADIUM_GET_API = "/api/v1/stadiums";
+	private final static String STADIUM_INTERNAL_API = "/internal/stadiums";
 	private final static String PATH_SEPARATOR = "/";
 
 	public StadiumApiClient(RestClient.Builder builder, ApiEndpointProperties properties) {
@@ -72,4 +75,11 @@ public class StadiumApiClient extends BaseRestClient implements StadiumClient {
 		);
 		return response != null ? response : Collections.emptyList();
 	}
+
+	@Override
+	public StadiumTotalSeatsResponse getStadiumTotalSeats(UUID stadiumId) {
+		String uri = STADIUM_INTERNAL_API + PATH_SEPARATOR + stadiumId;
+		return get(uri, null, null, StadiumTotalSeatsResponse.class);
+	}
+
 }

--- a/ticketing/src/main/java/com/goti/ticketing/infra/api/StadiumApiClient.java
+++ b/ticketing/src/main/java/com/goti/ticketing/infra/api/StadiumApiClient.java
@@ -78,7 +78,7 @@ public class StadiumApiClient extends BaseRestClient implements StadiumClient {
 
 	@Override
 	public StadiumTotalSeatsResponse getStadiumTotalSeats(UUID stadiumId) {
-		String uri = STADIUM_INTERNAL_API + PATH_SEPARATOR + stadiumId;
+		String uri = STADIUM_INTERNAL_API + PATH_SEPARATOR + stadiumId + PATH_SEPARATOR + "total-seats";
 		return get(uri, null, null, StadiumTotalSeatsResponse.class);
 	}
 

--- a/ticketing/src/main/java/com/goti/ticketing/infra/api/StadiumClient.java
+++ b/ticketing/src/main/java/com/goti/ticketing/infra/api/StadiumClient.java
@@ -2,6 +2,7 @@ package com.goti.ticketing.infra.api;
 
 import com.goti.ticketing.infra.api.dto.response.StadiumLocationResponse;
 import com.goti.ticketing.infra.api.dto.response.BaseballTeamDisplayNameResponse;
+import com.goti.ticketing.infra.api.dto.response.StadiumTotalSeatsResponse;
 
 import java.util.List;
 import java.util.UUID;
@@ -11,4 +12,5 @@ public interface StadiumClient {
 	void validateStadium(UUID stadiumId);
 	List<BaseballTeamDisplayNameResponse> getBaseballTeamDisplayNames(List<UUID> teamIds);
 	List<StadiumLocationResponse> getStadiumLocations(List<UUID> stadiumIds);
+	StadiumTotalSeatsResponse getStadiumTotalSeats(UUID stadiumId);
 }

--- a/ticketing/src/main/java/com/goti/ticketing/infra/api/StadiumClient.java
+++ b/ticketing/src/main/java/com/goti/ticketing/infra/api/StadiumClient.java
@@ -9,7 +9,6 @@ import java.util.UUID;
 
 public interface StadiumClient {
 	void validateBaseballTeam(UUID teamId);
-	void validateStadium(UUID stadiumId);
 	List<BaseballTeamDisplayNameResponse> getBaseballTeamDisplayNames(List<UUID> teamIds);
 	List<StadiumLocationResponse> getStadiumLocations(List<UUID> stadiumIds);
 	StadiumTotalSeatsResponse getStadiumTotalSeats(UUID stadiumId);

--- a/ticketing/src/main/java/com/goti/ticketing/infra/api/dto/response/StadiumTotalSeatsResponse.java
+++ b/ticketing/src/main/java/com/goti/ticketing/infra/api/dto/response/StadiumTotalSeatsResponse.java
@@ -1,0 +1,6 @@
+package com.goti.ticketing.infra.api.dto.response;
+
+public record StadiumTotalSeatsResponse(
+	int totalSeats
+) {
+}

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderPaymentConfirmService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderPaymentConfirmService.java
@@ -89,10 +89,6 @@ public class OrderPaymentConfirmService {
 		List<TicketResponse> tickets = ticketCreateService.create(order);
 		gameTicketManagementService.processSoldout(order.getGameSchedule());
 
-		UUID gameId = order.getGameSchedule().getId();
-		int ticketCount = orderItems.size();
-		gameSeatUpdateHandler.onSeatDecrease(gameId, ticketCount);
-
 		log.info(
 			"action=PAYMENT_CONFIRM gameId={} userId={} orderId={} ticketCount={}",
 			order.getGameSchedule().getId(),

--- a/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderPaymentConfirmService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/order/service/application/OrderPaymentConfirmService.java
@@ -89,6 +89,10 @@ public class OrderPaymentConfirmService {
 		List<TicketResponse> tickets = ticketCreateService.create(order);
 		gameTicketManagementService.processSoldout(order.getGameSchedule());
 
+		UUID gameId = order.getGameSchedule().getId();
+		int ticketCount = orderItems.size();
+		gameSeatUpdateHandler.onSeatDecrease(gameId, ticketCount);
+
 		log.info(
 			"action=PAYMENT_CONFIRM gameId={} userId={} orderId={} ticketCount={}",
 			order.getGameSchedule().getId(),

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/GameSeatSummaryService.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/GameSeatSummaryService.java
@@ -1,11 +1,14 @@
 package com.goti.ticketing.seat.service.domain;
 
+import com.goti.ticketing.domain.entity.game.GameScheduleEntity;
 import com.goti.ticketing.domain.entity.seat.GameSeatSummaryEntity;
 
 import java.util.List;
 import java.util.UUID;
 
 public interface GameSeatSummaryService {
+
+	GameSeatSummaryEntity create(GameScheduleEntity gameSchedule, int totalSeats);
 
 	List<GameSeatSummaryEntity> getRemainingSeatCounts(List<UUID> gameIds);
 

--- a/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/GameSeatSummaryServiceImpl.java
+++ b/ticketing/src/main/java/com/goti/ticketing/seat/service/domain/GameSeatSummaryServiceImpl.java
@@ -2,6 +2,7 @@ package com.goti.ticketing.seat.service.domain;
 
 import com.goti.constants.messages.ErrorCode;
 import com.goti.exception.CustomException;
+import com.goti.ticketing.domain.entity.game.GameScheduleEntity;
 import com.goti.ticketing.domain.entity.seat.GameSeatSummaryEntity;
 import com.goti.ticketing.seat.repository.GameSeatSummaryRepository;
 
@@ -18,6 +19,14 @@ import java.util.UUID;
 public class GameSeatSummaryServiceImpl implements GameSeatSummaryService {
 
 	private final GameSeatSummaryRepository gameSeatSummaryRepository;
+
+	@Override
+	@Transactional
+	public GameSeatSummaryEntity create(GameScheduleEntity gameSchedule, int totalSeats) {
+		GameSeatSummaryEntity gameSeatSummary = GameSeatSummaryEntity.create(gameSchedule, totalSeats);
+		gameSeatSummaryRepository.save(gameSeatSummary);
+		return gameSeatSummary;
+	}
 
 	@Override
 	@Transactional(readOnly = true)

--- a/ticketing/src/test/java/com/goti/ticketing/game/api/game/GameRegistrationTest.java
+++ b/ticketing/src/test/java/com/goti/ticketing/game/api/game/GameRegistrationTest.java
@@ -75,6 +75,7 @@ public class GameRegistrationTest {
 
 	private static final String BASEBALL_GET_API_URI = "/api/v1/baseball-teams/";
 	private static final String STADIUM_GET_API_URI = "/api/v1/stadiums/";
+	private static final String STADIUM_INTERNAL_API_URI = "/internal/stadiums/";
 
 	@BeforeEach
 	void setup() {
@@ -82,23 +83,15 @@ public class GameRegistrationTest {
 		saveHomeTeam();
 		saveStadium();
 
-		stubFor(
-			get(
-				urlEqualTo(BASEBALL_GET_API_URI + homeTeam.getId())
-			).willReturn(aResponse().withStatus(200))
-		);
+		stubFor(get(urlEqualTo(BASEBALL_GET_API_URI + homeTeam.getId())).willReturn(aResponse().withStatus(200)));
+		stubFor(get(urlEqualTo(BASEBALL_GET_API_URI + awayTeam.getId())).willReturn(aResponse().withStatus(200)));
+		stubFor(get(urlEqualTo(STADIUM_GET_API_URI + stadium.getId())).willReturn(aResponse().withStatus(200)));
 
-		stubFor(
-			get(
-				urlEqualTo(BASEBALL_GET_API_URI + awayTeam.getId())
-			).willReturn(aResponse().withStatus(200))
-		);
-
-		stubFor(
-			get(
-				urlEqualTo(STADIUM_GET_API_URI + stadium.getId())
-			).willReturn(aResponse().withStatus(200))
-		);
+		stubFor(get(urlEqualTo(STADIUM_INTERNAL_API_URI + stadium.getId() + "/total-seats"))
+			.willReturn(aResponse()
+				.withStatus(200)
+				.withHeader("Content-Type", "application/json")
+				.withBody("{\"totalSeats\": 20500}")));
 	}
 
 

--- a/ticketing/src/test/java/com/goti/ticketing/game/api/game/GameSchedulesSearchApiTest.java
+++ b/ticketing/src/test/java/com/goti/ticketing/game/api/game/GameSchedulesSearchApiTest.java
@@ -14,6 +14,8 @@ import com.goti.ticketing.infra.api.StadiumApiClient;
 import com.goti.ticketing.infra.api.dto.response.BaseballTeamDisplayNameResponse;
 import com.goti.ticketing.infra.api.dto.response.StadiumLocationResponse;
 
+import com.goti.ticketing.infra.api.dto.response.StadiumTotalSeatsResponse;
+
 import lombok.extern.slf4j.Slf4j;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -90,6 +92,9 @@ public class GameSchedulesSearchApiTest {
 			.willReturn(List.of(
 				new StadiumLocationResponse(stadium.getId(), "광주")
 			));
+
+		given(stadiumApiClient.getStadiumTotalSeats(any()))
+			.willReturn(new StadiumTotalSeatsResponse(20500));
 	}
 
 	@Test

--- a/ticketing/src/test/java/com/goti/ticketing/game/service/GameManagementServiceTest.java
+++ b/ticketing/src/test/java/com/goti/ticketing/game/service/GameManagementServiceTest.java
@@ -68,9 +68,9 @@ public class GameManagementServiceTest {
 
 	@BeforeEach
 	void setup() {
-		saveHomeTeam();
-		saveAwayTeam();
-		saveStadium();
+		homeTeam = createAndGetHomeTeam();
+		awayTeam = createAndGetAwayTeam();
+		stadium = createAndGetStadium();
 		given(StadiumApiClient.getStadiumTotalSeats(any()))
 			.willReturn(new StadiumTotalSeatsResponse(20500));
 	}
@@ -105,8 +105,8 @@ public class GameManagementServiceTest {
 		log.info("response ticketingEndAt :: {}", response.ticketingEndAt());
 	}
 
-	void saveHomeTeam() {
-		homeTeam = BaseballTeamEntity.create(
+	BaseballTeamEntity createAndGetHomeTeam() {
+		BaseballTeamEntity team = BaseballTeamEntity.create(
 			TeamCode.KIA,
 			"KIA",
 			"KIA 타이거즈",
@@ -124,11 +124,11 @@ public class GameManagementServiceTest {
 			"최준영",
 			"https://example.com/logos/kia.png"
 		);
-		baseballTeamRepository.save(homeTeam);
+		return baseballTeamRepository.save(team);
 	}
 
-	void saveAwayTeam() {
-		awayTeam = BaseballTeamEntity.create(
+	BaseballTeamEntity createAndGetAwayTeam() {
+		BaseballTeamEntity team = BaseballTeamEntity.create(
 			TeamCode.SS,
 			"삼성",
 			"삼성 라이온즈",
@@ -146,16 +146,16 @@ public class GameManagementServiceTest {
 			"유정희",
 			"https://example.com/logos/samsung.png"
 		);
-		baseballTeamRepository.save(awayTeam);
+		return baseballTeamRepository.save(team);
 	}
 
-	void saveStadium() {
+	StadiumEntity createAndGetStadium() {
 		Map<String, Object> kiaSeatConfig = Map.of(
 			"rows", 50,
 			"sections", List.of("K3", "K5", "K7", "K9", "챔피언석")
 		);
 
-		stadium = StadiumEntity.create(
+		StadiumEntity stadium = StadiumEntity.create(
 			"광주-기아 챔피언스 필드",
 			"광주광역시 북구 임동",
 			"광주광역시",
@@ -167,6 +167,6 @@ public class GameManagementServiceTest {
 			kiaSeatConfig
 		);
 
-		stadiumRepository.save(stadium);
+		return stadiumRepository.save(stadium);
 	}
 }

--- a/ticketing/src/test/java/com/goti/ticketing/game/service/GameManagementServiceTest.java
+++ b/ticketing/src/test/java/com/goti/ticketing/game/service/GameManagementServiceTest.java
@@ -16,6 +16,8 @@ import com.goti.stadium.repository.StadiumRepository;
 
 import com.goti.ticketing.infra.api.StadiumApiClient;
 
+import com.goti.ticketing.infra.api.dto.response.StadiumTotalSeatsResponse;
+
 import lombok.extern.slf4j.Slf4j;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -34,6 +36,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
 
 @Slf4j
 @Transactional
@@ -67,6 +71,8 @@ public class GameManagementServiceTest {
 		saveHomeTeam();
 		saveAwayTeam();
 		saveStadium();
+		given(StadiumApiClient.getStadiumTotalSeats(any()))
+			.willReturn(new StadiumTotalSeatsResponse(20500));
 	}
 
 	@Test

--- a/ticketing/src/test/java/com/goti/ticketing/game/service/GameScheduleSearchServiceTest.java
+++ b/ticketing/src/test/java/com/goti/ticketing/game/service/GameScheduleSearchServiceTest.java
@@ -18,6 +18,8 @@ import com.goti.ticketing.infra.api.dto.response.BaseballTeamDisplayNameResponse
 
 import com.goti.ticketing.infra.api.dto.response.StadiumLocationResponse;
 
+import com.goti.ticketing.infra.api.dto.response.StadiumTotalSeatsResponse;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,7 +35,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.anyList;
+import static org.mockito.BDDMockito.any;
 
 @SpringBootTest(classes = GotiTicketingApplication.class)
 @Transactional
@@ -67,16 +71,19 @@ public class GameScheduleSearchServiceTest {
 		saveKia();
 		saveStadium();
 
-		when(StadiumApiClient.getBaseballTeamDisplayNames(anyList()))
-			.thenReturn(List.of(
+		given(StadiumApiClient.getBaseballTeamDisplayNames(anyList()))
+			.willReturn(List.of(
 				new BaseballTeamDisplayNameResponse(kia.getId(), kia.getDisplayName()),
 				new BaseballTeamDisplayNameResponse(samsung.getId(), samsung.getDisplayName())
 			));
 
-		when(StadiumApiClient.getStadiumLocations(anyList()))
-			.thenReturn(List.of(
+		given(StadiumApiClient.getStadiumLocations(anyList()))
+			.willReturn(List.of(
 				new StadiumLocationResponse(stadium.getId(), stadium.getLocation())
 			));
+
+		given(StadiumApiClient.getStadiumTotalSeats(any()))
+			.willReturn(new StadiumTotalSeatsResponse(20500));
 
 		gameManagementService.register(
 			kia.getId(),

--- a/user/src/main/java/com/goti/user/constants/SecurityPathConstants.java
+++ b/user/src/main/java/com/goti/user/constants/SecurityPathConstants.java
@@ -25,6 +25,7 @@ public final class SecurityPathConstants {
 		"/.well-known/**",
 		"/api/v1/resales/listings/count",
 		"/api/v1/payments/resales/unsettled",
+		"/internal/stadiums/**"
 	};
 
 	public static final String[] MEMBER_URLS = {


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#499 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
게임 일정 생성 시 -> 게임 잔여좌석 정보 생성 로직 추가 (In GameManagementService :  register())
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- 경기 좌석 요약 정보(GameSeatSummaryEntity) 생성 서비스 메서드 추가 (In GameSeatSummaryService)
- Stadium, ticketing 모듈 -> 구장 수용인원 정보 호출 API Response (StadiumTotalSeatsResponse) 생성 및 추가
- Stadium 모듈 -> Stadium 내부용 서비스 로직 및 API 추가 (StadiumInternalController, StadiumInternalService: -> 전체 수용좌석수 추출 API 및 Service)
- Ticketing -> Stadium 전체 좌석 수 조회 (Internal API) ApiClient 추가 (In Ticketing)
- 게임 일정 생성 시, 게임 일정별 잔여좌석 엔티티 생성 로직 추가 (in GameManagementService) 및 구장 수용인원 추출 Internal API SecurityPath 추가 (In User module)
- 결제 완료 시 -> 결제 완료 시 좌석수 삭감 로직 제거 (이전 커밋 누락)
<br/>